### PR TITLE
fix: harden wallet sync against provider throttling

### DIFF
--- a/backend/migrations/075_eth_feed_coverage_deferred.sql
+++ b/backend/migrations/075_eth_feed_coverage_deferred.sql
@@ -1,0 +1,44 @@
+-- Provider throttling is a temporary pause, not a failed source read. Keep the
+-- last proven coverage boundary while recording when the provider said work may
+-- resume. The next manual or scheduled sync always retries these rows.
+ALTER TABLE eth_feed_coverage
+  ADD COLUMN IF NOT EXISTS retry_after_at TIMESTAMPTZ;
+
+-- Migrations are re-run on every boot. Guard on the definition so an existing
+-- pre-075 status constraint is widened exactly once on deployed databases.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'eth_feed_coverage'::regclass
+       AND conname = 'eth_feed_coverage_status_check'
+       AND pg_get_constraintdef(oid) LIKE '%deferred%'
+  ) THEN
+    ALTER TABLE eth_feed_coverage
+      DROP CONSTRAINT IF EXISTS eth_feed_coverage_status_check;
+    ALTER TABLE eth_feed_coverage
+      ADD CONSTRAINT eth_feed_coverage_status_check
+      CHECK (status IN (
+        'complete', 'failed', 'deferred', 'unsupported',
+        'not_applicable', 'unverified'
+      ));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'eth_feed_coverage'::regclass
+       AND conname = 'eth_feed_coverage_deferred_retry_check'
+  ) THEN
+    ALTER TABLE eth_feed_coverage
+      ADD CONSTRAINT eth_feed_coverage_deferred_retry_check
+      CHECK (
+        status <> 'deferred'
+        OR (error_message IS NOT NULL AND retry_after_at IS NOT NULL)
+      );
+  END IF;
+END $$;

