### PR TITLE
fix: back off sustained Blockscout throttles

### DIFF
--- a/backend/src/config/etherscan.js
+++ b/backend/src/config/etherscan.js
@@ -8,15 +8,17 @@ const { DEFAULT_CHAIN_ID: CHAIN_ID } = require('./chains');
 
 // Free tier allows 5 req/s; space calls 250 ms apart (4 req/s) to stay under.
 // The spacing is an environment override so a provider plan can be tuned
-// without changing application code. Blockscout's public instances are more
-// conservative, so EtherscanService supplies its 500 ms queue for those hosts.
+// without changing application code. Anonymous Blockscout limits are scoped
+// by outbound IP rather than wallet. Keep those calls at 40/minute so a long
+// multi-wallet scan does not exhaust a minute bucket even when the documented
+// per-instance default is more generous.
 function envMilliseconds(name, fallback) {
   const value = Number(process.env[name]);
   return Number.isFinite(value) && value >= 0 ? Math.floor(value) : fallback;
 }
 
 const REQUEST_SPACING_MS = envMilliseconds('ETHERSCAN_REQUEST_SPACING_MS', 250);
-const BLOCKSCOUT_REQUEST_SPACING_MS = envMilliseconds('BLOCKSCOUT_REQUEST_SPACING_MS', 500);
+const BLOCKSCOUT_REQUEST_SPACING_MS = envMilliseconds('BLOCKSCOUT_REQUEST_SPACING_MS', 1500);
 const RPC_REQUEST_SPACING_MS = envMilliseconds('RPC_REQUEST_SPACING_MS', 250);
 
 // A rate limit is scoped to the provider host (or to an Etherscan key), not to

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -126,6 +126,9 @@ const EXPLORER_RATE_LIMIT_RETRIES = boundedEnvInteger(
 const INLINE_RATE_LIMIT_RETRY_MAX_MS = boundedEnvInteger(
   'EXPLORER_INLINE_RETRY_MAX_MS', 5000, MAX_EXPLORER_PAUSE_MS
 );
+const BLOCKSCOUT_DEFERRED_RETRY_MIN_MS = boundedEnvInteger(
+  'BLOCKSCOUT_DEFERRED_RETRY_MIN_MS', 60 * 1000, MAX_EXPLORER_PAUSE_MS
+);
 const EXPLORER_RETRY_JITTER_MS = boundedEnvInteger(
   'EXPLORER_RETRY_JITTER_MS', 250, 5000
 );
@@ -150,15 +153,30 @@ function parseRetryAfter(value) {
   return Number.isFinite(timestamp) ? Math.max(0, timestamp - Date.now()) : null;
 }
 
-function explorerRetryDelay(error, attempt) {
+function responseRetryAfterMs(error) {
   const headers = error?.response?.headers || {};
-  const header = headers['retry-after'] ?? headers['Retry-After'];
-  const retryAfterMs = parseRetryAfter(header);
+  return parseRetryAfter(headers['retry-after'] ?? headers['Retry-After']);
+}
+
+function explorerRetryDelay(error, attempt) {
+  const retryAfterMs = responseRetryAfterMs(error);
   const base = retryAfterMs != null ? retryAfterMs : 1100 * (2 ** attempt);
   const jitter = EXPLORER_RETRY_JITTER_MS > 0
     ? Math.floor(Math.random() * (EXPLORER_RETRY_JITTER_MS + 1))
     : 0;
   return Math.min(MAX_EXPLORER_PAUSE_MS, base + jitter);
+}
+
+function deferredRetryDelay(provider, error, attemptedDelayMs) {
+  // Base's public Blockscout instance returns a body-level throttle without a
+  // Retry-After header after sustained anonymous traffic. The short inline
+  // exponential delay is enough for a per-second burst, but production proved
+  // it immediately re-enters the same IP-wide minute bucket. Give that bucket
+  // time to drain. An explicit provider header remains authoritative.
+  if (provider.name === 'Blockscout' && responseRetryAfterMs(error) == null) {
+    return Math.max(attemptedDelayMs, BLOCKSCOUT_DEFERRED_RETRY_MIN_MS);
+  }
+  return attemptedDelayMs;
 }
 
 function isRateLimitedDetail(value) {
@@ -245,7 +263,12 @@ async function retryAfterRateLimit({
     await sleep(delayMs);
     return retry();
   }
-  throw rateLimitError(provider, chainId, params, delayMs, error);
+  const deferredDelayMs = deferredRetryDelay(provider, error, delayMs);
+  // Keep unrelated wallets and requests off the same host while the durable
+  // job waits. Otherwise they can consume the cooldown and make the retry fail
+  // before it begins.
+  etherscan.pause(provider.key, deferredDelayMs);
+  throw rateLimitError(provider, chainId, params, deferredDelayMs, error);
 }
 
 async function runThrottledRequest({

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -241,6 +241,11 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
   assert.equal(lite.enabledByDefault, true);
 });
 
+test('anonymous Blockscout requests stay below a conservative minute bucket', () => {
+  assert.equal(etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS, 1500);
+  assert.ok(60_000 / etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS <= 40);
+});
+
 test('all live-probed chains default on through their configured providers', () => {
   delete process.env.ETH_CHAINS;
   const byId = new Map(chains.allChains().map((chain) => [chain.id, chain]));
@@ -1277,6 +1282,7 @@ test('HTTP and body-level throttles share one bounded retry budget', async (t) =
   const axios = require('axios');
   const originalGet = axios.get;
   let requests = 0;
+  let terminalError;
   axios.get = async () => {
     requests += 1;
     if (requests === 2) {
@@ -1297,9 +1303,44 @@ test('HTTP and body-level throttles share one bounded retry budget', async (t) =
       { module: 'account', action: 'txlist', address: WALLET },
       { apiKey: null, chainId: 8453 }
     ),
-    (error) => error.code === 'EXPLORER_RATE_LIMITED'
+    (error) => {
+      terminalError = error;
+      return error.code === 'EXPLORER_RATE_LIMITED';
+    }
   );
   assert.equal(requests, 3, 'two configured retries permit three total attempts');
+  assert.ok(terminalError.retryAfterMs < 1000,
+    'an explicit Retry-After remains authoritative instead of using the anonymous-IP floor');
+});
+
+test('anonymous Blockscout throttles defer for a full minute bucket', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  let requests = 0;
+  let terminalError;
+  axios.get = async () => {
+    requests += 1;
+    return {
+      headers: {},
+      data: { status: '0', message: 'Too many requests', result: 'rate limit reached' },
+    };
+  };
+  t.after(() => { axios.get = originalGet; });
+  t.after(() => { etherscanConfig.resetRateLimits(); });
+
+  await assert.rejects(
+    () => EtherscanService._request(
+      { module: 'account', action: 'txlist', address: WALLET },
+      { apiKey: null, chainId: 8453 }
+    ),
+    (error) => {
+      terminalError = error;
+      return error.code === 'EXPLORER_RATE_LIMITED';
+    }
+  );
+  assert.equal(requests, 3, 'the minute cooldown begins only after bounded inline retries');
+  assert.ok(terminalError.retryAfterMs >= 60_000);
+  assert.ok(terminalError.retryAfterAt.getTime() - Date.now() > 55_000);
 });
 
 test('Etherscan proxy JSON-RPC responses supply the Polygon log coverage head', async (t) => {


### PR DESCRIPTION
## Summary

- slow anonymous Blockscout traffic from 120 requests/minute to 40 requests/minute per provider host
- apply a shared one-minute cooldown when Blockscout returns a throttle without `Retry-After`
- continue honoring an explicit provider `Retry-After` value
- keep unrelated wallet requests off the host during the durable cooldown

## Production evidence

The first deployed reliability pass correctly classified Base rate limits as deferred, but production JobLog 263 showed all 144 Base feed records remaining deferred during the automatic retry. Blockscout returned body-level throttles without a `Retry-After` header; the previous exponential fallback produced only an approximately five-second terminal cooldown and immediately re-entered the same anonymous-IP bucket.

The expected standing unsupported feeds remain limited to internal transactions on OP Mainnet and Gnosis. No failed or unverified feed records were observed in the run.

## Verification

- backend lint
- focused wallet/state-sync suite: 113 passing
- full backend suite: 1,046 passing
- `git diff --check`