--- a/backend/scripts/audit-history.js
+++ b/backend/scripts/audit-history.js
@@ -71,7 +71,7 @@ async function buildReport(userId, archiveReportPath = null) {
             MIN(c.covered_from_block) AS min_covered_from_block,
             MAX(c.covered_through_block) AS max_covered_through_block,
             MAX(c.indexed_head) AS max_indexed_head,
-            COUNT(*) FILTER (WHERE c.status IN ('failed', 'unsupported'))::int AS gap_rows,
+            COUNT(*) FILTER (WHERE c.status IN ('failed', 'deferred', 'unsupported'))::int AS gap_rows,
             COUNT(*) FILTER (WHERE c.status = 'unverified')::int AS unverified_rows
        FROM eth_feed_coverage c
        JOIN eth_wallets w ON w.id = c.wallet_id

--- a/backend/src/config/etherscan.js
+++ b/backend/src/config/etherscan.js
@@ -38,6 +38,7 @@ function pausedError(key, retryAfterMs) {
   error.code = 'EXPLORER_RATE_LIMITED';
   error.providerKey = key;
   error.retryAfterMs = retryAfterMs;
+  error.retryAfterAt = new Date(Date.now() + retryAfterMs);
   return error;
 }
 

--- a/backend/src/jobs/ethSyncJob.js
+++ b/backend/src/jobs/ethSyncJob.js
@@ -7,27 +7,36 @@ const logger = require('../config/logger');
 
 const JOB_NAME = 'eth-sync';
 
-async function run() {
-  const wallets = await EthWallet.findAllForJobs();
-  if (wallets.length === 0) {
-    logger.info({ job: JOB_NAME }, 'No ETH wallets to sync, skipping');
-    return { skipped: true, reason: 'no_wallets' };
-  }
-  // Keys are per-user now: syncAllWallets skips wallets whose owner has no
-  // Etherscan key, so there is no global configured/not-configured gate.
-
-  logger.info({ job: JOB_NAME }, 'Starting ETH wallet sync job');
-
-  const jobLog = await JobLog.createIfNotRunning(JOB_NAME);
-  if (!jobLog) {
-    logger.info({ job: JOB_NAME }, 'Job already running, skipping');
-    return { skipped: true, reason: 'concurrent_execution' };
-  }
-
-
+async function execute(jobLog) {
   try {
+    const wallets = await EthWallet.findAllForJobs();
+    if (wallets.length === 0) {
+      const summary = {
+        processed: 0,
+        succeeded: 0,
+        failed: 0,
+        deferred: 0,
+        unsupported: 0,
+        unverified: 0,
+        skipped: 0,
+        results: [],
+      };
+      await JobLog.complete(jobLog.id, 0, 0, 0, { ...summary, reason: 'no_wallets' });
+      logger.info({ job: JOB_NAME }, 'No ETH wallets to sync');
+      return { ...summary, skipped: true, reason: 'no_wallets' };
+    }
+    // Keys are per-user now: syncAllWallets skips wallets whose owner has no
+    // Etherscan key, so there is no global configured/not-configured gate.
+    logger.info({ job: JOB_NAME }, 'Starting ETH wallet sync job');
+
     const summary = await EthWalletService.syncAllWallets();
-    await JobLog.complete(jobLog.id, summary.processed, summary.succeeded, summary.failed, { results: summary.results });
+    await JobLog.complete(jobLog.id, summary.processed, summary.succeeded, summary.failed, {
+      deferred: summary.deferred,
+      unsupported: summary.unsupported,
+      unverified: summary.unverified,
+      skipped: summary.skipped,
+      results: summary.results,
+    });
     logger.info({ job: JOB_NAME, ...summary }, 'ETH wallet sync job completed');
     return summary;
   } catch (error) {
@@ -37,4 +46,32 @@ async function run() {
   }
 }
 
-module.exports = { JOB_NAME, run };
+async function claim() {
+  const jobLog = await JobLog.createIfNotRunning(JOB_NAME);
+  if (!jobLog) {
+    logger.info({ job: JOB_NAME }, 'Job already running, skipping');
+    return null;
+  }
+  return jobLog;
+}
+
+async function run() {
+  const jobLog = await claim();
+  if (!jobLog) return { skipped: true, reason: 'concurrent_execution' };
+  return execute(jobLog);
+}
+
+// Manual full scans can legitimately wait through several provider cooldowns.
+// Claim the durable JobLog row before responding, then run outside the HTTP
+// request lifecycle so Azure's request timeout cannot turn a healthy scan into
+// an apparent UI failure. Errors are already persisted by execute().
+async function enqueue() {
+  const jobLog = await claim();
+  if (!jobLog) return { skipped: true, reason: 'concurrent_execution' };
+  setImmediate(() => {
+    void execute(jobLog).catch(() => {});
+  });
+  return { started: true, jobLogId: jobLog.id };
+}
+
+module.exports = { JOB_NAME, run, enqueue };

--- a/backend/src/models/EthFeedCoverage.js
+++ b/backend/src/models/EthFeedCoverage.js
@@ -3,7 +3,7 @@
 const pool = require('../config/database');
 
 const FEEDS = new Set(['normal', 'internal', 'token', 'nft', 'nft1155', 'statesync']);
-const STATUSES = new Set(['complete', 'failed', 'unsupported', 'not_applicable', 'unverified']);
+const STATUSES = new Set(['complete', 'failed', 'deferred', 'unsupported', 'not_applicable', 'unverified']);
 const CURSOR_KINDS = new Set(['evm_block', 'archive_serial']);
 
 // One upsert for a chain's six verdicts. Besides avoiding six round trips, this
@@ -29,8 +29,13 @@ class EthFeedCoverage {
           && (entry.coveredFromBlock == null || entry.coveredThroughBlock == null)) {
         throw new Error(`Complete feed coverage requires both boundaries for ${entry.feed}`);
       }
-      if (['failed', 'unsupported'].includes(entry.status) && !entry.errorMessage) {
+      if (['failed', 'deferred', 'unsupported'].includes(entry.status) && !entry.errorMessage) {
         throw new Error(`Failed feed coverage requires an error message for ${entry.feed}`);
+      }
+      if (entry.status === 'deferred'
+          && (!(entry.retryAfterAt instanceof Date)
+            || Number.isNaN(entry.retryAfterAt.getTime()))) {
+        throw new Error(`Deferred feed coverage requires a retry time for ${entry.feed}`);
       }
 
       const offset = params.length;
@@ -48,13 +53,14 @@ class EthFeedCoverage {
         entry.indexedHead ?? null,
         entry.attemptedFromBlock ?? null,
         entry.errorCode ?? null,
-        entry.errorMessage ?? null
+        entry.errorMessage ?? null,
+        entry.retryAfterAt ?? null
       );
       values.push(`(
         $${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4},
         $${offset + 5}, $${offset + 6}::varchar(20), $${offset + 7}, $${offset + 8},
         $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12},
-        $${offset + 13}, $${offset + 14},
+        $${offset + 13}, $${offset + 14}, $${offset + 15},
         CASE WHEN $${offset + 6}::text = 'complete' THEN CURRENT_TIMESTAMP ELSE NULL END
       )`);
     }
@@ -64,7 +70,8 @@ class EthFeedCoverage {
          wallet_id, chain_id, feed, cursor_kind, provider, status,
          covered_from_block, covered_through_block,
          covered_from_at, covered_through_at, indexed_head,
-         attempted_from_block, error_code, error_message, last_success_at
+         attempted_from_block, error_code, error_message, retry_after_at,
+         last_success_at
        ) VALUES ${values.join(',')}
        ON CONFLICT (wallet_id, chain_id, feed) DO UPDATE SET
          cursor_kind = EXCLUDED.cursor_kind,
@@ -104,6 +111,10 @@ class EthFeedCoverage {
          attempted_from_block = EXCLUDED.attempted_from_block,
          error_code = EXCLUDED.error_code,
          error_message = EXCLUDED.error_message,
+         retry_after_at = CASE
+           WHEN EXCLUDED.status = 'deferred' THEN EXCLUDED.retry_after_at
+           ELSE NULL
+         END,
          last_attempt_at = CURRENT_TIMESTAMP,
          last_success_at = CASE
            WHEN EXCLUDED.status = 'complete' THEN CURRENT_TIMESTAMP

--- a/backend/src/routes/eth.js
+++ b/backend/src/routes/eth.js
@@ -402,6 +402,7 @@ router.get('/coverage', async (req, res) => {
       enabled_rows: rows.filter((row) => row.enabled).length,
       complete: 0,
       failed: 0,
+      deferred: 0,
       unsupported: 0,
       not_applicable: 0,
       unverified: 0,
@@ -409,7 +410,7 @@ router.get('/coverage', async (req, res) => {
     };
     for (const row of rows) {
       if (Object.hasOwn(summary, row.status)) summary[row.status] += 1;
-      if (row.enabled && ['failed', 'unsupported', 'unverified'].includes(row.status)) {
+      if (row.enabled && ['failed', 'deferred', 'unsupported', 'unverified'].includes(row.status)) {
         summary.gaps += 1;
       }
     }

--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -162,7 +162,18 @@ router.post('/trigger/plaid-sync', requireAdmin, async (req, res, next) => {
 // POST /api/jobs/trigger/eth-sync - Manually trigger ETH wallet sync for every wallet
 router.post('/trigger/eth-sync', requireAdmin, async (req, res, next) => {
   try {
-    await runTrigger(res, { job: EthSyncJob, label: 'ETH wallet sync job' });
+    const result = await EthSyncJob.enqueue();
+    if (result?.skipped && result.reason === 'concurrent_execution') {
+      return res.status(409).json({
+        error: 'Job already running',
+        message: 'ETH wallet sync job is currently in progress'
+      });
+    }
+    return res.status(202).json({
+      message: 'ETH wallet sync job started',
+      status: 'started',
+      result,
+    });
   } catch (error) {
     next(error);
   }

--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -76,6 +76,27 @@ function unitsToDecimalString(value, decimals) {
 // Ethereum's finality window (~2 epochs = 64 blocks).
 const REORG_OVERLAP_BLOCKS = 64;
 
+const DEFAULT_DEFERRED_RETRY_MS = 1100;
+const MAX_PROVIDER_RETRY_WAIT_MS = 5 * 60 * 1000;
+
+function boundedEnvInteger(name, fallback, maximum) {
+  const value = Number(process.env[name]);
+  if (!Number.isInteger(value) || value < 0) return fallback;
+  return Math.min(value, maximum);
+}
+
+const SYNC_DEFERRED_RETRY_ATTEMPTS = boundedEnvInteger(
+  'ETH_SYNC_DEFERRED_RETRY_ATTEMPTS', 2, 5
+);
+const SYNC_DEFERRED_RETRY_MAX_MS = boundedEnvInteger(
+  'ETH_SYNC_DEFERRED_RETRY_MAX_MS', MAX_PROVIDER_RETRY_WAIT_MS,
+  MAX_PROVIDER_RETRY_WAIT_MS
+);
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
 // A full-history replay is expensive. The derived pipeline already serializes
 // all wallet work for one user, but without this guard two clicks would still
 // queue two complete replays. This map covers one running process; after a
@@ -121,13 +142,36 @@ function providerName(chain, spec = null) {
 }
 
 function coverageFailureStatus(error) {
+  if (isExplorerRateLimited(error)) return 'deferred';
   return ['ETHERSCAN_CHAIN_UNAVAILABLE', 'ETHERSCAN_FEED_UNSUPPORTED'].includes(error?.code)
-    ? 'unsupported'
-    : 'failed';
+    ? 'unsupported' : 'failed';
 }
 
 function isExplorerRateLimited(error) {
   return error?.code === 'EXPLORER_RATE_LIMITED';
+}
+
+function retryAfterAt(error) {
+  const explicit = error?.retryAfterAt instanceof Date
+    ? error.retryAfterAt
+    : new Date(error?.retryAfterAt || NaN);
+  if (!Number.isNaN(explicit.getTime())) return explicit;
+  const delay = Math.min(
+    MAX_PROVIDER_RETRY_WAIT_MS,
+    Math.max(1, Number(error?.retryAfterMs) || DEFAULT_DEFERRED_RETRY_MS)
+  );
+  return new Date(Date.now() + delay);
+}
+
+function retryAfterMsForResult(result) {
+  const retryAt = new Date(result?.retryAfterAt || NaN);
+  if (!Number.isNaN(retryAt.getTime())) {
+    return Math.max(0, retryAt.getTime() - Date.now());
+  }
+  return Math.min(
+    MAX_PROVIDER_RETRY_WAIT_MS,
+    Math.max(1, Number(result?.retryAfterMs) || DEFAULT_DEFERRED_RETRY_MS)
+  );
 }
 
 class EthWalletService {
@@ -156,16 +200,19 @@ class EthWalletService {
         { accountId: account.committed.accountId }
       );
     } catch (error) {
+      const failureStatus = coverageFailureStatus(error);
+      const retryAt = failureStatus === 'deferred' ? retryAfterAt(error) : null;
       await EthFeedCoverage.recordAttempts(wallet.id, chain.id, FEED_SPECS.map((spec) => (
         spec.key === 'normal'
           ? {
             feed: spec.key,
             cursorKind: 'archive_serial',
             provider: providerName(chain),
-            status: coverageFailureStatus(error),
+            status: failureStatus,
             attemptedFromBlock: resume,
             errorCode: error.code || 'ZKSYNC_LITE_ARCHIVE_ERROR',
             errorMessage: error.message,
+            retryAfterAt: retryAt,
           }
           : {
             feed: spec.key,
@@ -247,6 +294,8 @@ class EthWalletService {
       chainName: chain.name,
       inserted,
       skippedFeeds: [],
+      failedFeeds: [],
+      deferredFeeds: [],
       unsupportedFeeds: normalized.limitations,
       unavailable: false,
       fetched: {
@@ -635,8 +684,10 @@ class EthWalletService {
   // caller after all chains have landed.
   //
   // Failure is isolated per (chain, feed), in three flavours:
-  //   * transient (rate limit, timeout, 5xx) -> 'skipped'. Retried next sync,
-  //     and it badges the wallet.
+  //   * rate limit -> 'deferred'. Retried after the provider cooldown without
+  //     a red wallet failure.
+  //   * other transient/transport errors -> 'failed'. Retried next sync and
+  //     badged as a real wallet failure.
   //   * ETHERSCAN_FEED_UNSUPPORTED -> 'unsupported', this feed only.
   //   * ETHERSCAN_CHAIN_UNAVAILABLE -> 'unsupported', and a verdict on the whole
   //     chain, so the remaining feeds are marked without being called.
@@ -702,15 +753,18 @@ class EthWalletService {
         prefetchedStateSync?.indexedHead ?? null
       );
     } catch (error) {
+      const failureStatus = coverageFailureStatus(error);
+      const retryAt = failureStatus === 'deferred' ? retryAfterAt(error) : null;
       await EthFeedCoverage.recordAttempts(wallet.id, chain.id, FEED_SPECS.map((spec) => (
         feedActive(spec)
           ? {
             feed: spec.key,
             provider: providerName(chain, spec),
-            status: coverageFailureStatus(error),
+            status: failureStatus,
             attemptedFromBlock: resume[spec.key],
             errorCode: error.code || 'ETHERSCAN_API_ERROR',
             errorMessage: error.message,
+            retryAfterAt: retryAt,
           }
           : {
             feed: spec.key,
@@ -723,8 +777,8 @@ class EthWalletService {
         await EthWalletChain.setError(
           wallet.id,
           chain.id,
-          'FEED_SKIPPED',
-          `Partial sync: ${chain.name} explorer rate limited; feeds deferred and will retry next sync (${error.message})`
+          'SYNC_DEFERRED',
+          `Partial sync: ${chain.name} explorer rate limited; feeds deferred; automatic retry pending (${error.message})`
         );
         await EthWalletChain.updateSyncTime(wallet.id, chain.id);
         return {
@@ -732,9 +786,13 @@ class EthWalletService {
           chainName: chain.name,
           inserted: 0,
           skippedFeeds,
+          failedFeeds: [],
+          deferredFeeds: skippedFeeds,
           unsupportedFeeds: state?.unsupported_feeds || [],
           unavailable: false,
           rateLimited: true,
+          retryAfterMs: Math.max(1, Number(error.retryAfterMs) || DEFAULT_DEFERRED_RETRY_MS),
+          retryAfterAt: retryAt.toISOString(),
           fetched: Object.fromEntries(FEED_SPECS.map((spec) => [spec.key, 0])),
         };
       }
@@ -745,7 +803,8 @@ class EthWalletService {
     const feeds = {};
     const fetchedOk = {};
     const feedErrors = {};
-    const skipped = [];
+    const failed = [];
+    const deferred = [];
     const unsupported = [];
 
     // Set by the first feed that reports the CHAIN as unreadable. The remaining
@@ -775,7 +834,7 @@ class EthWalletService {
       }
       if (rateLimited) {
         fetchedOk[spec.key] = false;
-        skipped.push(spec.key);
+        deferred.push(spec.key);
         feedErrors[spec.key] = rateLimited;
         continue;
       }
@@ -809,7 +868,7 @@ class EthWalletService {
         feedErrors[spec.key] = err;
         if (isExplorerRateLimited(err)) {
           rateLimited = err;
-          skipped.push(spec.key);
+          deferred.push(spec.key);
           logger.warn({
             walletId: wallet.id,
             chainId: chain.id,
@@ -826,7 +885,7 @@ class EthWalletService {
           logger.warn({ walletId: wallet.id, chainId: chain.id, feed: spec.key, code: err.code, err: err.message },
             'Etherscan cannot serve this feed; cursor frozen and gap recorded');
         } else {
-          skipped.push(spec.key);
+          failed.push(spec.key);
           logger.warn({ walletId: wallet.id, chainId: chain.id, feed: spec.key, err },
             'Feed fetch failed; feed skipped this sync and its cursor left unchanged');
         }
@@ -880,14 +939,16 @@ class EthWalletService {
         };
       }
       const error = feedErrors[spec.key];
+      const status = coverageFailureStatus(error);
       return {
         feed: spec.key,
         provider: providerName(chain, spec),
-        status: coverageFailureStatus(error),
+        status,
         indexedHead,
         attemptedFromBlock: resume[spec.key],
         errorCode: error?.code || 'ETHERSCAN_API_ERROR',
         errorMessage: error?.message || 'Feed was not attempted after the chain provider became unavailable',
+        retryAfterAt: status === 'deferred' ? retryAfterAt(error) : null,
       };
     }));
     // Coverage lands before the resume cursor. If that audit write fails, the
@@ -908,11 +969,20 @@ class EthWalletService {
     if (unsupported.length === activeCount) {
       await EthWalletChain.setError(wallet.id, chain.id, 'CHAIN_UNAVAILABLE',
         `${chain.name} is not readable with this Etherscan key. Upgrade the plan or remove ${chain.id} from ETH_CHAINS.`);
-    } else if (skipped.length) {
-      const message = rateLimited
-        ? `Partial sync: ${chain.name} explorer rate limited; ${skipped.join(', ')} feeds deferred; will retry next sync`
-        : `Partial sync: ${skipped.join(', ')} feed failed; will retry next sync`;
-      await EthWalletChain.setError(wallet.id, chain.id, 'FEED_SKIPPED', message);
+    } else if (failed.length) {
+      await EthWalletChain.setError(
+        wallet.id,
+        chain.id,
+        'FEED_SKIPPED',
+        `Partial sync: ${failed.join(', ')} feed failed; will retry next sync`
+      );
+    } else if (deferred.length) {
+      await EthWalletChain.setError(
+        wallet.id,
+        chain.id,
+        'SYNC_DEFERRED',
+        `Partial sync: ${chain.name} explorer rate limited; ${deferred.join(', ')} feeds deferred; automatic retry pending`
+      );
     } else if (unsupported.length) {
       await EthWalletChain.setError(wallet.id, chain.id, 'FEED_UNSUPPORTED',
         `${unsupported.join(', ')} unavailable on ${chain.name}; derived balances there may drift`);
@@ -925,10 +995,16 @@ class EthWalletService {
       chainId: chain.id,
       chainName: chain.name,
       inserted,
-      skippedFeeds: skipped,
+      skippedFeeds: [...failed, ...deferred],
+      failedFeeds: failed,
+      deferredFeeds: deferred,
       unsupportedFeeds: unsupported,
       unavailable: unsupported.length === activeCount,
       rateLimited: Boolean(rateLimited),
+      retryAfterMs: rateLimited
+        ? Math.max(1, Number(rateLimited.retryAfterMs) || DEFAULT_DEFERRED_RETRY_MS)
+        : null,
+      retryAfterAt: rateLimited ? retryAfterAt(rateLimited).toISOString() : null,
       fetched: Object.fromEntries(FEED_SPECS.map((spec) => [spec.key, feeds[spec.key].length])),
     };
   }
@@ -991,6 +1067,8 @@ class EthWalletService {
             chainName: chain.name,
             inserted: 0,
             skippedFeeds: [],
+            failedFeeds: [],
+            deferredFeeds: [],
             unsupportedFeeds: [],
             unavailable: false,
             error: err.message,
@@ -1070,38 +1148,60 @@ class EthWalletService {
       // on another.
       const skippedFeeds = perChain.flatMap((result) =>
         result.skippedFeeds.map((feed) => `${result.chainName}/${feed}`));
+      const failedFeeds = perChain.flatMap((result) =>
+        (result.failedFeeds || []).map((feed) => `${result.chainName}/${feed}`));
+      const deferredFeeds = perChain.flatMap((result) =>
+        (result.deferredFeeds || []).map((feed) => `${result.chainName}/${feed}`));
       const unsupportedFeeds = perChain.flatMap((result) =>
         result.unsupportedFeeds.map((feed) => `${result.chainName}/${feed}`));
 
       // A partial sync must not report clean: the error slot doubles as the
       // degraded-feed badge until a sync fetches every feed.
       //
-      // Only TRANSIENT skips reach the wallet badge. An unsupported feed is a
-      // standing property of the chain and the key, so badging it would pin the
+      // Only real failures reach the red wallet badge. An unsupported feed is
+      // a standing property of the chain and the key, so badging it would pin the
       // wallet's attention count above zero permanently -- and a badge that
       // cannot reach zero gets ignored, which would cost us the real sync
       // errors too. Those gaps live on the chain row, which the wallets API
       // returns, and are what #62 reconciles against.
       //
       // A chain that threw outright badges the wallet for the same reason a
-      // skipped feed does: it is transient by assumption and it retries, so the
+      // failed feed does: it is transient by assumption and it retries, so the
       // badge can still reach zero.
-      const partial = [
-        ...skippedFeeds.map((feed) => `${feed} feed`),
+      const failures = [
+        ...failedFeeds.map((feed) => `${feed} feed`),
         ...failedChains.map((result) => `${result.chainName} chain`),
       ];
-      if (partial.length === 0) {
-        await EthWallet.clearError(walletId);
-      } else {
-        const providerPaused = perChain.some((result) => result.rateLimited);
-        const message = providerPaused
-          ? `Partial sync: ${partial.join(', ')} deferred because the explorer is rate limited; will retry next sync`
-          : `Partial sync: ${partial.join(', ')} failed; will retry next sync`;
+      if (failures.length > 0) {
+        const message = `Partial sync: ${failures.join(', ')} failed; will retry next sync`;
         await EthWallet.setError(walletId, failedChains.length ? 'CHAIN_SYNC_FAILED' : 'FEED_SKIPPED', message);
+      } else if (deferredFeeds.length > 0) {
+        await EthWallet.setError(
+          walletId,
+          'SYNC_DEFERRED',
+          `Partial sync: ${deferredFeeds.map((feed) => `${feed} feed`).join(', ')} deferred because the explorer is rate limited; automatic retry pending`
+        );
+      } else {
+        await EthWallet.clearError(walletId);
       }
       await EthWallet.updateSyncTime(walletId);
 
+      const retryAtValues = perChain
+        .map((result) => new Date(result.retryAfterAt || NaN))
+        .filter((value) => !Number.isNaN(value.getTime()));
+      const latestRetryAt = retryAtValues.length
+        ? new Date(Math.max(...retryAtValues.map((value) => value.getTime())))
+        : null;
+      const status = failures.length > 0
+        ? 'failed'
+        : deferredFeeds.length > 0
+          ? 'deferred'
+          : unsupportedFeeds.length > 0
+            ? 'unsupported'
+            : 'complete';
+
       const results = {
+        status,
         inserted: perChain.reduce((sum, result) => sum + result.inserted, 0),
         holdings: derived.holdings,
         mirror: derived.mirror,
@@ -1111,7 +1211,13 @@ class EthWalletService {
         valued: derived.valued,
         methods,
         skippedFeeds,
+        failedFeeds,
+        deferredFeeds,
         unsupportedFeeds,
+        retryAfterMs: latestRetryAt
+          ? Math.max(0, latestRetryAt.getTime() - Date.now())
+          : null,
+        retryAfterAt: latestRetryAt?.toISOString() || null,
         chains: perChain,
         // Cross-chain totals, so the shape callers already read still means
         // "how much did this sync bring in".
@@ -1132,77 +1238,147 @@ class EthWalletService {
   // here: the historical price job at 8:10 owns the provider walk for every
   // wallet, so the 7:50 sync must not do it first. A caller that wants the
   // interactive behaviour passes it explicitly.
-  static async syncAllWallets({ fillPrices = false } = {}) {
+  static async syncAllWallets({
+    fillPrices = false,
+    deferredRetryAttempts = SYNC_DEFERRED_RETRY_ATTEMPTS,
+    deferredRetryMaxMs = SYNC_DEFERRED_RETRY_MAX_MS,
+  } = {}) {
     const wallets = await EthWallet.findAllForJobs();
-    const summary = { processed: 0, succeeded: 0, failed: 0, results: [] };
-    const stateSyncPrefetch = await this._prefetchStateSyncForWallets(wallets);
+    const outcomes = new Map();
 
-    const byUser = new Map();
-    for (const wallet of wallets) {
-      const key = wallet.user_id ?? null;
-      if (!byUser.has(key)) byUser.set(key, []);
-      byUser.get(key).push(wallet);
-    }
+    const runBatch = async (batch) => {
+      const stateSyncPrefetch = await this._prefetchStateSyncForWallets(batch);
+      const byUser = new Map();
+      for (const wallet of batch) {
+        const key = wallet.user_id ?? null;
+        if (!byUser.has(key)) byUser.set(key, []);
+        byUser.get(key).push(wallet);
+      }
 
-    // Keep the entire owner block inside one rebuild lane. The previous flat
-    // walk ran finishUser once per wallet, repeating the same cross-wallet
-    // bridge matching, legacy mirror rebuild, and global classification pass.
-    // The raw ingest and per-wallet derived rows still run once per wallet;
-    // only the user-wide tail is coalesced here.
-    for (const [userId, userWallets] of byUser) {
-      await EthDerivedPipeline.serializedForUser(userId, async () => {
-        const successful = [];
-        for (const wallet of userWallets) {
-          summary.processed++;
-          try {
-            const result = await this._syncWallet(wallet.id, {
-              fillPrices,
-              prefetchedStateSync: stateSyncPrefetch.get(wallet.id) || null,
-              deferUserFinish: true,
-              rebuildMatches: false,
-            });
-            summary.succeeded++;
-            const entry = { walletId: wallet.id, address: wallet.address, ...result };
-            summary.results.push(entry);
-            successful.push({ wallet, entry });
-          } catch (err) {
-            if (err.code === 'ETHERSCAN_NOT_CONFIGURED') {
-              summary.skipped = (summary.skipped || 0) + 1;
-              summary.results.push({ walletId: wallet.id, address: wallet.address, skipped: 'not_configured' });
-              logger.warn({ walletId: wallet.id, userId: wallet.user_id }, 'Skipping ETH wallet: owner has no Etherscan key');
-              continue;
-            }
-            summary.failed++;
-            summary.results.push({ walletId: wallet.id, address: wallet.address, error: err.message });
-            logger.error({ walletId: wallet.id, err }, 'Failed to sync ETH wallet');
-          }
-        }
-
-        if (!successful.length) return;
-        try {
-          await EthDerivedPipeline.finishUser(userId, {
-            match: userId != null,
-            context: 'nightly ETH sync',
-          });
-        } catch (err) {
-          // Match the old per-wallet failure semantics: a failed user-wide
-          // tail invalidates every wallet whose ingest succeeded in this block.
-          for (const { wallet, entry } of successful) {
-            entry.error = err.message;
+      // Keep one owner's raw and derived writes inside the established lane.
+      // Retry waits happen outside this function, so a provider cooldown never
+      // blocks that owner's label writes or unrelated wallet actions.
+      for (const [userId, userWallets] of byUser) {
+        await EthDerivedPipeline.serializedForUser(userId, async () => {
+          const successful = [];
+          for (const wallet of userWallets) {
+            const attempts = Number(outcomes.get(wallet.id)?.attempts || 0) + 1;
             try {
-              await EthWallet.setError(wallet.id, err.code || 'SYNC_ERROR', err.message);
-            } catch (recordErr) {
-              logger.error({ walletId: wallet.id, err: recordErr },
-                'Could not record coalesced nightly ETH tail error');
+              const result = await this._syncWallet(wallet.id, {
+                fillPrices,
+                prefetchedStateSync: stateSyncPrefetch.get(wallet.id) || null,
+                deferUserFinish: true,
+                rebuildMatches: false,
+              });
+              const entry = {
+                walletId: wallet.id,
+                address: wallet.address,
+                attempts,
+                ...result,
+              };
+              outcomes.set(wallet.id, entry);
+              successful.push({ wallet, entry });
+            } catch (err) {
+              if (err.code === 'ETHERSCAN_NOT_CONFIGURED') {
+                outcomes.set(wallet.id, {
+                  walletId: wallet.id,
+                  address: wallet.address,
+                  attempts,
+                  status: 'skipped',
+                  skipped: 'not_configured',
+                });
+                logger.warn({ walletId: wallet.id, userId: wallet.user_id },
+                  'Skipping ETH wallet: owner has no Etherscan key');
+                continue;
+              }
+              outcomes.set(wallet.id, {
+                walletId: wallet.id,
+                address: wallet.address,
+                attempts,
+                status: 'failed',
+                error: err.message,
+              });
+              logger.error({ walletId: wallet.id, err }, 'Failed to sync ETH wallet');
             }
           }
-          summary.succeeded -= successful.length;
-          summary.failed += successful.length;
-          logger.error({ userId, err }, 'Nightly ETH user-wide tail failed');
-        }
-      });
+
+          if (!successful.length) return;
+          try {
+            await EthDerivedPipeline.finishUser(userId, {
+              match: userId != null,
+              context: 'nightly ETH sync',
+            });
+          } catch (err) {
+            // Match the old per-wallet failure semantics: a failed user-wide
+            // tail invalidates every wallet whose ingest succeeded in this block.
+            for (const { wallet, entry } of successful) {
+              entry.status = 'failed';
+              entry.error = err.message;
+              try {
+                await EthWallet.setError(wallet.id, err.code || 'SYNC_ERROR', err.message);
+              } catch (recordErr) {
+                logger.error({ walletId: wallet.id, err: recordErr },
+                  'Could not record coalesced nightly ETH tail error');
+              }
+            }
+            logger.error({ userId, err }, 'Nightly ETH user-wide tail failed');
+          }
+        });
+      }
+    };
+
+    await runBatch(wallets);
+
+    // A provider pause is shared across wallets. Wait once outside every user
+    // lane, then retry only wallets that actually deferred. A fresh state-sync
+    // prefetch is taken on each pass, so an RPC 429 is not replayed forever from
+    // the first pass's cached error. The bounded attempts and wait budget keep
+    // one unhealthy public endpoint from holding the nightly job indefinitely.
+    const retryLimit = Math.min(5, Math.max(0, Number(deferredRetryAttempts) || 0));
+    const waitLimit = Math.min(
+      MAX_PROVIDER_RETRY_WAIT_MS,
+      Math.max(0, Number(deferredRetryMaxMs) || 0)
+    );
+    let waitedMs = 0;
+    for (let retry = 0; retry < retryLimit; retry++) {
+      const pending = wallets.filter((wallet) => (
+        outcomes.get(wallet.id)?.deferredFeeds?.length > 0
+      ));
+      if (!pending.length) break;
+      const delayMs = Math.max(...pending.map((wallet) =>
+        retryAfterMsForResult(outcomes.get(wallet.id))));
+      if (waitedMs + delayMs > waitLimit) {
+        logger.warn({ pending: pending.length, delayMs, waitedMs, waitLimit },
+          'Deferred ETH wallet retry exceeds the bounded job wait budget');
+        break;
+      }
+      logger.warn({ pending: pending.length, delayMs, attempt: retry + 1 },
+        'Waiting for explorer cooldown before retrying deferred wallets');
+      await sleep(delayMs);
+      waitedMs += delayMs;
+      await runBatch(pending);
     }
 
+    const summary = {
+      processed: wallets.length,
+      succeeded: 0,
+      failed: 0,
+      deferred: 0,
+      unsupported: 0,
+      unverified: 0,
+      skipped: 0,
+      results: wallets.map((wallet) => outcomes.get(wallet.id)),
+    };
+    for (const entry of summary.results) {
+      if (entry?.status === 'skipped') summary.skipped += 1;
+      else if (entry?.status === 'failed') summary.failed += 1;
+      else if (entry?.status === 'deferred') summary.deferred += 1;
+      else {
+        summary.succeeded += 1;
+        if (entry?.status === 'unsupported') summary.unsupported += 1;
+        if (entry?.status === 'unverified') summary.unverified += 1;
+      }
+    }
     return summary;
   }
 

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -29,7 +29,7 @@ const LOG_PAGE_SIZE = 1000;
 // fromBlock (or pages that never advance) -- a walk that spins would sit
 // INSIDE the per-user rebuild lane holding the provider queue, blocking every
 // label write and sync for that user. Exhaustion is a transport failure: the
-// feed is skipped, the cursor stays frozen, and the next sync retries.
+// feed fails, the cursor stays frozen, and the next sync retries.
 const MAX_LOG_PAGES = 200;
 
 // Coverage dates are block facts, not wallet facts. A nightly run walks many
@@ -107,10 +107,34 @@ const FEED_UNSUPPORTED_RE = /missing or invalid (action|module) name|internal tr
 // batch may carry it. Retry the complete batch so no partial window can ever
 // be accepted as coverage.
 const RPC_RATE_LIMIT_RE = /rate limit|over rate|too many requests|429/i;
-const EXPLORER_RATE_LIMIT_RETRIES = 1;
-const INLINE_RATE_LIMIT_RETRY_MAX_MS = 5000;
 const MAX_EXPLORER_PAUSE_MS = 5 * 60 * 1000;
 const EXPLORER_RATE_LIMIT_RE = /rate[\s_-]*limit|too many requests|\b429\b/i;
+
+function boundedEnvInteger(name, fallback, maximum) {
+  const value = Number(process.env[name]);
+  if (!Number.isInteger(value) || value < 0) return fallback;
+  return Math.min(value, maximum);
+}
+
+// Blockscout may answer several adjacent account-feed calls with the same
+// provider-wide 429. Retry the request that observed it a small bounded number
+// of times, honoring Retry-After, before handing a durable deferral to the
+// wallet job. Jitter keeps multiple app instances from resuming on one tick.
+const EXPLORER_RATE_LIMIT_RETRIES = boundedEnvInteger(
+  'EXPLORER_RATE_LIMIT_RETRIES', 2, 5
+);
+const INLINE_RATE_LIMIT_RETRY_MAX_MS = boundedEnvInteger(
+  'EXPLORER_INLINE_RETRY_MAX_MS', 5000, MAX_EXPLORER_PAUSE_MS
+);
+const EXPLORER_RETRY_JITTER_MS = boundedEnvInteger(
+  'EXPLORER_RETRY_JITTER_MS', 250, 5000
+);
+const EXPLORER_TRANSIENT_RETRIES = boundedEnvInteger(
+  'EXPLORER_TRANSIENT_RETRIES', 1, 3
+);
+const EXPLORER_TRANSIENT_RETRY_BASE_MS = boundedEnvInteger(
+  'EXPLORER_TRANSIENT_RETRY_BASE_MS', 500, 10000
+);
 
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -130,8 +154,11 @@ function explorerRetryDelay(error, attempt) {
   const headers = error?.response?.headers || {};
   const header = headers['retry-after'] ?? headers['Retry-After'];
   const retryAfterMs = parseRetryAfter(header);
-  if (retryAfterMs != null) return Math.min(MAX_EXPLORER_PAUSE_MS, retryAfterMs);
-  return Math.min(MAX_EXPLORER_PAUSE_MS, 1100 * (2 ** attempt));
+  const base = retryAfterMs != null ? retryAfterMs : 1100 * (2 ** attempt);
+  const jitter = EXPLORER_RETRY_JITTER_MS > 0
+    ? Math.floor(Math.random() * (EXPLORER_RETRY_JITTER_MS + 1))
+    : 0;
+  return Math.min(MAX_EXPLORER_PAUSE_MS, base + jitter);
 }
 
 function isRateLimitedDetail(value) {
@@ -151,6 +178,18 @@ function isRateLimitedError(error) {
   return error?.response?.status === 429
     || isRateLimitedDetail(error?.response?.data)
     || isRateLimitedDetail(error?.message);
+}
+
+function isTransientExplorerError(error) {
+  const status = Number(error?.response?.status);
+  if ([408, 425].includes(status) || (status >= 500 && status <= 599)) return true;
+  return ['ECONNABORTED', 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN'].includes(error?.code);
+}
+
+function responseDetailError(message, response) {
+  const error = new Error(message);
+  error.response = { headers: response?.headers || {} };
+  return error;
 }
 
 function keyFingerprint(apiKey) {
@@ -175,6 +214,7 @@ function rateLimitError(provider, chainId, params, retryAfterMs, cause = null) {
   error.providerKey = provider.key;
   error.chainId = chainId;
   error.retryAfterMs = retryAfterMs;
+  error.retryAfterAt = new Date(Date.now() + retryAfterMs);
   error.params = {
     module: params?.module,
     action: params?.action,
@@ -187,33 +227,42 @@ async function retryAfterRateLimit({
   provider,
   chainId,
   params,
-  attempt,
+  rateLimitState,
   error,
   retry,
   inlineRetry = true,
 }) {
+  const attempt = rateLimitState.attempt;
   const delayMs = explorerRetryDelay(error, attempt);
   etherscan.pause(provider.key, delayMs);
   if (inlineRetry && attempt < EXPLORER_RATE_LIMIT_RETRIES
       && delayMs <= INLINE_RATE_LIMIT_RETRY_MAX_MS) {
+    rateLimitState.attempt += 1;
     logger.warn({
-      chainId, provider: provider.name, attempt: attempt + 1, delayMs,
+      chainId, provider: provider.name, attempt: rateLimitState.attempt, delayMs,
       params: { module: params?.module, action: params?.action },
-    }, 'Explorer provider rate limited; pausing before one retry');
+    }, 'Explorer provider rate limited; pausing before a bounded retry');
     await sleep(delayMs);
-    return retry(attempt + 1);
+    return retry();
   }
   throw rateLimitError(provider, chainId, params, delayMs, error);
 }
 
-async function runThrottledRequest({ provider, chainId, params, attempt = 0, fn }) {
+async function runThrottledRequest({
+  provider,
+  chainId,
+  params,
+  rateLimitState,
+  transientAttempt = 0,
+  fn,
+}) {
   try {
     return await etherscan.throttled(fn, {
       key: provider.key,
       spacingMs: provider.spacingMs,
-      // This is the one retry explicitly authorized for the request that
-      // received the 429. Other queued work must fail fast during the pause.
-      bypassPause: attempt > 0,
+      // Only retries belonging to the request that received the 429 may bypass
+      // its pause. Other queued work fails fast until the cooldown expires.
+      bypassPause: rateLimitState.attempt > 0,
     });
   } catch (error) {
     if (error?.code === 'EXPLORER_RATE_LIMITED') {
@@ -221,11 +270,33 @@ async function runThrottledRequest({ provider, chainId, params, attempt = 0, fn 
       error.chainId ||= chainId;
       throw error;
     }
-    if (!isRateLimitedError(error)) throw error;
+    if (!isRateLimitedError(error)) {
+      if (!isTransientExplorerError(error)
+          || transientAttempt >= EXPLORER_TRANSIENT_RETRIES) throw error;
+      const delayMs = EXPLORER_TRANSIENT_RETRY_BASE_MS * (2 ** transientAttempt);
+      logger.warn({
+        chainId,
+        provider: provider.name,
+        attempt: transientAttempt + 1,
+        delayMs,
+        code: error.code,
+        status: error.response?.status,
+        params: { module: params?.module, action: params?.action },
+      }, 'Explorer request failed transiently; retrying');
+      await sleep(delayMs);
+      return runThrottledRequest({
+        provider,
+        chainId,
+        params,
+        rateLimitState,
+        transientAttempt: transientAttempt + 1,
+        fn,
+      });
+    }
     return retryAfterRateLimit({
-      provider, chainId, params, attempt, error,
-      retry: (nextAttempt) => runThrottledRequest({
-        provider, chainId, params, attempt: nextAttempt, fn,
+      provider, chainId, params, rateLimitState, error,
+      retry: () => runThrottledRequest({
+        provider, chainId, params, rateLimitState, transientAttempt, fn,
       }),
     });
   }
@@ -264,7 +335,11 @@ class EtherscanService {
   // Keys are per-user (Settings -> API Keys, env fallback), resolved by the
   // caller and threaded through every fetch. chainId defaults to mainnet so
   // every pre-#58 call site keeps its exact behavior.
-  static async _request(params, { apiKey, chainId = etherscan.CHAIN_ID, attempt = 0 }) {
+  static async _request(params, {
+    apiKey,
+    chainId = etherscan.CHAIN_ID,
+    rateLimitState = { attempt: 0 },
+  }) {
     const provider = this._provider(chainId, apiKey);
     if (provider.requiresApiKey && !apiKey) {
       const error = new Error('Etherscan is not configured. Add your Etherscan key under Settings -> API Keys.');
@@ -275,7 +350,7 @@ class EtherscanService {
       provider,
       chainId,
       params,
-      attempt,
+      rateLimitState,
       fn: () => axios.get(provider.baseUrl, {
         timeout: 15000,
         params: {
@@ -303,11 +378,10 @@ class EtherscanService {
           provider,
           chainId,
           params,
-          attempt,
-          error: new Error(detail),
-          inlineRetry: false,
-          retry: (nextAttempt) => this._request(params, {
-            apiKey, chainId, attempt: nextAttempt,
+          rateLimitState,
+          error: responseDetailError(detail, response),
+          retry: () => this._request(params, {
+            apiKey, chainId, rateLimitState,
           }),
         });
       }
@@ -322,11 +396,13 @@ class EtherscanService {
         provider,
         chainId,
         params,
-        attempt,
-        error: new Error(detail.trim() || `${provider.name} rate limited`),
-        inlineRetry: false,
-        retry: (nextAttempt) => this._request(params, {
-          apiKey, chainId, attempt: nextAttempt,
+        rateLimitState,
+        error: responseDetailError(
+          detail.trim() || `${provider.name} rate limited`,
+          response
+        ),
+        retry: () => this._request(params, {
+          apiKey, chainId, rateLimitState,
         }),
       });
     }
@@ -363,7 +439,7 @@ class EtherscanService {
     throw error;
   }
 
-  static async _rpcRequest(chainId, method, params, attempt = 0) {
+  static async _rpcRequest(chainId, method, params, rateLimitState = { attempt: 0 }) {
     const rpcUrl = chains.getChain(chainId)?.rpcUrl;
     if (!rpcUrl) return null;
     const provider = rpcProvider(chainId, rpcUrl);
@@ -372,7 +448,7 @@ class EtherscanService {
       provider,
       chainId,
       params: rpcParams,
-      attempt,
+      rateLimitState,
       fn: () => axios.post(rpcUrl, {
         jsonrpc: '2.0',
         id: 1,
@@ -388,10 +464,9 @@ class EtherscanService {
           provider,
           chainId,
           params: rpcParams,
-          attempt,
-          error: new Error(detail),
-          inlineRetry: false,
-          retry: (nextAttempt) => this._rpcRequest(chainId, method, params, nextAttempt),
+          rateLimitState,
+          error: responseDetailError(detail, response),
+          retry: () => this._rpcRequest(chainId, method, params, rateLimitState),
         });
       }
       const error = new Error(`Chain RPC error: ${payload.error?.message || 'invalid response'}`);
@@ -479,7 +554,7 @@ class EtherscanService {
   // by the chain-declared public-RPC state-sync scanner; its caller bounds
   // concurrency per provider instead of putting a multi-minute historical
   // walk behind the Etherscan account-feed throttle.
-  static async _rpcBatchRequest(chainId, calls, attempt = 0) {
+  static async _rpcBatchRequest(chainId, calls, rateLimitState = { attempt: 0 }) {
     const rpcUrl = chains.getChain(chainId)?.rpcUrl;
     if (!rpcUrl) {
       const error = new Error(`Chain ${chainId} has no JSON-RPC endpoint configured`);
@@ -499,7 +574,7 @@ class EtherscanService {
       provider,
       chainId,
       params: rpcParams,
-      attempt,
+      rateLimitState,
       fn: () => axios.post(rpcUrl, body, { timeout: 30000 }),
     });
     if (!Array.isArray(response.data)) {
@@ -509,9 +584,9 @@ class EtherscanService {
           provider,
           chainId,
           params: rpcParams,
-          attempt,
-          error: new Error(detail),
-          retry: (nextAttempt) => this._rpcBatchRequest(chainId, calls, nextAttempt),
+          rateLimitState,
+          error: responseDetailError(detail, response),
+          retry: () => this._rpcBatchRequest(chainId, calls, rateLimitState),
         });
       }
       const suffix = detail ? `: ${detail}` : '';
@@ -526,9 +601,12 @@ class EtherscanService {
         provider,
         chainId,
         params: rpcParams,
-        attempt,
-        error: new Error(String(rateLimited.error?.message || rateLimited.error)),
-        retry: (nextAttempt) => this._rpcBatchRequest(chainId, calls, nextAttempt),
+        rateLimitState,
+        error: responseDetailError(
+          String(rateLimited.error?.message || rateLimited.error),
+          response
+        ),
+        retry: () => this._rpcBatchRequest(chainId, calls, rateLimitState),
       });
     }
     const byId = new Map(response.data.map((item) => [item?.id, item]));
@@ -544,7 +622,7 @@ class EtherscanService {
     });
   }
 
-  static async _latestBlockNumber(apiKey, chainId) {
+  static async _latestBlockNumber(apiKey, chainId, rateLimitState = { attempt: 0 }) {
     const chain = chains.getChain(chainId);
     let result;
     if (chain?.accountApi?.provider === 'Blockscout') {
@@ -558,8 +636,19 @@ class EtherscanService {
           provider,
           chainId,
           params: { module: 'v2', action: 'blocks' },
+          rateLimitState,
           fn: () => axios.get(blocksUrl, { timeout: 15000 }),
         });
+        if (isRateLimitedDetail(response.data)) {
+          return retryAfterRateLimit({
+            provider,
+            chainId,
+            params: { module: 'v2', action: 'blocks' },
+            rateLimitState,
+            error: responseDetailError('Blockscout v2 blocks endpoint rate limited', response),
+            retry: () => this._latestBlockNumber(apiKey, chainId, rateLimitState),
+          });
+        }
         // `total_blocks` from /api/v2/stats is an aggregate count, not a block
         // height (Base's value was ~200k behind its newest indexed height).
         // Blockscout orders this endpoint newest-first; the first item is the

--- a/backend/tests/ethFeedCoverage.test.js
+++ b/backend/tests/ethFeedCoverage.test.js
@@ -52,6 +52,14 @@ test('migration creates six-feed durable coverage without blessing old cursors a
   assert.match(migration, /coverage_recapture_version < 1/);
   assert.match(migration, /ALTER COLUMN coverage_recapture_version SET DEFAULT 1/);
   assert.match(migration, /last_block_normal = 0/);
+
+  const deferredMigration = fs.readFileSync(
+    path.join(__dirname, '..', 'migrations', '075_eth_feed_coverage_deferred.sql'),
+    'utf8'
+  );
+  assert.match(deferredMigration, /ADD COLUMN IF NOT EXISTS retry_after_at TIMESTAMPTZ/);
+  assert.match(deferredMigration, /'deferred'/);
+  assert.match(deferredMigration, /pg_get_constraintdef\(oid\) LIKE '%deferred%'/);
 });
 
 test('one chain attempt is written as one six-feed snapshot with exact errors', async () => {
@@ -99,9 +107,11 @@ test('one chain attempt is written as one six-feed snapshot with exact errors', 
   assert.match(sqlOf(queries[0]), /\$6::varchar\(20\)/, 'status parameters are explicitly typed for PostgreSQL inference');
   assert.match(sqlOf(queries[0]), /ON CONFLICT \(wallet_id, chain_id, feed\) DO UPDATE/);
   assert.match(sqlOf(queries[0]), /ELSE eth_feed_coverage\.covered_through_block/);
-  assert.equal(queries[0].params.length, 6 * 14);
+  assert.equal(queries[0].params.length, 6 * 15);
   assert.ok(queries[0].params.includes('ETHERSCAN_FEED_UNSUPPORTED'));
   assert.ok(queries[0].params.includes('internal traces are unavailable for blocks 0-123'));
+  assert.match(sqlOf(queries[0]), /WHEN EXCLUDED\.status = 'deferred' THEN EXCLUDED\.retry_after_at ELSE NULL/,
+    'a later success or standing limitation clears stale provider cooldown state');
 });
 
 test('failed coverage entries cannot omit their exact reason', async () => {
@@ -115,6 +125,30 @@ test('failed coverage entries cannot omit their exact reason', async () => {
   );
 });
 
+test('deferred coverage requires and stores a durable retry time', async () => {
+  await assert.rejects(
+    EthFeedCoverage.recordAttempts(7, 1, [{
+      feed: 'normal',
+      provider: 'Blockscout',
+      status: 'deferred',
+      errorMessage: 'rate limited',
+    }]),
+    /requires a retry time/
+  );
+
+  queries.length = 0;
+  const retryAt = new Date('2026-08-07T01:00:00Z');
+  await EthFeedCoverage.recordAttempts(7, 8453, [{
+    feed: 'normal',
+    provider: 'Blockscout',
+    status: 'deferred',
+    errorCode: 'EXPLORER_RATE_LIMITED',
+    errorMessage: 'rate limited',
+    retryAfterAt: retryAt,
+  }]);
+  assert.ok(queries[0].params.includes(retryAt));
+});
+
 test('coverage report reads only wallets owned by the requesting user', async () => {
   queries.length = 0;
   returnedRows = [{ wallet_id: 7, chain_id: 1, feed: 'normal' }];
@@ -123,6 +157,17 @@ test('coverage report reads only wallets owned by the requesting user', async ()
   assert.match(sqlOf(queries[0]), /JOIN eth_wallets w ON w\.id = c\.wallet_id/);
   assert.match(sqlOf(queries[0]), /WHERE w\.user_id = \$1/);
   assert.deepEqual(queries[0].params, [42]);
+});
+
+test('history audit counts deferred coverage as an incomplete gap', () => {
+  const auditScript = fs.readFileSync(
+    path.join(__dirname, '..', 'scripts', 'audit-history.js'),
+    'utf8'
+  );
+  assert.match(
+    auditScript,
+    /c\.status IN \('failed', 'deferred', 'unsupported'\)/
+  );
 });
 
 test('an explicit shared-scan head bounds every feed without taking a newer head', async (t) => {

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -45,6 +45,7 @@ const EthWalletChain = require('../src/models/EthWalletChain');
 const EthFeedCoverage = require('../src/models/EthFeedCoverage');
 const EthTransfer = require('../src/models/EthTransfer');
 const SecretsService = require('../src/services/SecretsService');
+const EthDerivedPipeline = require('../src/services/EthDerivedPipeline');
 const MirrorService = require('../src/services/EthTransactionMirrorService');
 const TransactionClassificationService = require('../src/services/TransactionClassificationService');
 const { collapseDuplicateKeys } = require('../src/services/SnapshotService');
@@ -617,10 +618,193 @@ test('a provider rate limit defers the remaining feeds without spending more req
     'Ethereum/nft', 'Ethereum/nft1155',
   ]);
   assert.equal(result.chains[0].rateLimited, true);
+  assert.equal(result.status, 'deferred');
+  assert.deepEqual(result.deferredFeeds, result.skippedFeeds);
   assert.equal(calls.deletes.length, 0, 'no feed is deleted after a rate-limited fetch');
   assert.equal(calls.cursors.every((cursor) => Object.values(cursor).every((value) => value == null || value === 1)), true);
-  assert.equal(calls.chainErrors.find((entry) => entry.chainId === 1).code, 'FEED_SKIPPED');
+  assert.equal(calls.chainErrors.find((entry) => entry.chainId === 1).code, 'SYNC_DEFERRED');
+  assert.equal(calls.walletError.code, 'SYNC_DEFERRED');
+  assert.ok(calls.coverage[0].entries.every((entry) => (
+    entry.status === 'not_applicable'
+    || (entry.status === 'deferred' && entry.retryAfterAt instanceof Date)
+  )));
   assert.match(calls.walletError.message, /rate limited/);
+});
+
+test('a mid-feed 429 preserves completed cursors and defers only the unfetched tail', async (t) => {
+  const rateLimited = () => {
+    const error = new Error('Blockscout rate limit reached');
+    error.code = 'EXPLORER_RATE_LIMITED';
+    error.retryAfterMs = 10000;
+    throw error;
+  };
+  const { calls } = harness(t, {
+    chainSet: '1',
+    feedBehavior: { '1:token': rateLimited },
+  });
+
+  const result = await EthWalletService.syncWallet(7);
+
+  assert.deepEqual(calls.fetches.map((call) => call.feed), ['normal', 'internal', 'token']);
+  assert.deepEqual(result.deferredFeeds, [
+    'Ethereum/token', 'Ethereum/nft', 'Ethereum/nft1155',
+  ]);
+  assert.equal(calls.deletes.length, 2, 'only feeds fetched completely replace their overlap window');
+  assert.equal(calls.cursors[0].normal, 50000000);
+  assert.equal(calls.cursors[0].internal, 50000000);
+  assert.equal(calls.cursors[0].token, null);
+  const verdicts = new Map(calls.coverage[0].entries.map((entry) => [entry.feed, entry.status]));
+  assert.equal(verdicts.get('normal'), 'complete');
+  assert.equal(verdicts.get('internal'), 'complete');
+  for (const feed of ['token', 'nft', 'nft1155']) assert.equal(verdicts.get(feed), 'deferred');
+});
+
+test('a healthy retry clears stale deferred coverage and sync errors', async (t) => {
+  let shouldLimit = true;
+  const { calls } = harness(t, {
+    chainSet: '1',
+    feedBehavior: {
+      '1:normal': () => {
+        if (!shouldLimit) return [];
+        const error = new Error('Blockscout rate limit reached');
+        error.code = 'EXPLORER_RATE_LIMITED';
+        error.retryAfterMs = 1;
+        throw error;
+      },
+    },
+  });
+
+  assert.equal((await EthWalletService.syncWallet(7)).status, 'deferred');
+  shouldLimit = false;
+  const retried = await EthWalletService.syncWallet(7);
+
+  assert.equal(retried.status, 'complete');
+  assert.ok(calls.cleared.includes(1), 'the recovered chain clears its stale warning');
+  assert.equal(calls.walletCleared, true, 'the recovered wallet clears its stale warning');
+  const finalCoverage = calls.coverage.at(-1).entries;
+  assert.ok(finalCoverage.every((entry) => (
+    entry.status === 'complete' || entry.status === 'not_applicable'
+  )));
+});
+
+test('the full-wallet job waits outside the user lane and retries deferred wallets automatically', async (t) => {
+  const originals = {
+    findAllForJobs: EthWallet.findAllForJobs,
+    prefetch: EthWalletService._prefetchStateSyncForWallets,
+    sync: EthWalletService._syncWallet,
+    serialized: EthDerivedPipeline.serializedForUser,
+    finishUser: EthDerivedPipeline.finishUser,
+  };
+  t.after(() => {
+    EthWallet.findAllForJobs = originals.findAllForJobs;
+    EthWalletService._prefetchStateSyncForWallets = originals.prefetch;
+    EthWalletService._syncWallet = originals.sync;
+    EthDerivedPipeline.serializedForUser = originals.serialized;
+    EthDerivedPipeline.finishUser = originals.finishUser;
+  });
+
+  const wallets = [
+    { id: 7, user_id: 1, address: WALLET },
+    { id: 8, user_id: 1, address: '0x1111111111111111111111111111111111111111' },
+  ];
+  EthWallet.findAllForJobs = async () => wallets;
+  EthWalletService._prefetchStateSyncForWallets = async () => new Map();
+  const laneEvents = [];
+  EthDerivedPipeline.serializedForUser = async (userId, fn) => {
+    laneEvents.push(`enter:${userId}`);
+    const value = await fn();
+    laneEvents.push(`exit:${userId}`);
+    return value;
+  };
+  EthDerivedPipeline.finishUser = async () => ({});
+  const attempts = new Map();
+  EthWalletService._syncWallet = async (walletId) => {
+    const attempt = Number(attempts.get(walletId) || 0) + 1;
+    attempts.set(walletId, attempt);
+    if (walletId === 7 && attempt === 1) {
+      return {
+        status: 'deferred',
+        deferredFeeds: ['Base/normal'],
+        skippedFeeds: ['Base/normal'],
+        unsupportedFeeds: [],
+        retryAfterMs: 1,
+      };
+    }
+    return {
+      status: walletId === 8 ? 'unsupported' : 'complete',
+      deferredFeeds: [],
+      skippedFeeds: [],
+      unsupportedFeeds: walletId === 8 ? ['Gnosis Chain/internal'] : [],
+    };
+  };
+
+  const summary = await EthWalletService.syncAllWallets({
+    deferredRetryAttempts: 1,
+    deferredRetryMaxMs: 100,
+  });
+
+  assert.equal(attempts.get(7), 2);
+  assert.equal(attempts.get(8), 1, 'healthy and limited wallets are not needlessly replayed');
+  assert.equal(summary.processed, 2);
+  assert.equal(summary.succeeded, 2);
+  assert.equal(summary.failed, 0);
+  assert.equal(summary.deferred, 0);
+  assert.equal(summary.unsupported, 1);
+  assert.equal(summary.results.find((entry) => entry.walletId === 7).attempts, 2);
+  assert.deepEqual(laneEvents, ['enter:1', 'exit:1', 'enter:1', 'exit:1'],
+    'the cooldown wait occurs between serialized lane acquisitions');
+});
+
+test('the full-wallet job retries deferred feeds even when another feed failed', async (t) => {
+  const originals = {
+    findAllForJobs: EthWallet.findAllForJobs,
+    prefetch: EthWalletService._prefetchStateSyncForWallets,
+    sync: EthWalletService._syncWallet,
+    serialized: EthDerivedPipeline.serializedForUser,
+    finishUser: EthDerivedPipeline.finishUser,
+  };
+  t.after(() => {
+    EthWallet.findAllForJobs = originals.findAllForJobs;
+    EthWalletService._prefetchStateSyncForWallets = originals.prefetch;
+    EthWalletService._syncWallet = originals.sync;
+    EthDerivedPipeline.serializedForUser = originals.serialized;
+    EthDerivedPipeline.finishUser = originals.finishUser;
+  });
+
+  EthWallet.findAllForJobs = async () => [{ id: 7, user_id: 1, address: WALLET }];
+  EthWalletService._prefetchStateSyncForWallets = async () => new Map();
+  EthDerivedPipeline.serializedForUser = async (_userId, fn) => fn();
+  EthDerivedPipeline.finishUser = async () => ({});
+  let attempts = 0;
+  EthWalletService._syncWallet = async () => {
+    attempts += 1;
+    return attempts === 1
+      ? {
+        status: 'failed',
+        failedFeeds: ['Polygon/token'],
+        deferredFeeds: ['Base/normal'],
+        skippedFeeds: ['Polygon/token', 'Base/normal'],
+        unsupportedFeeds: [],
+        retryAfterMs: 1,
+      }
+      : {
+        status: 'failed',
+        failedFeeds: ['Polygon/token'],
+        deferredFeeds: [],
+        skippedFeeds: ['Polygon/token'],
+        unsupportedFeeds: [],
+      };
+  };
+
+  const summary = await EthWalletService.syncAllWallets({
+    deferredRetryAttempts: 1,
+    deferredRetryMaxMs: 100,
+  });
+
+  assert.equal(attempts, 2, 'deferral is retried independently of the red failure status');
+  assert.equal(summary.failed, 1);
+  assert.equal(summary.deferred, 0);
+  assert.equal(summary.results[0].attempts, 2);
 });
 
 test('a rate-limited coverage boundary returns a deferred chain instead of failing the wallet', async (t) => {
@@ -639,7 +823,14 @@ test('a rate-limited coverage boundary returns a deferred chain instead of faili
     'Base/normal', 'Base/internal', 'Base/token', 'Base/nft', 'Base/nft1155', 'Base/statesync',
   ]);
   assert.equal(result.chains[0].rateLimited, true);
+  assert.equal(result.status, 'deferred');
   assert.equal(calls.deletes.length, 0);
+  assert.equal(calls.chainErrors[0].code, 'SYNC_DEFERRED');
+  assert.equal(calls.walletError.code, 'SYNC_DEFERRED');
+  assert.ok(calls.coverage[0].entries.every((entry) => (
+    entry.status === 'not_applicable'
+    || (entry.status === 'deferred' && entry.retryAfterAt instanceof Date)
+  )));
   assert.match(calls.walletError.message, /rate limited/);
 });
 
@@ -797,6 +988,26 @@ test('an HTTP 429 from a chain explorer backs off and retries without accepting 
   t.after(() => { etherscanConfig.resetRateLimits(); });
 
   assert.equal(await EtherscanService.getEthBalance(WALLET, 'key', 1), '0');
+  assert.equal(requests, 2);
+});
+
+test('a one-off explorer timeout is retried before the feed is marked failed', async (t) => {
+  const axios = require('axios');
+  const original = axios.get;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    if (requests === 1) {
+      const error = new Error('timeout of 15000ms exceeded');
+      error.code = 'ECONNABORTED';
+      throw error;
+    }
+    return { data: { status: '1', result: '0' } };
+  };
+  t.after(() => { axios.get = original; });
+  t.after(() => { etherscanConfig.resetRateLimits(); });
+
+  assert.equal(await EtherscanService.getEthBalance(WALLET, 'key', 137), '0');
   assert.equal(requests, 2);
 });
 
@@ -1041,6 +1252,56 @@ test('Blockscout log coverage uses the explorer indexed head, not the newer RPC 
   assert.equal(seenUrl, 'https://base.blockscout.com/api/v2/blocks?type=block');
 });
 
+test('a body-level Blockscout throttle on the indexed-head boundary is retried', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    if (requests === 1) {
+      return {
+        headers: { 'retry-after': '0' },
+        data: { message: 'Too many requests' },
+      };
+    }
+    return { data: { items: [{ height: 49295092 }] } };
+  };
+  t.after(() => { axios.get = originalGet; });
+  t.after(() => { etherscanConfig.resetRateLimits(); });
+
+  assert.equal(await EtherscanService._latestBlockNumber(null, 8453), 49295092);
+  assert.equal(requests, 2);
+});
+
+test('HTTP and body-level throttles share one bounded retry budget', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    if (requests === 2) {
+      return {
+        headers: { 'retry-after': '0' },
+        data: { status: '0', message: 'Too many requests', result: 'rate limit reached' },
+      };
+    }
+    const error = new Error('HTTP 429');
+    error.response = { status: 429, headers: { 'retry-after': '0' } };
+    throw error;
+  };
+  t.after(() => { axios.get = originalGet; });
+  t.after(() => { etherscanConfig.resetRateLimits(); });
+
+  await assert.rejects(
+    () => EtherscanService._request(
+      { module: 'account', action: 'txlist', address: WALLET },
+      { apiKey: null, chainId: 8453 }
+    ),
+    (error) => error.code === 'EXPLORER_RATE_LIMITED'
+  );
+  assert.equal(requests, 3, 'two configured retries permit three total attempts');
+});
+
 test('Etherscan proxy JSON-RPC responses supply the Polygon log coverage head', async (t) => {
   const axios = require('axios');
   const originalGet = axios.get;
@@ -1075,9 +1336,11 @@ test('Blockscout head falls back to the documented legacy explorer endpoint', as
 
   assert.equal(await EtherscanService._latestBlockNumber(null, 8453), 49328373);
   assert.equal(calls[0].url, 'https://base.blockscout.com/api/v2/blocks?type=block');
-  assert.equal(calls[1].url, 'https://base.blockscout.com/api');
-  assert.equal(calls[1].params.module, 'block');
-  assert.equal(calls[1].params.action, 'eth_block_number');
+  assert.equal(calls[1].url, 'https://base.blockscout.com/api/v2/blocks?type=block',
+    'one transient v2 failure is retried before changing endpoints');
+  assert.equal(calls[2].url, 'https://base.blockscout.com/api');
+  assert.equal(calls[2].params.module, 'block');
+  assert.equal(calls[2].params.action, 'eth_block_number');
 });
 
 test('a direct OP Stack self-deposit becomes one bridge-classifiable inbound credit', () => {

--- a/backend/tests/ethRoutes.test.js
+++ b/backend/tests/ethRoutes.test.js
@@ -385,17 +385,27 @@ test('GET /api/eth/coverage returns a user-scoped gap summary', async () => {
         error_code: 'ETHERSCAN_FEED_UNSUPPORTED',
         error_message: 'trace index incomplete for blocks 0-123',
       },
+      {
+        wallet_id: 7,
+        chain_id: 8453,
+        feed: 'token',
+        status: 'deferred',
+        error_code: 'EXPLORER_RATE_LIMITED',
+        error_message: 'retry after 10s',
+        retry_after_at: '2026-08-07T01:00:00Z',
+      },
       { wallet_id: 7, chain_id: 1, feed: 'statesync', status: 'not_applicable' },
     ];
   };
   try {
     const response = await request(app).get('/api/eth/coverage');
     assert.equal(response.status, 200);
-    assert.equal(response.body.summary.rows, 3);
+    assert.equal(response.body.summary.rows, 4);
     assert.equal(response.body.summary.complete, 1);
+    assert.equal(response.body.summary.deferred, 1);
     assert.equal(response.body.summary.unsupported, 1);
     assert.equal(response.body.summary.not_applicable, 1);
-    assert.equal(response.body.summary.gaps, 1);
+    assert.equal(response.body.summary.gaps, 2);
     assert.equal(response.body.coverage[1].chain_name, 'Gnosis Chain');
     assert.equal(response.body.coverage[1].enabled, true);
   } finally {

--- a/backend/tests/ethSyncJob.test.js
+++ b/backend/tests/ethSyncJob.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = 'postgresql://test:test@localhost/test';
+
+const pgModulePath = require.resolve('pg');
+require.cache[pgModulePath] = {
+  id: pgModulePath,
+  filename: pgModulePath,
+  loaded: true,
+  exports: {
+    Pool: class FakePool {
+      async query() { return { rows: [], rowCount: 0 }; }
+      on() {}
+    },
+    types: { setTypeParser() {} },
+  },
+};
+
+const EthSyncJob = require('../src/jobs/ethSyncJob');
+const JobLog = require('../src/models/JobLog');
+const EthWallet = require('../src/models/EthWallet');
+const EthWalletService = require('../src/services/EthWalletService');
+
+test('enqueue claims the job and returns before a cooldown-capable scan finishes', async (t) => {
+  const originals = {
+    claim: JobLog.createIfNotRunning,
+    complete: JobLog.complete,
+    fail: JobLog.fail,
+    wallets: EthWallet.findAllForJobs,
+    sync: EthWalletService.syncAllWallets,
+  };
+  t.after(() => {
+    JobLog.createIfNotRunning = originals.claim;
+    JobLog.complete = originals.complete;
+    JobLog.fail = originals.fail;
+    EthWallet.findAllForJobs = originals.wallets;
+    EthWalletService.syncAllWallets = originals.sync;
+  });
+
+  let releaseScan;
+  const scan = new Promise((resolve) => { releaseScan = resolve; });
+  let completeJob;
+  const completed = new Promise((resolve) => { completeJob = resolve; });
+  JobLog.createIfNotRunning = async () => ({ id: 91 });
+  JobLog.complete = async (...args) => { completeJob(args); };
+  JobLog.fail = async () => { throw new Error('unexpected job failure'); };
+  EthWallet.findAllForJobs = async () => [{ id: 7 }];
+  EthWalletService.syncAllWallets = async () => scan;
+
+  const queued = await EthSyncJob.enqueue();
+  assert.deepEqual(queued, { started: true, jobLogId: 91 });
+
+  releaseScan({
+    processed: 1,
+    succeeded: 1,
+    failed: 0,
+    deferred: 0,
+    unsupported: 0,
+    unverified: 0,
+    skipped: 0,
+    results: [{ walletId: 7, status: 'complete' }],
+  });
+  const completeArgs = await completed;
+  assert.deepEqual(completeArgs.slice(0, 4), [91, 1, 1, 0]);
+  assert.equal(completeArgs[4].deferred, 0);
+});
+
+test('enqueue reports a concurrent scan without scheduling another one', async (t) => {
+  const original = JobLog.createIfNotRunning;
+  t.after(() => { JobLog.createIfNotRunning = original; });
+  JobLog.createIfNotRunning = async () => null;
+
+  assert.deepEqual(await EthSyncJob.enqueue(), {
+    skipped: true,
+    reason: 'concurrent_execution',
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import NotFound from './pages/NotFound';
 import Sidebar from './components/Sidebar';
 import LoadingState from './components/LoadingState';
+import { isWalletSyncFailure } from './utils/walletSync';
 import { Menu } from 'lucide-react';
 
 const Dashboard = lazyWithReload(() => import('./components/Dashboard'));
@@ -163,7 +164,7 @@ function App() {
       applyBootCryptoAttention({
         errored: wallets
           ? (wallets.wallets || []).filter((wallet) => (
-            wallet.error_code || wallet.reconciliation?.needs_review
+            isWalletSyncFailure(wallet) || wallet.reconciliation?.needs_review
         )).length
           : null,
         needsReview: ledger ? (ledger.summary?.needs_review_count || 0) : null,

--- a/frontend/src/__tests__/App.smoke.test.jsx
+++ b/frontend/src/__tests__/App.smoke.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
 import { me, crypto as cryptoAPI, eth as ethAPI, exchanges as exchangesAPI } from '../utils/api';
@@ -43,6 +43,10 @@ vi.mock('../pages/CryptoPage', () => ({
 }));
 
 describe('App smoke test', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders the app shell for the authenticated user', async () => {
     render(
       <MemoryRouter>
@@ -96,6 +100,35 @@ describe('App smoke test', () => {
     );
 
     expect(await screen.findByTitle('Crypto Review (5)')).toBeInTheDocument();
+  });
+
+  it('does not badge a provider cooldown as a red wallet failure during boot', async () => {
+    ethAPI.getWallets.mockResolvedValueOnce({
+      wallets: [{ id: 7, error_code: 'SYNC_DEFERRED', reconciliation: null }],
+    });
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(ethAPI.getWallets).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTitle('Crypto Wallets (1)')).not.toBeInTheDocument();
+  });
+
+  it('still badges a genuine wallet sync failure during boot', async () => {
+    ethAPI.getWallets.mockResolvedValueOnce({
+      wallets: [{ id: 7, error_code: 'FEED_SKIPPED', reconciliation: null }],
+    });
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTitle('Crypto Wallets (1)')).toBeInTheDocument();
   });
 
   it('keeps the old Discovery URL as a Wallets alias', async () => {

--- a/frontend/src/components/crypto/WalletsPanel.jsx
+++ b/frontend/src/components/crypto/WalletsPanel.jsx
@@ -6,6 +6,7 @@ import { eth as ethAPI } from '../../utils/api';
 import { formatExactUnits, formatRelativeTime, shortEthAddress as shortEthAddressOrUnknown } from '../../utils/format';
 import { getAccountDisplayName } from '../../utils/accountDisplay';
 import { explorerAddressUrl } from '../../utils/chains';
+import { DEFERRED_SYNC_CODES, LIMITED_SYNC_CODES } from '../../utils/walletSync';
 import DataTable from '../DataTable';
 import { useIsMobile } from '../../hooks/useMediaQuery';
 
@@ -311,8 +312,27 @@ export function WalletReconciliation({ report, chainNames, walletId, onChanged, 
 // carries the verdict and the expanded panel carries the evidence -- a table
 // cannot hold the audit's several lines, but it must never round the audit down
 // to silence either, so every state has words rather than only a colour.
+const chainIssueTone = (chain) => {
+  if (!chain.enabled) return 'neutral';
+  if (DEFERRED_SYNC_CODES.has(chain.error_code)) return 'deferred';
+  if (chain.error_code && !LIMITED_SYNC_CODES.has(chain.error_code)) return 'failed';
+  if (LIMITED_SYNC_CODES.has(chain.error_code) || chain.unsupported_feeds?.length > 0) {
+    return 'limited';
+  }
+  return 'neutral';
+};
+
 const walletStatus = (wallet) => {
+  if (DEFERRED_SYNC_CODES.has(wallet.error_code)) {
+    return { label: 'Sync deferred', tone: 'text-amber-400' };
+  }
+  if (LIMITED_SYNC_CODES.has(wallet.error_code)) {
+    return { label: 'Limited coverage', tone: 'text-amber-400' };
+  }
   if (wallet.error_code) return { label: 'Sync failed', tone: 'text-loss' };
+  if (wallet.chains?.some((chain) => chainIssueTone(chain) === 'limited')) {
+    return { label: 'Limited coverage', tone: 'text-amber-400' };
+  }
   const report = wallet.reconciliation;
   if (!report) return { label: 'Not audited', tone: 'text-tertiary' };
   const { nativeDrift, tokenDrift } = splitAuditIssues(report);
@@ -330,11 +350,14 @@ const walletStatus = (wallet) => {
 const chainSummary = (wallet) => {
   const chains = wallet.chains || [];
   const live = chains.filter((chain) => chain.enabled);
+  const tones = live.map(chainIssueTone);
   return {
     label: chains.length === 0 ? '—'
       : live.length === 1 ? live[0].name
       : `${live.length} chains`,
-    degraded: chains.some((chain) => chain.enabled && (chain.error_code || chain.unsupported_feeds?.length > 0)),
+    tone: tones.includes('failed') ? 'failed'
+      : tones.some((tone) => ['deferred', 'limited'].includes(tone)) ? 'limited'
+        : 'neutral',
   };
 };
 
@@ -343,7 +366,7 @@ const ROW_ACTION_CLASS = 'inline-flex h-7 items-center gap-1.5 rounded border bo
 // The tracked-wallet list and everything that changes it: add, sync, disconnect.
 // Moved off Settings with #75 -- a wallet is crypto data, not an app preference,
 // and the add form was three clicks from the feed it fills.
-function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
+function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = showSuccess }) {
   const [addOpen, setAddOpen] = useState(false);
   const [walletAddress, setWalletAddress] = useState('');
   const [walletLabel, setWalletLabel] = useState('');
@@ -433,9 +456,17 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
     setSyncingId(id);
     onError(null);
     try {
-      await ethAPI.syncWallet(id);
-      showSuccess('Wallet synced successfully');
+      const result = await ethAPI.syncWallet(id);
       await onChanged();
+      if (result.sync?.status === 'failed') {
+        onError('Wallet sync completed with feed errors. Open the wallet for details.');
+      } else if (result.sync?.status === 'deferred') {
+        showNotice('Wallet sync deferred while the explorer cools down. Retry after the time shown in Coverage; scheduled full scans also retry automatically.');
+      } else if (result.sync?.status === 'unsupported') {
+        showNotice('Wallet synced with limited coverage on feeds the explorer does not support.');
+      } else {
+        showSuccess('Wallet synced successfully');
+      }
     } catch (err) {
       onError(err.response?.data?.error || 'Failed to sync wallet');
     } finally {
@@ -582,10 +613,10 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
       header: 'Chains',
       meta: { width: '9rem', cellClassName: 'whitespace-nowrap' },
       cell: ({ row }) => {
-        const { label, degraded } = chainSummary(row.original);
+        const { label, tone } = chainSummary(row.original);
         return (
-          <span className={`inline-flex items-center gap-1.5 text-caption ${degraded ? 'text-loss' : 'text-secondary'}`}>
-            {degraded && <AlertTriangle size={11} className="shrink-0" />}
+          <span className={`inline-flex items-center gap-1.5 text-caption ${tone === 'failed' ? 'text-loss' : tone === 'limited' ? 'text-amber-400' : 'text-secondary'}`}>
+            {tone !== 'neutral' && <AlertTriangle size={11} className="shrink-0" />}
             {label}
           </span>
         );
@@ -652,11 +683,12 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
                 || (chain.enabled ? `Last synced ${formatRelativeTime(chain.last_synced_at)}` : 'Chain turned off; stored history kept')}
               className={`inline-flex items-center gap-1.5 px-2 py-1 rounded border text-[10px] font-bold uppercase tracking-wide ${
                 !chain.enabled ? 'bg-surface-3 border-border text-tertiary'
-                  : chain.error_code ? 'bg-loss/5 border-loss/20 text-loss'
+                  : chainIssueTone(chain) === 'failed' ? 'bg-loss/5 border-loss/20 text-loss'
+                    : chainIssueTone(chain) !== 'neutral' ? 'bg-amber-500/10 border-amber-500/30 text-amber-400'
                   : 'bg-surface-3 border-border text-secondary'
               }`}
             >
-              {chain.enabled && chain.error_code && <AlertTriangle size={10} />}
+              {chain.enabled && chainIssueTone(chain) !== 'neutral' && <AlertTriangle size={10} />}
               {chain.name}
               {!chain.enabled && <span className="font-normal normal-case">off</span>}
               {chain.unsupported_feeds?.length > 0 && (
@@ -670,7 +702,7 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
       )}
 
       {wallet.error_code && (
-        <div className="rounded border border-loss/20 bg-loss/5 p-3 text-xs leading-relaxed text-loss">
+        <div className={`rounded p-3 text-xs leading-relaxed ${DEFERRED_SYNC_CODES.has(wallet.error_code) || LIMITED_SYNC_CODES.has(wallet.error_code) ? 'border border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border border-loss/20 bg-loss/5 text-loss'}`}>
           <div className="flex items-start gap-3">
             <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
             <p>{wallet.error_message || `Wallet sync reported an error: ${wallet.error_code}`}</p>
@@ -813,15 +845,16 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
                 </button>
               </div>
 
-              <div className="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-4">
+              <div className="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-5">
                 {[
                   ['Complete', coverageReport.summary.complete],
-                  ['Gaps', coverageReport.summary.gaps],
+                  ['Failed', coverageReport.summary.failed],
+                  ['Deferred', coverageReport.summary.deferred],
                   ['Unsupported', coverageReport.summary.unsupported],
                   ['Unverified', coverageReport.summary.unverified],
                 ].map(([label, value]) => (
                   <div key={label} className="rounded border border-border bg-surface-2 p-3">
-                    <p className="text-[10px] font-bold uppercase tracking-wider text-tertiary">{label}</p>
+                    <p className={`text-[10px] font-bold uppercase tracking-wider ${['Deferred', 'Unsupported'].includes(label) ? 'text-amber-400' : label === 'Complete' ? 'text-tertiary' : 'text-loss'}`}>{label}</p>
                     <p className="mt-1 font-money text-xl text-primary">{value}</p>
                   </div>
                 ))}
@@ -832,7 +865,7 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
                   Enabled-feed gaps
                 </h3>
                 {coverageReport.coverage.filter((row) => (
-                  row.enabled && ['failed', 'unsupported', 'unverified'].includes(row.status)
+                  row.enabled && ['failed', 'deferred', 'unsupported', 'unverified'].includes(row.status)
                 )).length === 0 ? (
                   <p className="mt-2 rounded border border-gain/20 bg-gain/5 p-3 text-sm text-gain">
                     Every enabled feed has a verified boundary.
@@ -840,14 +873,14 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
                 ) : (
                   <div className="mt-2 divide-y divide-border overflow-hidden rounded border border-border">
                     {coverageReport.coverage.filter((row) => (
-                      row.enabled && ['failed', 'unsupported', 'unverified'].includes(row.status)
+                      row.enabled && ['failed', 'deferred', 'unsupported', 'unverified'].includes(row.status)
                     )).map((row) => (
                       <div key={`${row.wallet_id}:${row.chain_id}:${row.feed}`} className="bg-surface-2 p-3">
                         <div className="flex flex-wrap items-baseline justify-between gap-2">
                           <p className="text-sm font-semibold text-primary">
                             {row.wallet_label || shortEthAddress(row.wallet_address)} · {row.chain_name} · {row.feed}
                           </p>
-                          <span className="text-[10px] font-bold uppercase tracking-wider text-loss">{row.status}</span>
+                          <span className={`text-[10px] font-bold uppercase tracking-wider ${['deferred', 'unsupported'].includes(row.status) ? 'text-amber-400' : 'text-loss'}`}>{row.status}</span>
                         </div>
                         <p className="mt-1 break-words text-xs text-secondary">
                           {row.error_message || 'A pre-report cursor exists, but this feed has not completed a post-report sync yet.'}
@@ -855,6 +888,7 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess }) {
                         <p className="mt-1 text-[10px] text-tertiary">
                           Provider: {row.provider}
                           {row.covered_through_block != null ? ` · last proven block ${row.covered_through_block}` : ''}
+                          {row.retry_after_at ? ` · retry after ${new Date(row.retry_after_at).toLocaleString()}` : ''}
                         </p>
                       </div>
                     ))}

--- a/frontend/src/pages/CryptoPage.jsx
+++ b/frontend/src/pages/CryptoPage.jsx
@@ -31,6 +31,7 @@ import ReviewPanel, { SPAM_PAGE_SIZE, SPAM_MAX_LIMIT } from '../components/crypt
 import LabelsPanel from '../components/crypto/LabelsPanel';
 import DiscoveryPanel from '../components/crypto/DiscoveryPanel';
 import useTransientMessage from '../hooks/useTransientMessage';
+import { isWalletSyncFailure } from '../utils/walletSync';
 
 const getHoldingValue = (holding) => parseFloat(holding.current_value ?? holding.manual_value ?? 0) || 0;
 
@@ -91,7 +92,6 @@ const TRANSFERS_VIEW = 'transfers';
 
 // Sentinel for "sync every wallet"; real wallet ids are >= 1.
 const SYNC_ALL = 'all';
-
 // onAttentionChange reports the wallet, ledger and management attention counts
 // up to the app shell, which renders them as page-specific Crypto badges.
 const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
@@ -114,6 +114,7 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingHolding, setEditingHolding] = useState(null);
   const [successMessage, showSuccess] = useTransientMessage();
+  const [noticeMessage, showNotice] = useTransientMessage();
   // Bumped after a sync so the feed refetches: OnChainActivity is keyed on the
   // selected wallet, which a sync does not change, so without this the rows
   // sitting right under the Sync button would stay stale.
@@ -197,7 +198,7 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
         onAttentionChange?.({
           errored: walletsData
             ? (walletsData.wallets || []).filter((wallet) => (
-              wallet.error_code || wallet.reconciliation?.needs_review
+              isWalletSyncFailure(wallet) || wallet.reconciliation?.needs_review
             )).length
             : null,
           needsReview: ok ? (ledgerData?.summary?.needs_review_count || 0) : null,
@@ -339,7 +340,11 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
     [wallets, accountDisplayNames]
   );
 
-  const erroredWallets = useMemo(() => wallets.filter((wallet) => wallet.error_code), [wallets]);
+  const erroredWallets = useMemo(() => wallets.filter(isWalletSyncFailure), [wallets]);
+  const deferredWallets = useMemo(
+    () => wallets.filter((wallet) => wallet.error_code === 'SYNC_DEFERRED'),
+    [wallets]
+  );
 
   // Material only, deliberately. A badge that cannot reach zero -- because a
   // single airdrop wave parked 40 dust counterparties behind it -- teaches the
@@ -407,10 +412,18 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
     setSyncingWalletId(walletId);
     setError(null);
     try {
-      await ethAPI.syncWallet(walletId);
+      const result = await ethAPI.syncWallet(walletId);
       await fetchData();
       setSyncNonce((nonce) => nonce + 1);
-      showSuccess('Wallet synced');
+      if (result.sync?.status === 'failed') {
+        setError('Wallet sync completed with feed errors. Open Wallets for details.');
+      } else if (result.sync?.status === 'deferred') {
+        showNotice('Wallet sync deferred while the explorer cools down. Retry after the time shown in Coverage; scheduled full scans also retry automatically.');
+      } else if (result.sync?.status === 'unsupported') {
+        showNotice('Wallet synced with limited explorer coverage.');
+      } else {
+        showSuccess('Wallet synced');
+      }
     } catch (err) {
       setError(err.response?.data?.error || 'Failed to sync wallet');
     } finally {
@@ -427,9 +440,14 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
     setSyncingWalletId(SYNC_ALL);
     setError(null);
     const failed = [];
+    const deferred = [];
+    const limited = [];
     for (const wallet of wallets) {
       try {
-        await ethAPI.syncWallet(wallet.id);
+        const result = await ethAPI.syncWallet(wallet.id);
+        if (result.sync?.status === 'failed') failed.push(walletLabel(wallet));
+        else if (result.sync?.status === 'deferred') deferred.push(walletLabel(wallet));
+        else if (result.sync?.status === 'unsupported') limited.push(walletLabel(wallet));
       } catch {
         failed.push(walletLabel(wallet));
       }
@@ -437,8 +455,15 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
     await fetchData();
     setSyncNonce((nonce) => nonce + 1);
     setSyncingWalletId(null);
-    if (failed.length) setError(`${failed.length} of ${wallets.length} wallets failed to sync: ${failed.join(', ')}`);
-    else showSuccess('Wallets synced');
+    if (failed.length) {
+      setError(`${failed.length} of ${wallets.length} wallets failed to sync: ${failed.join(', ')}`);
+    } else if (deferred.length) {
+      showNotice(`${deferred.length} of ${wallets.length} wallets deferred while an explorer cools down. Retry after the time shown in Coverage; scheduled full scans also retry automatically.`);
+    } else if (limited.length) {
+      showNotice(`Wallets synced; ${limited.length} have evidence-backed explorer coverage limits.`);
+    } else {
+      showSuccess('Wallets synced');
+    }
   };
 
   const handleSyncClick = () => (
@@ -601,6 +626,11 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
       {successMessage && (
         <div className="mb-4 border border-gain/20 bg-gain-bg p-3 text-body-sm text-gain">
           {successMessage}
+        </div>
+      )}
+      {noticeMessage && (
+        <div className="mb-4 border border-amber-500/30 bg-amber-500/10 p-3 text-body-sm text-amber-300">
+          {noticeMessage}
         </div>
       )}
       {error && (
@@ -780,6 +810,20 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
                   </button>
                 </div>
               )}
+              {deferredWallets.length > 0 && (
+                <div className="mb-4 flex flex-wrap items-center gap-2 border border-accent/20 bg-accent/5 p-2 text-body-sm text-accent">
+                  <AlertTriangle size={14} className="shrink-0" />
+                  <span>
+                    {deferredWallets.length} {deferredWallets.length === 1 ? 'wallet is' : 'wallets are'} waiting for an explorer cooldown.
+                  </span>
+                  <button
+                    onClick={() => goToTab(WALLETS_TAB)}
+                    className="underline hover:text-primary"
+                  >
+                    View details
+                  </button>
+                </div>
+              )}
 
               {txView === LEDGER_VIEW ? (
                 <CryptoLedger
@@ -826,6 +870,7 @@ const CryptoPage = ({ tab = OVERVIEW_TAB, onTabChange, onAttentionChange }) => {
                 onChanged={handleManageChanged}
                 onError={setError}
                 showSuccess={showSuccess}
+                showNotice={showNotice}
               />
               <DiscoveryPanel
                 onChanged={handleManageChanged}

--- a/frontend/src/pages/CryptoWallets.test.jsx
+++ b/frontend/src/pages/CryptoWallets.test.jsx
@@ -356,6 +356,62 @@ describe('Crypto -> Wallets tab', () => {
     expect(screen.getByText('Base')).toBeInTheDocument();
     expect(screen.getByText('off')).toBeInTheDocument();
     // Chain-level coverage detail alone does not inflate the Wallets badge.
+    expect(screen.getAllByText('Limited coverage').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Sync failed')).toBeNull();
+  });
+
+  it('shows provider cooldowns as deferred instead of failed', async () => {
+    await openEthereumTab([{
+      ...CHAIN_WALLET,
+      error_code: 'SYNC_DEFERRED',
+      error_message: 'Base explorer rate limited; automatic retry pending',
+      chains: [{
+        chain_id: 8453,
+        name: 'Base',
+        enabled: true,
+        error_code: 'SYNC_DEFERRED',
+        error_message: 'Base explorer rate limited; automatic retry pending',
+        unsupported_feeds: [],
+        last_synced_at: '2026-07-26T09:00:00Z',
+      }],
+    }]);
+
+    expect(screen.getAllByText('Sync deferred').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Sync failed')).toBeNull();
+    await expandWallet();
+    expect(await screen.findByText(/automatic retry pending/i)).toBeInTheDocument();
+  });
+
+  it('keeps genuine feed failures red even when another chain has a standing limit', async () => {
+    await openEthereumTab([{
+      ...CHAIN_WALLET,
+      error_code: 'FEED_SKIPPED',
+      error_message: 'Polygon token feed timed out',
+      chains: [
+        {
+          chain_id: 137, name: 'Polygon', enabled: true,
+          error_code: 'FEED_SKIPPED', error_message: 'token feed timed out',
+          unsupported_feeds: [], last_synced_at: '2026-07-26T09:00:00Z',
+        },
+        {
+          chain_id: 100, name: 'Gnosis Chain', enabled: true,
+          error_code: 'FEED_UNSUPPORTED', error_message: 'internal traces unavailable',
+          unsupported_feeds: ['internal'], last_synced_at: '2026-07-26T09:00:00Z',
+        },
+      ],
+    }]);
+
+    expect(screen.getAllByText('Sync failed').length).toBeGreaterThan(0);
+  });
+
+  it('reports a deferred Sync click without a red failure banner', async () => {
+    apiMocks.eth.syncWallet.mockResolvedValue({ sync: { status: 'deferred' } });
+    await openEthereumTab([wallet(report())]);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /sync main/i }))[0]);
+
+    expect(await screen.findByText(/wallet sync deferred while the explorer cools down/i)).toBeInTheDocument();
+    expect(screen.queryByText('Failed to sync wallet')).toBeNull();
   });
 
   it('shows a single chain\u2019s standing gap, which a chain-count gate hid entirely', async () => {
@@ -406,8 +462,8 @@ describe('Crypto -> Wallets tab', () => {
     apiMocks.eth.getCoverage.mockResolvedValue({
       generated_at: '2026-07-30T22:00:00.000Z',
       summary: {
-        rows: 2, enabled_rows: 2, complete: 1, failed: 0,
-        unsupported: 1, not_applicable: 0, unverified: 0, gaps: 1,
+        rows: 3, enabled_rows: 3, complete: 1, failed: 0,
+        deferred: 1, unsupported: 1, not_applicable: 0, unverified: 0, gaps: 2,
       },
       coverage: [
         {
@@ -422,6 +478,14 @@ describe('Crypto -> Wallets tab', () => {
           error_message: 'Internal traces unavailable for blocks 0-123',
           covered_through_block: 99,
         },
+        {
+          wallet_id: 1, wallet_label: 'Main', wallet_address: wallet().address,
+          chain_id: 8453, chain_name: 'Base', feed: 'token',
+          status: 'deferred', enabled: true, provider: 'Blockscout',
+          error_message: 'Provider cooldown; retry after 10 seconds',
+          retry_after_at: '2026-07-30T22:00:10.000Z',
+          covered_through_block: 49999999,
+        },
       ],
     });
     await openEthereumTab([wallet(report())]);
@@ -431,6 +495,8 @@ describe('Crypto -> Wallets tab', () => {
     expect(await screen.findByRole('dialog', { name: /evm source coverage/i })).toBeInTheDocument();
     expect(screen.getByText(/main · gnosis chain · internal/i)).toBeInTheDocument();
     expect(screen.getByText(/internal traces unavailable for blocks 0-123/i)).toBeInTheDocument();
+    expect(screen.getByText(/main · base · token/i)).toBeInTheDocument();
+    expect(screen.getByText(/provider cooldown; retry after 10 seconds/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /download json/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -35,6 +35,38 @@ const JOB_TRIGGER_NAMES = {
   'snapshot-creation': 'snapshot',
 };
 
+const jobRunPresentation = (name, lastRun) => {
+  if (!lastRun) return { text: 'Never run', tone: 'text-tertiary' };
+  const when = formatRelativeTime(lastRun.completed_at || lastRun.started_at);
+  if (lastRun.status === 'running') {
+    return { text: `Running since ${when}`, tone: 'text-accent' };
+  }
+  if (lastRun.status === 'failed') {
+    return { text: `Last run ${when} — failed`, tone: 'text-loss' };
+  }
+  if (name !== 'eth-sync') {
+    return { text: `Last run ${when} — ${lastRun.status}`, tone: 'text-tertiary' };
+  }
+  const details = lastRun.details && typeof lastRun.details === 'object'
+    ? lastRun.details
+    : {};
+  const counts = {
+    processed: Number(lastRun.tickers_processed || 0),
+    succeeded: Number(lastRun.tickers_succeeded || 0),
+    failed: Number(lastRun.tickers_failed || 0),
+    deferred: Number(details.deferred || 0),
+    unsupported: Number(details.unsupported || 0),
+    unverified: Number(details.unverified || 0),
+    skipped: Number(details.skipped || 0),
+  };
+  const text = `Last run ${when} — ${counts.succeeded}/${counts.processed} succeeded · ${counts.failed} failed · ${counts.deferred} deferred · ${counts.unsupported} unsupported · ${counts.unverified} unverified · ${counts.skipped} skipped`;
+  const degraded = counts.deferred + counts.unsupported + counts.unverified + counts.skipped > 0;
+  return {
+    text,
+    tone: counts.failed > 0 ? 'text-loss' : degraded ? 'text-amber-400' : 'text-tertiary',
+  };
+};
+
 // Rows on the API Keys tab. Plaid/Etherscan pull the signed-in user's own
 // financial data; the price keys are shared app-wide (prices are global).
 const USER_KEY_ROWS = [
@@ -255,6 +287,7 @@ const Settings = ({ user }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [successMessage, showSuccess] = useTransientMessage();
+  const [noticeMessage, showNotice] = useTransientMessage();
   const [syncingId, setSyncingId] = useState(null);
   const [disconnectingItem, setDisconnectingItem] = useState(null);
   const [removeDataOnDisconnect, setRemoveDataOnDisconnect] = useState(true);
@@ -280,6 +313,7 @@ const Settings = ({ user }) => {
   const [activeTab, setActiveTab] = useState(() =>
     SETTINGS_TABS.some((t) => t.id === location.state?.tab) ? location.state.tab : 'appearance'
   );
+  const ethSyncRunning = adminOverview?.jobs?.jobs?.['eth-sync']?.lastRun?.status === 'running';
 
   const institutionSummary = useMemo(
     () => buildInstitutionSummary(items, consentItems),
@@ -339,6 +373,26 @@ const Settings = ({ user }) => {
       .then((data) => { if (!cancelled) setAdminOverview(data || null); });
     return () => { cancelled = true; };
   }, [isAdmin]);
+
+  // The full wallet scan is deliberately detached from the trigger request so
+  // provider cooldowns cannot hit Azure's HTTP timeout. Keep its durable
+  // JobLog row live while the operator is looking at Server, and stop polling
+  // as soon as the row reaches a terminal state or the page is left.
+  useEffect(() => {
+    if (!isAdmin || activeTab !== 'server' || !ethSyncRunning) return undefined;
+    let cancelled = false;
+    const timer = setInterval(() => {
+      adminAPI.getOverview()
+        .catch(() => null)
+        .then((data) => {
+          if (!cancelled && data) setAdminOverview(data);
+        });
+    }, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [activeTab, ethSyncRunning, isAdmin]);
 
   const handlePlaidSuccess = async (publicToken, metadata) => {
     setConnecting(true);
@@ -449,8 +503,19 @@ const Settings = ({ user }) => {
     setTriggeringJob(statusKey);
     setError(null);
     try {
-      await adminAPI.triggerJob(JOB_TRIGGER_NAMES[statusKey] || statusKey);
-      showSuccess('Job completed');
+      const response = await adminAPI.triggerJob(JOB_TRIGGER_NAMES[statusKey] || statusKey);
+      const result = response?.result || {};
+      if (response?.status === 'started' || result.started) {
+        showSuccess('Job started. Live status and the final outcome appear below.');
+      } else if (statusKey === 'eth-sync' && Number(result.failed || 0) > 0) {
+        setError(`Wallet scan completed with ${result.failed} failed wallet${result.failed === 1 ? '' : 's'}.`);
+      } else if (statusKey === 'eth-sync'
+          && Number(result.deferred || 0) + Number(result.unsupported || 0)
+            + Number(result.unverified || 0) + Number(result.skipped || 0) > 0) {
+        showNotice(`Wallet scan completed with ${Number(result.deferred || 0)} deferred, ${Number(result.unsupported || 0)} unsupported, ${Number(result.unverified || 0)} unverified, and ${Number(result.skipped || 0)} skipped.`);
+      } else {
+        showSuccess('Job completed');
+      }
       // Keep the previous overview if the refresh fails: clearing it used to
       // unmount the tab the user is standing on and leave a blank page.
       const refreshed = await adminAPI.getOverview().catch(() => null);
@@ -607,6 +672,12 @@ const Settings = ({ user }) => {
         <Motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} className="mb-6 p-4 bg-gain-bg border border-gain/20 text-gain rounded text-xs flex items-center gap-3">
           <Check size={16} />
           {successMessage}
+        </Motion.div>
+      )}
+      {noticeMessage && (
+        <Motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} className="mb-6 flex items-center gap-3 rounded border border-amber-500/30 bg-amber-500/10 p-4 text-xs text-amber-300">
+          <AlertTriangle size={16} />
+          {noticeMessage}
         </Motion.div>
       )}
       {error && (
@@ -1186,31 +1257,33 @@ const Settings = ({ user }) => {
       <section className="mb-8">
         <div className="mb-3 px-2">
           <h2 className="text-lg font-bold uppercase tracking-tight text-primary">Scheduled Jobs</h2>
-          <p className="mt-1 text-xs text-secondary">Nightly pipeline (all times UTC). Manual runs execute immediately with your permissions.</p>
+          <p className="mt-1 text-xs text-secondary">Nightly pipeline (all times UTC). Manual runs execute with your permissions; long wallet scans continue in the background.</p>
         </div>
         <div className="card divide-y divide-border overflow-hidden">
-          {Object.entries(adminOverview.jobs?.jobs || {}).map(([name, job]) => (
-            <div key={name} className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.6fr)_auto] sm:items-center">
-              <div className="min-w-0">
-                <span className="block text-body-sm font-semibold text-primary">{name}</span>
-                <span className="block font-mono text-[10px] text-tertiary">{job.schedule} UTC</span>
+          {Object.entries(adminOverview.jobs?.jobs || {}).map(([name, job]) => {
+            const run = jobRunPresentation(name, job.lastRun);
+            const running = job.lastRun?.status === 'running';
+            return (
+              <div key={name} className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.6fr)_auto] sm:items-center">
+                <div className="min-w-0">
+                  <span className="block text-body-sm font-semibold text-primary">{name}</span>
+                  <span className="block font-mono text-[10px] text-tertiary">{job.schedule} UTC</span>
+                </div>
+                <span className={`min-w-0 text-caption ${run.tone}`}>
+                  {run.text}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleTriggerJob(name)}
+                  disabled={triggeringJob !== null || running}
+                  className="inline-flex h-9 items-center justify-center gap-2 rounded border border-border bg-surface-3 px-3 text-xs font-bold uppercase tracking-wider text-secondary transition-all hover:border-accent hover:text-accent disabled:opacity-40"
+                >
+                  {triggeringJob === name || running ? <RefreshCw size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+                  {running ? 'Running' : 'Run Now'}
+                </button>
               </div>
-              <span className="min-w-0 truncate text-caption text-tertiary">
-                {job.lastRun
-                  ? `Last run ${formatRelativeTime(job.lastRun.completed_at || job.lastRun.started_at)} — ${job.lastRun.status}`
-                  : 'Never run'}
-              </span>
-              <button
-                type="button"
-                onClick={() => handleTriggerJob(name)}
-                disabled={triggeringJob !== null}
-                className="inline-flex h-9 items-center justify-center gap-2 rounded border border-border bg-surface-3 px-3 text-xs font-bold uppercase tracking-wider text-secondary transition-all hover:border-accent hover:text-accent disabled:opacity-40"
-              >
-                {triggeringJob === name ? <RefreshCw size={12} className="animate-spin" /> : <RefreshCw size={12} />}
-                Run Now
-              </button>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
 

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -302,6 +302,71 @@ describe('Settings display names', () => {
     expect(screen.getByText('Market Data Keys')).toBeInTheDocument();
   });
 
+  it('shows wallet-scan outcome counts and reports a background trigger as started', async () => {
+    const completedOverview = {
+      encryptionConfigured: true,
+      appSettings: { cg_api_key: { source: 'none', masked: null }, cmc_api_key: { source: 'none', masked: null } },
+      env: [],
+      users: [],
+      jobs: {
+        jobs: {
+          'eth-sync': {
+            schedule: '50 7 * * *',
+            timezone: 'Etc/UTC',
+            description: '',
+            lastRun: {
+              status: 'completed',
+              started_at: new Date().toISOString(),
+              completed_at: new Date().toISOString(),
+              tickers_processed: 2,
+              tickers_succeeded: 2,
+              tickers_failed: 0,
+              details: { deferred: 0, unsupported: 1, unverified: 0, skipped: 0 },
+            },
+          },
+        },
+      },
+      health: { dbReachable: true, encryptionConfigured: true, latestPriceFetchedAt: null, migrationCount: 75 },
+    };
+    apiMocks.admin.getOverview
+      .mockResolvedValueOnce(completedOverview)
+      .mockResolvedValueOnce({
+        ...completedOverview,
+        jobs: {
+          jobs: {
+            'eth-sync': {
+              ...completedOverview.jobs.jobs['eth-sync'],
+              lastRun: {
+                status: 'running',
+                started_at: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce(completedOverview);
+    apiMocks.admin.triggerJob.mockResolvedValue({
+      status: 'started',
+      result: { started: true, jobLogId: 91 },
+    });
+
+    renderSettings({ id: 1, username: 'zachery', isAdmin: true });
+    fireEvent.click(await screen.findByRole('tab', { name: 'Server' }));
+
+    const outcome = await screen.findByText(/2\/2 succeeded · 0 failed · 0 deferred · 1 unsupported/);
+    expect(outcome.className).toContain('text-amber-400');
+
+    fireEvent.click(screen.getByRole('button', { name: /run now/i }));
+    expect(await screen.findByText(/Job started\. Live status and the final outcome appear below/)).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Running' })).toBeDisabled();
+    expect(await screen.findByText(
+      /2\/2 succeeded · 0 failed · 0 deferred · 1 unsupported/,
+      {},
+      { timeout: 3000 }
+    )).toBeInTheDocument();
+    expect(apiMocks.admin.getOverview).toHaveBeenCalledTimes(3);
+  });
+
   it('loads all accounts and toggles account visibility', async () => {
     renderSettings();
     await openAccountsTab();

--- a/frontend/src/utils/walletSync.js
+++ b/frontend/src/utils/walletSync.js
@@ -1,0 +1,10 @@
+export const DEFERRED_SYNC_CODES = new Set(['SYNC_DEFERRED']);
+export const LIMITED_SYNC_CODES = new Set(['FEED_UNSUPPORTED', 'CHAIN_UNAVAILABLE']);
+export const NON_FAILURE_SYNC_CODES = new Set([
+  ...DEFERRED_SYNC_CODES,
+  ...LIMITED_SYNC_CODES,
+]);
+
+export const isWalletSyncFailure = (wallet) => Boolean(
+  wallet?.error_code && !NON_FAILURE_SYNC_CODES.has(wallet.error_code)
+);


### PR DESCRIPTION
## Summary

- add provider-wide explorer cooldowns with a shared bounded retry budget and transient timeout retry
- preserve feed cursors while classifying throttles as deferred and standing provider limits as unsupported
- retry deferred wallets in full scans, run manual full scans outside the HTTP timeout, and expose live/final job outcomes
- render only genuine sync failures in red; show deferred and limited coverage in amber

## Validation

- backend lint
- backend tests: 1,044 passed
- frontend lint: 0 errors (12 existing warnings)
- frontend tests: 207 passed
- frontend production build
- ledger SQL verification: 92 checks passed; migrations idempotent on two passes

## Review

Independent bug and compatibility reviews were completed. All actionable findings were addressed, including shared retry accounting, mixed failed/deferred retries, truthful manual-sync messaging, boot badge consistency, background job execution/polling, and deferred audit coverage.