### PR TITLE
fix: route Base wallet history through Blockscout v2

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -3,9 +3,10 @@
 // The chains an Ethereum wallet address is synced across. Most use Etherscan
 // API V2 from one host and one key, selected per request by the `chainid`
 // param. A chain may instead declare `accountApi`: the same five account-feed
-// contract is then served by that per-chain explorer. Every provider still
-// shares its provider-host queue in ./etherscan.js; adding chains must not
-// multiply the request rate against the same explorer.
+// contract is then served by that per-chain explorer, either through its
+// Etherscan-compatible API or a declared adapter. Every provider still shares
+// its provider-host queue in ./etherscan.js; adding chains must not multiply
+// the request rate against the same explorer.
 //
 // EVERY ENTRY BELOW WAS PROBED LIVE, not taken from documentation:
 // GET https://api.etherscan.io/v2/chainlist (64 chains served), then each of
@@ -26,11 +27,12 @@
 //     arriving from a contract is seen at all, so a chain without them silently
 //     drifts away from its own derived balance.
 //   * OP Mainnet (10) and Base (8453) remain paid-plan-only through Etherscan,
-//     so both use their public Blockscout instances instead. The five account
-//     feeds were probed separately on each chain. Their internal feed reports
-//     partially indexed ranges as status=2; that remains an explicit,
-//     cursor-frozen gap, while a per-chain ETHBridgeFinalized log feed records
-//     canonical native bridge credits independently.
+//     so both use their public Blockscout instances instead. OP still uses the
+//     Etherscan-compatible facade. Base's anonymous legacy facade began
+//     returning a standing 429 in August 2026 while its documented v2 REST API
+//     remained healthy, so Base has an explicit v2 adapter. A per-chain
+//     ETHBridgeFinalized log feed records canonical native bridge credits
+//     independently.
 //   * Polygon PoS (137) is served on the FREE key -- balance, txlist and
 //     txlistinternal all answered on a live probe, so it ships enabled. It is
 //     also the first chain here that is NOT ETH-native (see NATIVE_ASSETS).
@@ -250,6 +252,8 @@ const REGISTRY = [
     accountApi: {
       provider: 'Blockscout',
       baseUrl: 'https://base.blockscout.com/api',
+      apiStyle: 'blockscout-v2',
+      v2BaseUrl: 'https://base.blockscout.com/api/v2',
       requiresApiKey: false,
     },
     rpcUrl: 'https://mainnet.base.org',
@@ -261,15 +265,18 @@ const REGISTRY = [
       contract: '0x4200000000000000000000000000000000000010',
       topic0: '0x31b2166ff604fc5672ea5df08a78081d2bc6d746cadce880747f3643d819e83d',
       userTopicIndex: 2,
-      // Base's Blockscout logs endpoint serves bounded 10,000-block windows,
-      // includes the event timestamp, and accepts a comma-separated OR of all
-      // tracked receiver topics. That avoids a 21-wallet archive RPC walk;
-      // full 1,000-log responses are recursively split rather than treated as
-      // an apparently complete window.
+      // Base's public JSON-RPC caps eth_getLogs ranges at 10,000 blocks. All
+      // tracked receiver topics share each bounded request, so the nightly
+      // incremental scan walks the public chain once rather than once per
+      // wallet. The legacy Blockscout logs facade is deliberately not used:
+      // it is behind the same standing anonymous 429 as its account facade.
       rpcScan: {
-        provider: 'blockscout',
+        provider: 'rpc',
         blockRange: 10000,
-        batchSize: 1,
+        // The public Base endpoint accepts at most 10 JSON-RPC calls per
+        // batch. Use that verified ceiling so the one-time genesis walk is
+        // about 500 HTTP requests rather than about 5,000.
+        batchSize: 10,
         concurrency: 1,
         // Some public Base log responses include valid ETHBridgeFinalized
         // events outside the requested receiver OR-set. The scanner validates

--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -136,7 +136,8 @@ function providerName(chain, spec = null) {
     return `JSON-RPC (${chain.rpcUrl})`;
   }
   if (chain.accountApi) {
-    return `${chain.accountApi.provider || 'chain explorer'} (${chain.accountApi.baseUrl})`;
+    const accountUrl = chain.accountApi.v2BaseUrl || chain.accountApi.baseUrl;
+    return `${chain.accountApi.provider || 'chain explorer'} (${accountUrl})`;
   }
   return 'Etherscan V2';
 }
@@ -526,7 +527,12 @@ class EthWalletService {
         });
       }
       if ((raw.from || '').toLowerCase() === wallet) {
-        const fee = BigInt(raw.gasUsed || 0) * BigInt(raw.gasPrice || 0);
+        // Blockscout v2 exposes the exact OP Stack fee, including the L1-data
+        // component that gasUsed * gasPrice omits. Other providers retain the
+        // original multiplication contract.
+        const fee = raw.feeWei != null
+          ? BigInt(raw.feeWei)
+          : BigInt(raw.gasUsed || 0) * BigInt(raw.gasPrice || 0);
         rows.push({
           ...baseRow(raw, 'gas'),
           value_wei: fee.toString(),
@@ -752,6 +758,30 @@ class EthWalletService {
         chain.id,
         prefetchedStateSync?.indexedHead ?? null
       );
+      // A temporarily regressed explorer head must never shrink a persisted
+      // cursor. The overlap delete below is intentionally open-ended, so
+      // accepting a head behind any active feed's prior cursor would erase
+      // already-ingested rows above that head and then persist the regression.
+      const persistedCursors = {
+        normal: Number(state?.last_block_normal ?? 0),
+        internal: Number(state?.last_block_internal ?? 0),
+        token: Number(state?.last_block_token ?? 0),
+        nft: Number(state?.last_block_nft ?? 0),
+        nft1155: Number(state?.last_block_1155 ?? 0),
+        statesync: Number(state?.last_block_statesync ?? 0),
+      };
+      const regressedFeeds = chain.accountApi?.apiStyle === 'blockscout-v2'
+        ? FEED_SPECS
+          .filter((spec) => feedActive(spec) && persistedCursors[spec.key] > boundary.throughBlock)
+          .map((spec) => spec.key)
+        : [];
+      if (regressedFeeds.length > 0) {
+        const error = new Error(
+          `${chain.name} indexed head ${boundary.throughBlock} is behind persisted cursor for ${regressedFeeds.join(', ')}; cursors frozen`
+        );
+        error.code = 'ETHERSCAN_API_ERROR';
+        throw error;
+      }
     } catch (error) {
       const failureStatus = coverageFailureStatus(error);
       const retryAt = failureStatus === 'deferred' ? retryAfterAt(error) : null;

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -19,6 +19,70 @@ const PAGE_SIZE = 1000;
 // nightly job.
 const MAX_ACCOUNT_PAGES = 200;
 
+// Blockscout v2 address feeds use cursor pagination with 50 rows per page.
+// Preserve the legacy walk's 200,000-row safety envelope while also bounding
+// a hostile endpoint that returns one row and a fresh cursor forever.
+const MAX_ACCOUNT_ROWS = PAGE_SIZE * MAX_ACCOUNT_PAGES;
+const MAX_BLOCKSCOUT_V2_PAGES = 5000;
+
+const BLOCKSCOUT_V2_FEEDS = Object.freeze({
+  txlist: { path: 'transactions' },
+  txlistinternal: { path: 'internal-transactions' },
+  tokentx: { path: 'token-transfers', type: 'ERC-20' },
+  tokennfttx: { path: 'token-transfers', type: 'ERC-721' },
+  token1155tx: { path: 'token-transfers', type: 'ERC-1155' },
+});
+
+const ADDRESS_RE = /^0x[0-9a-f]{40}$/i;
+const TX_HASH_RE = /^0x[0-9a-f]{64}$/i;
+
+function apiError(message) {
+  const error = new Error(message);
+  error.code = 'ETHERSCAN_API_ERROR';
+  return error;
+}
+
+function decimalString(value, { optional = false } = {}) {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) {
+    return String(value);
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value)) return value;
+  if (optional && (value == null || value === '')) return '';
+  return null;
+}
+
+function addressHash(value, { optional = false } = {}) {
+  const hash = typeof value === 'string' ? value : value?.hash;
+  if (optional && (hash == null || hash === '')) return '';
+  return ADDRESS_RE.test(String(hash || '')) ? String(hash) : null;
+}
+
+function unixTimestamp(value) {
+  const text = String(value || '');
+  if (!/^\d{4}-\d{2}-\d{2}T.+Z$/i.test(text)) return null;
+  const milliseconds = Date.parse(text);
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) return null;
+  const seconds = Math.floor(milliseconds / 1000);
+  return Number.isSafeInteger(seconds) ? String(seconds) : null;
+}
+
+function selector(value) {
+  const text = String(value || '');
+  if (/^0x[0-9a-f]{8}$/i.test(text)) return text;
+  if (/^[0-9a-f]{8}$/i.test(text)) return `0x${text}`;
+  return '';
+}
+
+function compareDecimalStrings(left, right) {
+  const a = String(left || '0').replace(/^0+(?=\d)/, '');
+  const b = String(right || '0').replace(/^0+(?=\d)/, '');
+  return a.length - b.length || a.localeCompare(b);
+}
+
+function stableCursor(cursor) {
+  return JSON.stringify(Object.entries(cursor).sort(([a], [b]) => a.localeCompare(b)));
+}
+
 // The logs (getLogs) endpoint caps a single response at 1000 rows, so the
 // state-sync fetch walks a block cursor the same way _fetchPaged does. A wallet
 // has a handful of bridge deposits over its whole life, so this almost never
@@ -462,6 +526,370 @@ class EtherscanService {
     throw error;
   }
 
+  // Blockscout's v2 REST API is not Etherscan-shaped, but it uses the same
+  // public instance and therefore the same provider-host throttle/cooldown.
+  // Return only a validated page envelope; callers must still validate every
+  // row before treating the page as evidence that a cursor may advance.
+  static async _requestBlockscoutV2(path, query, {
+    apiKey,
+    chainId,
+    rateLimitState = { attempt: 0 },
+  }) {
+    const chain = chains.getChain(chainId);
+    const config = chain?.accountApi;
+    if (config?.apiStyle !== 'blockscout-v2' || !config.v2BaseUrl) {
+      throw apiError(`Chain ${chainId} has no Blockscout v2 account API configured`);
+    }
+    const provider = this._provider(chainId, apiKey);
+    const url = `${config.v2BaseUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+    const endpoint = path.split('/').filter(Boolean).at(-1) || 'account';
+    const params = {
+      module: 'v2',
+      action: query?.type ? `${endpoint}:${query.type}` : endpoint,
+    };
+    const response = await runThrottledRequest({
+      provider,
+      chainId,
+      params,
+      rateLimitState,
+      fn: () => axios.get(url, { timeout: 30000, params: query }),
+    });
+    const payload = response.data;
+    if (!Array.isArray(payload?.items) && isRateLimitedDetail(payload)) {
+      return retryAfterRateLimit({
+        provider,
+        chainId,
+        params,
+        rateLimitState,
+        error: responseDetailError(
+          String(payload?.message || payload?.error || 'Blockscout v2 rate limited'),
+          response
+        ),
+        retry: () => this._requestBlockscoutV2(path, query, {
+          apiKey, chainId, rateLimitState,
+        }),
+      });
+    }
+    if (!payload || typeof payload !== 'object' || !Array.isArray(payload.items)) {
+      throw apiError(`Blockscout v2 ${endpoint} returned an invalid page; cursor frozen`);
+    }
+    const next = payload.next_page_params;
+    if (next != null && (typeof next !== 'object' || Array.isArray(next))) {
+      throw apiError(`Blockscout v2 ${endpoint} returned an invalid page cursor; cursor frozen`);
+    }
+    if (next) {
+      for (const [key, value] of Object.entries(next)) {
+        if (!/^[a-z][a-z0-9_]*$/i.test(key)
+            || !['string', 'number', 'boolean'].includes(typeof value)
+            || (typeof value === 'number' && !Number.isFinite(value))) {
+          throw apiError(`Blockscout v2 ${endpoint} returned an unsafe page cursor; cursor frozen`);
+        }
+      }
+    }
+    return { items: payload.items, nextPageParams: next || null };
+  }
+
+  // Normalize one validated Blockscout v2 row into the raw Etherscan account
+  // shape consumed by EthWalletService. Missing economic fields fail the
+  // complete feed: silently defaulting an amount, status, address, token id or
+  // timestamp would authorize destructive overlap replacement with guessed
+  // history.
+  static _mapBlockscoutV2Row(action, raw) {
+    const fail = (field) => {
+      throw apiError(`Blockscout v2 ${action} row has invalid ${field}; cursor frozen`);
+    };
+    const blockNumber = decimalString(raw?.block_number);
+    const timeStamp = unixTimestamp(raw?.timestamp);
+    if (blockNumber == null) fail('block_number');
+    if (timeStamp == null) fail('timestamp');
+
+    if (action === 'txlist') {
+      const hash = TX_HASH_RE.test(String(raw?.hash || '')) ? String(raw.hash).toLowerCase() : null;
+      const from = addressHash(raw?.from);
+      const to = addressHash(raw?.to, { optional: true });
+      const contractAddress = addressHash(raw?.created_contract, { optional: true });
+      const value = decimalString(raw?.value);
+      const gas = decimalString(raw?.gas_limit);
+      const gasUsed = decimalString(raw?.gas_used);
+      const gasPrice = decimalString(raw?.gas_price);
+      const feeWei = decimalString(raw?.fee?.value);
+      const nonce = decimalString(raw?.nonce, { optional: true });
+      const transactionIndex = decimalString(raw?.position, { optional: true });
+      if (!hash) fail('hash');
+      if (!from) fail('from');
+      if (to == null) fail('to');
+      if (contractAddress == null) fail('created_contract');
+      if (value == null) fail('value');
+      if (gas == null) fail('gas_limit');
+      if (gasUsed == null) fail('gas_used');
+      if (gasPrice == null) fail('gas_price');
+      if (raw?.fee?.type !== 'actual' || feeWei == null) fail('fee');
+      if (nonce == null) fail('nonce');
+      if (transactionIndex == null) fail('position');
+      if (!['ok', 'error'].includes(raw?.status)) fail('status');
+      const input = String(raw?.raw_input || '0x');
+      if (!/^0x[0-9a-f]*$/i.test(input)) fail('raw_input');
+      const failed = raw.status === 'error';
+      return {
+        blockNumber,
+        timeStamp,
+        hash,
+        nonce,
+        blockHash: TX_HASH_RE.test(String(raw.block_hash || ''))
+          ? String(raw.block_hash).toLowerCase() : '',
+        transactionIndex,
+        from: from.toLowerCase(),
+        to: to.toLowerCase(),
+        value,
+        gas,
+        gasPrice,
+        feeWei,
+        isError: failed ? '1' : '0',
+        txreceipt_status: failed ? '0' : '1',
+        input,
+        contractAddress: contractAddress.toLowerCase(),
+        cumulativeGasUsed: '',
+        gasUsed,
+        confirmations: decimalString(raw?.confirmations, { optional: true }),
+        methodId: selector(raw?.decoded_input?.method_id),
+        functionName: typeof raw?.decoded_input?.method_call === 'string'
+          ? raw.decoded_input.method_call
+          : (typeof raw?.method === 'string' ? raw.method : ''),
+      };
+    }
+
+    if (action === 'txlistinternal') {
+      const hash = TX_HASH_RE.test(String(raw?.transaction_hash || ''))
+        ? String(raw.transaction_hash).toLowerCase() : null;
+      const from = addressHash(raw?.from);
+      const directTo = addressHash(raw?.to, { optional: true });
+      const created = addressHash(raw?.created_contract, { optional: true });
+      const to = directTo || created;
+      const value = decimalString(raw?.value);
+      const gas = decimalString(raw?.gas_limit);
+      const transactionIndex = decimalString(raw?.transaction_index, { optional: true });
+      const index = decimalString(raw?.index);
+      if (!hash) fail('transaction_hash');
+      if (!from) fail('from');
+      if (directTo == null || created == null || !to) fail('to');
+      if (value == null) fail('value');
+      if (gas == null) fail('gas_limit');
+      if (transactionIndex == null) fail('transaction_index');
+      if (index == null) fail('index');
+      if (typeof raw?.success !== 'boolean') fail('success');
+      return {
+        blockNumber,
+        timeStamp,
+        hash,
+        from: from.toLowerCase(),
+        to: to.toLowerCase(),
+        value,
+        contractAddress: created.toLowerCase(),
+        input: '',
+        type: typeof raw?.type === 'string' ? raw.type : '',
+        gas,
+        gasUsed: '',
+        traceId: `${transactionIndex || '0'}_${index}`,
+        transactionIndex,
+        isError: raw.success ? '0' : '1',
+        errCode: typeof raw?.error === 'string' ? raw.error : '',
+      };
+    }
+
+    const feed = BLOCKSCOUT_V2_FEEDS[action];
+    if (!feed?.type) fail('feed action');
+    const tokenType = raw?.token_type || raw?.token?.type;
+    const hash = TX_HASH_RE.test(String(raw?.transaction_hash || ''))
+      ? String(raw.transaction_hash).toLowerCase() : null;
+    const from = addressHash(raw?.from);
+    const to = addressHash(raw?.to);
+    const contractAddress = addressHash(raw?.token?.address_hash);
+    const logIndex = decimalString(raw?.log_index);
+    if (tokenType !== feed.type) fail('token_type');
+    if (!hash) fail('transaction_hash');
+    if (!from) fail('from');
+    if (!to) fail('to');
+    if (!contractAddress) fail('token.address_hash');
+    if (logIndex == null) fail('log_index');
+    const tokenDecimal = raw?.token?.decimals == null
+      ? null
+      : decimalString(raw.token.decimals);
+    if (raw?.token?.decimals != null && tokenDecimal == null) fail('token.decimals');
+    const result = {
+      blockNumber,
+      timeStamp,
+      hash,
+      blockHash: TX_HASH_RE.test(String(raw?.block_hash || ''))
+        ? String(raw.block_hash).toLowerCase() : '',
+      from: from.toLowerCase(),
+      contractAddress: contractAddress.toLowerCase(),
+      to: to.toLowerCase(),
+      tokenName: typeof raw?.token?.name === 'string' ? raw.token.name : '',
+      tokenSymbol: typeof raw?.token?.symbol === 'string' ? raw.token.symbol : '',
+      tokenDecimal: feed.type === 'ERC-20' ? tokenDecimal : '0',
+      transactionIndex: '',
+      logIndex,
+      gas: '',
+      gasPrice: '',
+      gasUsed: '',
+      cumulativeGasUsed: '',
+      input: '',
+      confirmations: '',
+      isError: '0',
+    };
+    if (feed.type === 'ERC-20') {
+      const value = decimalString(raw?.total?.value);
+      if (value == null) fail('total.value');
+      result.value = value;
+    } else {
+      const tokenID = decimalString(raw?.total?.token_id);
+      if (tokenID == null) fail('total.token_id');
+      result.tokenID = tokenID;
+      if (feed.type === 'ERC-1155') {
+        const tokenValue = decimalString(raw?.total?.value);
+        if (tokenValue == null) fail('total.value');
+        result.tokenValue = tokenValue;
+      }
+    }
+    return result;
+  }
+
+  static _blockscoutV2RowKey(action, row) {
+    if (action === 'txlist') return row.hash;
+    if (action === 'txlistinternal') {
+      return `${row.hash}:${row.traceId}`;
+    }
+    // Provider identity must contain only immutable event coordinates. Keeping
+    // economic fields such as addresses/value in this key would let two
+    // contradictory versions of one event evade the conflict check and both
+    // reach balance math. One EVM log index is unique within a transaction;
+    // token id disambiguates Blockscout's expanded ERC-1155 batch rows.
+    return [row.hash, row.logIndex, row.contractAddress, row.tokenID || ''].join(':');
+  }
+
+  // Blockscout v2 pages newest-first and exposes an opaque cursor instead of
+  // block-range pagination. Walk until the first page proven older than the
+  // requested overlap, validate monotonic block order, then sort to the legacy
+  // ascending contract before returning. The shared indexed head filters rows
+  // that arrived after this scan's boundary.
+  static async _fetchBlockscoutV2Paged(
+    action,
+    address,
+    startBlock,
+    apiKey,
+    chainId,
+    scannedThroughBlock = null
+  ) {
+    const feed = BLOCKSCOUT_V2_FEEDS[action];
+    if (!feed) throw apiError(`Unsupported Blockscout v2 account action ${action}`);
+    if (!ADDRESS_RE.test(String(address || ''))) {
+      throw apiError(`Invalid Blockscout v2 account address ${address}`);
+    }
+    const start = Number(startBlock);
+    const end = scannedThroughBlock ?? 999999999;
+    if (!Number.isSafeInteger(start) || start < 0) {
+      throw apiError(`Invalid Blockscout v2 resume block ${startBlock}; cursor frozen`);
+    }
+    if (!Number.isSafeInteger(end) || end < start) {
+      throw apiError(
+        `account provider head ${end} is behind requested block ${start}; cursor frozen`
+      );
+    }
+
+    const path = `addresses/${String(address).toLowerCase()}/${feed.path}`;
+    const fixedQuery = feed.type ? { type: feed.type } : {};
+    let cursor = {};
+    let previousBlock = null;
+    let walkedRows = 0;
+    let page = 0;
+    const seenCursors = new Set();
+    const rowsByKey = new Map();
+
+    for (;;) {
+      page += 1;
+      if (page > MAX_BLOCKSCOUT_V2_PAGES) {
+        throw apiError(
+          `${action} Blockscout v2 walk exceeded ${MAX_BLOCKSCOUT_V2_PAGES} pages; cursor frozen`
+        );
+      }
+      const { items, nextPageParams } = await this._requestBlockscoutV2(
+        path,
+        { ...fixedQuery, ...cursor },
+        { apiKey, chainId }
+      );
+      walkedRows += items.length;
+      if (walkedRows > MAX_ACCOUNT_ROWS) {
+        throw apiError(
+          `${action} Blockscout v2 walk exceeded ${MAX_ACCOUNT_ROWS} rows; cursor frozen`
+        );
+      }
+
+      let reachedStart = false;
+      for (const raw of items) {
+        const blockText = decimalString(raw?.block_number);
+        const block = blockText == null ? NaN : Number(blockText);
+        if (!Number.isSafeInteger(block)) {
+          throw apiError(
+            `${action} Blockscout v2 returned invalid block ${JSON.stringify(raw?.block_number)}; cursor frozen`
+          );
+        }
+        if (previousBlock != null && block > previousBlock) {
+          throw apiError(
+            `${action} Blockscout v2 pages are not newest-first at block ${block}; cursor frozen`
+          );
+        }
+        previousBlock = block;
+        if (block > end) continue;
+        if (block < start) {
+          reachedStart = true;
+          continue;
+        }
+        const mapped = this._mapBlockscoutV2Row(action, raw);
+        const key = this._blockscoutV2RowKey(action, mapped);
+        const prior = rowsByKey.get(key);
+        if (prior && JSON.stringify(prior) !== JSON.stringify(mapped)) {
+          throw apiError(`Blockscout v2 ${action} returned conflicting duplicate rows; cursor frozen`);
+        }
+        rowsByKey.set(key, mapped);
+      }
+
+      if (reachedStart || !nextPageParams || Object.keys(nextPageParams).length === 0) break;
+      if (items.length === 0) {
+        throw apiError(`Blockscout v2 ${action} returned an empty page with a cursor; cursor frozen`);
+      }
+      const cursorKey = stableCursor(nextPageParams);
+      if (seenCursors.has(cursorKey)) {
+        throw apiError(`Blockscout v2 ${action} repeated a page cursor; cursor frozen`);
+      }
+      seenCursors.add(cursorKey);
+      cursor = nextPageParams;
+    }
+
+    const result = [...rowsByKey.values()].sort((left, right) => {
+      const blockOrder = Number(left.blockNumber) - Number(right.blockNumber);
+      if (blockOrder) return blockOrder;
+      const positionOrder = compareDecimalStrings(
+        left.transactionIndex || left.traceId?.split('_')[0] || left.logIndex,
+        right.transactionIndex || right.traceId?.split('_')[0] || right.logIndex
+      );
+      if (positionOrder) return positionOrder;
+      const subOrder = compareDecimalStrings(
+        left.traceId?.split('_')[1] || left.logIndex || left.tokenID,
+        right.traceId?.split('_')[1] || right.logIndex || right.tokenID
+      );
+      if (subOrder) return subOrder;
+      return this._blockscoutV2RowKey(action, left)
+        .localeCompare(this._blockscoutV2RowKey(action, right));
+    });
+    if (scannedThroughBlock != null) {
+      Object.defineProperty(result, 'scannedThroughBlock', {
+        value: scannedThroughBlock,
+        enumerable: false,
+      });
+    }
+    return result;
+  }
+
   static async _rpcRequest(chainId, method, params, rateLimitState = { attempt: 0 }) {
     const rpcUrl = chains.getChain(chainId)?.rpcUrl;
     if (!rpcUrl) return null;
@@ -652,7 +1080,9 @@ class EtherscanService {
       // Advance only through the explorer's indexed head, not the chain RPC
       // head. The indexer can lag; persisting an RPC block that getLogs has not
       // indexed yet would skip a late-arriving deposit forever.
-      const blocksUrl = new URL('/api/v2/blocks?type=block', chain.accountApi.baseUrl).toString();
+      const blocksBaseUrl = chain.accountApi.v2BaseUrl
+        || new URL('/api/v2/', chain.accountApi.baseUrl).toString();
+      const blocksUrl = new URL('blocks?type=block', `${blocksBaseUrl.replace(/\/$/, '')}/`).toString();
       const provider = this._provider(chainId, apiKey);
       try {
         const response = await runThrottledRequest({
@@ -682,6 +1112,10 @@ class EtherscanService {
           throw new Error('Blockscout v2 blocks response has no valid indexed height');
         }
       } catch (err) {
+        // A v2-only declaration means the legacy facade is known unavailable,
+        // not a fallback. Preserve the failed boundary so no feed cursor can
+        // advance under a different provider with an unproven indexed head.
+        if (chain.accountApi.apiStyle === 'blockscout-v2') throw err;
         // Some public instances intermittently disable or fail the v2 blocks
         // route while their documented legacy block module and account/log
         // APIs remain healthy. Querying eth_block_number on the SAME explorer
@@ -893,6 +1327,11 @@ class EtherscanService {
     chainId = etherscan.CHAIN_ID,
     scannedThroughBlock = null
   ) {
+    if (chains.getChain(chainId)?.accountApi?.apiStyle === 'blockscout-v2') {
+      return this._fetchBlockscoutV2Paged(
+        action, address, startBlock, apiKey, chainId, scannedThroughBlock
+      );
+    }
     const all = [];
     let cursor = startBlock;
     const endBlock = scannedThroughBlock ?? 999999999;
@@ -1262,19 +1701,31 @@ class EtherscanService {
       error.code = 'ETHERSCAN_API_ERROR';
       throw error;
     }
-    const normalized = requests.map(({ address, startBlock }) => {
+    // The same public address may be tracked by more than one user, and their
+    // persisted cursors can differ. The return contract is keyed by address,
+    // so collapse duplicates to the earliest requested block. Returning the
+    // wider safe overlap to both callers is harmless (older existing rows hit
+    // ON CONFLICT); choosing whichever duplicate appeared last could skip
+    // history for the owner with the older cursor.
+    const requestsByAddress = new Map();
+    for (const { address, startBlock } of requests) {
       const normalizedAddress = String(address).toLowerCase();
       if (!/^0x[0-9a-f]{40}$/.test(normalizedAddress)) {
         const error = new Error(`Invalid state-sync wallet address: ${address}`);
         error.code = 'ETHERSCAN_API_ERROR';
         throw error;
       }
-      return {
+      const candidate = {
         address: normalizedAddress,
         topic: addressTopic(normalizedAddress),
         startBlock: Math.max(0, Number(startBlock) || 0),
       };
-    });
+      const prior = requestsByAddress.get(normalizedAddress);
+      if (!prior || candidate.startBlock < prior.startBlock) {
+        requestsByAddress.set(normalizedAddress, candidate);
+      }
+    }
+    const normalized = [...requestsByAddress.values()];
     const head = indexedHead ?? await this._latestBlockNumber(null, chainId);
     for (const request of normalized) {
       if (head < request.startBlock) {

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -64,7 +64,13 @@ const UTC_CHAIN_TIMES_MIGRATION = fs.readFileSync(
 
 // Shared harness: stubs everything a sync touches except the parts under test,
 // and records the (chain, feed) calls the sync actually made.
-function harness(t, { chainSet, cursors = {}, feedBehavior = {}, apiKey = 'key' } = {}) {
+function harness(t, {
+  chainSet,
+  cursors = {},
+  feedBehavior = {},
+  apiKey = 'key',
+  indexedHead = 50000000,
+} = {}) {
   const restore = [];
   const stub = (obj, key, fn) => { restore.push([obj, key, obj[key]]); obj[key] = fn; };
   const priorChains = process.env.ETH_CHAINS;
@@ -132,7 +138,7 @@ function harness(t, { chainSet, cursors = {}, feedBehavior = {}, apiKey = 'key' 
     calls.heads.push({ chainId, apiKey: requestApiKey });
     return {
       fromBlock: 0,
-      throughBlock: 50000000,
+      throughBlock: indexedHead,
       fromAt: new Date('2015-07-30T00:00:00Z'),
       throughAt: new Date('2026-07-30T00:00:00Z'),
     };
@@ -235,6 +241,10 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
     assert.equal(chain.stateSyncDeposits.userTopicIndex, 2);
     assert.equal(chain.opStackDeposits.creditSource, chain.stateSyncDeposits.contract);
   }
+  const base = chains.getChain(8453);
+  assert.equal(base.accountApi.apiStyle, 'blockscout-v2');
+  assert.equal(base.accountApi.v2BaseUrl, 'https://base.blockscout.com/api/v2');
+  assert.equal(base.stateSyncDeposits.rpcScan.provider, 'rpc');
   const lite = chains.getChain(32401);
   assert.equal(lite.historyProvider, 'zksync-lite');
   assert.equal(lite.requiresApiKey, false);
@@ -1098,17 +1108,253 @@ test('an account feed is bounded at the shared indexed head and reports empty co
   let seen;
   axios.get = async (url, config) => {
     seen = { url, params: config.params };
-    return { data: { status: '0', message: 'No transactions found', result: [] } };
+    return { data: { items: [], next_page_params: null } };
   };
   t.after(() => { axios.get = original; });
 
   const rows = await EtherscanService.fetchTokenTxs(WALLET, 100, null, 8453, 50000000);
 
-  assert.equal(seen.params.startblock, 100);
-  assert.equal(seen.params.endblock, 50000000);
+  assert.equal(
+    seen.url,
+    `https://base.blockscout.com/api/v2/addresses/${WALLET}/token-transfers`
+  );
+  assert.deepEqual(seen.params, { type: 'ERC-20' });
   assert.equal(rows.length, 0);
   assert.equal(rows.scannedThroughBlock, 50000000);
   assert.deepEqual(Object.keys(rows), [], 'coverage metadata does not become a transfer row field');
+});
+
+test('Base Blockscout v2 maps all five account feeds into the ingest contract', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  const originalThrottled = etherscanConfig.throttled;
+  const to = `0x${'1'.repeat(40)}`;
+  const contract = `0x${'2'.repeat(40)}`;
+  const calls = [];
+  const commonToken = (type, block, hash, total) => ({
+    block_number: block,
+    timestamp: '2024-01-01T00:00:00.000000Z',
+    transaction_hash: hash,
+    from: { hash: WALLET },
+    to: { hash: to },
+    log_index: block,
+    token_type: type,
+    token: {
+      address_hash: contract,
+      name: `${type} asset`,
+      symbol: 'TEST',
+      decimals: type === 'ERC-20' ? '6' : null,
+      type,
+    },
+    total,
+  });
+  axios.get = async (url, config) => {
+    calls.push({ url, params: config.params });
+    if (url.endsWith('/transactions')) {
+      return { data: { items: [{
+        block_number: 101,
+        timestamp: '2024-01-01T00:00:00.000000Z',
+        hash: `0x${'a'.repeat(64)}`,
+        status: 'ok',
+        from: { hash: WALLET },
+        to: { hash: to },
+        created_contract: null,
+        value: '42',
+        gas_limit: '21000',
+        gas_used: '20000',
+        gas_price: '7',
+        fee: { type: 'actual', value: '140123' },
+        nonce: 3,
+        position: 4,
+        confirmations: 5,
+        raw_input: '0xa9059cbb',
+        decoded_input: { method_id: 'a9059cbb', method_call: 'transfer(address,uint256)' },
+      }], next_page_params: null } };
+    }
+    if (url.endsWith('/internal-transactions')) {
+      return { data: { items: [{
+        block_number: 102,
+        timestamp: '2024-01-01T00:00:01.000000Z',
+        transaction_hash: `0x${'b'.repeat(64)}`,
+        from: { hash: WALLET },
+        to: { hash: to },
+        created_contract: null,
+        value: '43',
+        gas_limit: '10000',
+        transaction_index: 5,
+        index: 6,
+        success: false,
+        error: 'reverted',
+        type: 'call',
+      }], next_page_params: null } };
+    }
+    const type = config.params.type;
+    const rows = {
+      'ERC-20': commonToken('ERC-20', 103, `0x${'c'.repeat(64)}`, { value: '44' }),
+      'ERC-721': commonToken('ERC-721', 104, `0x${'d'.repeat(64)}`, { token_id: '45' }),
+      'ERC-1155': commonToken('ERC-1155', 105, `0x${'e'.repeat(64)}`, {
+        token_id: '46', value: '47',
+      }),
+    };
+    return { data: { items: [rows[type]], next_page_params: null } };
+  };
+  etherscanConfig.throttled = (fn) => fn();
+  t.after(() => {
+    axios.get = originalGet;
+    etherscanConfig.throttled = originalThrottled;
+  });
+
+  const normal = await EtherscanService.fetchNormalTxs(WALLET, 100, null, 8453, 200);
+  const internal = await EtherscanService.fetchInternalTxs(WALLET, 100, null, 8453, 200);
+  const token = await EtherscanService.fetchTokenTxs(WALLET, 100, null, 8453, 200);
+  const nft = await EtherscanService.fetchNftTxs(WALLET, 100, null, 8453, 200);
+  const nft1155 = await EtherscanService.fetch1155Txs(WALLET, 100, null, 8453, 200);
+
+  assert.equal(normal[0].methodId, '0xa9059cbb');
+  assert.equal(normal[0].functionName, 'transfer(address,uint256)');
+  assert.equal(normal[0].timeStamp, '1704067200');
+  assert.equal(normal[0].isError, '0');
+  assert.equal(normal[0].feeWei, '140123');
+  assert.equal(internal[0].traceId, '5_6');
+  assert.equal(internal[0].isError, '1');
+  assert.equal(token[0].value, '44');
+  assert.equal(token[0].tokenDecimal, '6');
+  assert.equal(nft[0].tokenID, '45');
+  assert.equal(nft[0].tokenDecimal, '0');
+  assert.equal(nft1155[0].tokenID, '46');
+  assert.equal(nft1155[0].tokenValue, '47');
+  assert.ok([normal, internal, token, nft, nft1155]
+    .every((rows) => rows.scannedThroughBlock === 200));
+  assert.deepEqual(calls.slice(2).map((call) => call.params.type), [
+    'ERC-20', 'ERC-721', 'ERC-1155',
+  ]);
+});
+
+test('Base Blockscout v2 follows opaque cursors, filters the fixed head, and returns ascending rows', async (t) => {
+  const original = EtherscanService._requestBlockscoutV2;
+  const queries = [];
+  const row = (block, suffix) => ({
+    block_number: block,
+    timestamp: '2024-01-01T00:00:00.000000Z',
+    transaction_hash: `0x${suffix.repeat(64)}`,
+    from: { hash: WALLET },
+    to: { hash: `0x${'1'.repeat(40)}` },
+    log_index: block,
+    token_type: 'ERC-721',
+    token: {
+      address_hash: `0x${'2'.repeat(40)}`,
+      name: 'NFT', symbol: 'NFT', decimals: null, type: 'ERC-721',
+    },
+    total: { token_id: String(block) },
+  });
+  EtherscanService._requestBlockscoutV2 = async (path, query) => {
+    queries.push({ path, query });
+    if (queries.length === 1) {
+      return {
+        items: [row(300, 'a'), row(200, 'b')],
+        nextPageParams: { block_number: 200, index: 1 },
+      };
+    }
+    return {
+      items: [row(150, 'c'), { block_number: 99 }],
+      nextPageParams: { block_number: 99, index: 2 },
+    };
+  };
+  t.after(() => { EtherscanService._requestBlockscoutV2 = original; });
+
+  const rows = await EtherscanService.fetchNftTxs(WALLET, 100, null, 8453, 250);
+
+  assert.deepEqual(rows.map((item) => item.blockNumber), ['150', '200']);
+  assert.deepEqual(queries[0].query, { type: 'ERC-721' });
+  assert.deepEqual(queries[1].query, {
+    type: 'ERC-721', block_number: 200, index: 1,
+  });
+  assert.equal(rows.scannedThroughBlock, 250);
+});
+
+test('Base Blockscout v2 freezes on a repeated cursor or malformed in-range row', async (t) => {
+  const original = EtherscanService._requestBlockscoutV2;
+  const valid = {
+    block_number: 200,
+    timestamp: '2024-01-01T00:00:00.000000Z',
+    hash: `0x${'a'.repeat(64)}`,
+    status: 'ok',
+    from: { hash: WALLET },
+    to: { hash: `0x${'1'.repeat(40)}` },
+    created_contract: null,
+    value: '1', gas_limit: '2', gas_used: '2', gas_price: '3',
+    fee: { type: 'actual', value: '7' },
+    nonce: 1, position: 1, raw_input: '0x',
+  };
+  let calls = 0;
+  EtherscanService._requestBlockscoutV2 = async () => {
+    calls += 1;
+    return {
+      items: [{ ...valid, block_number: 200 }],
+      nextPageParams: { block_number: 200, index: 1 },
+    };
+  };
+  t.after(() => { EtherscanService._requestBlockscoutV2 = original; });
+
+  await assert.rejects(
+    () => EtherscanService.fetchNormalTxs(WALLET, 100, null, 8453, 300),
+    (error) => error.code === 'ETHERSCAN_API_ERROR' && /repeated a page cursor/.test(error.message)
+  );
+  EtherscanService._requestBlockscoutV2 = async () => ({
+    items: [{ ...valid, status: 'pending' }], nextPageParams: null,
+  });
+  await assert.rejects(
+    () => EtherscanService.fetchNormalTxs(WALLET, 100, null, 8453, 300),
+    (error) => error.code === 'ETHERSCAN_API_ERROR' && /invalid status/.test(error.message)
+  );
+});
+
+test('Base Blockscout v2 rejects conflicting versions of one provider event', async (t) => {
+  const original = EtherscanService._requestBlockscoutV2;
+  const event = {
+    block_number: 200,
+    timestamp: '2024-01-01T00:00:00.000000Z',
+    transaction_hash: `0x${'a'.repeat(64)}`,
+    from: { hash: WALLET },
+    to: { hash: `0x${'1'.repeat(40)}` },
+    log_index: 7,
+    token_type: 'ERC-20',
+    token: {
+      address_hash: `0x${'2'.repeat(40)}`,
+      name: 'Token', symbol: 'TKN', decimals: '6', type: 'ERC-20',
+    },
+    total: { value: '10' },
+  };
+  EtherscanService._requestBlockscoutV2 = async () => ({
+    items: [event, { ...event, total: { value: '11' } }],
+    nextPageParams: null,
+  });
+  t.after(() => { EtherscanService._requestBlockscoutV2 = original; });
+
+  await assert.rejects(
+    () => EtherscanService.fetchTokenTxs(WALLET, 100, null, 8453, 300),
+    (error) => error.code === 'ETHERSCAN_API_ERROR'
+      && /conflicting duplicate rows/.test(error.message)
+  );
+});
+
+test('Base Blockscout v2 body throttles use the shared bounded retry path', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    if (requests === 1) {
+      return { headers: { 'retry-after': '0' }, data: { message: 'Too many requests' } };
+    }
+    return { data: { items: [], next_page_params: null } };
+  };
+  t.after(() => { axios.get = originalGet; });
+  t.after(() => { etherscanConfig.resetRateLimits(); });
+
+  const rows = await EtherscanService.fetchNormalTxs(WALLET, 0, null, 8453, 100);
+  assert.deepEqual(rows, []);
+  assert.equal(requests, 2);
 });
 
 test('an account feed freezes when the indexed head falls behind its resume block', async () => {
@@ -1116,6 +1362,36 @@ test('an account feed freezes when the indexed head falls behind its resume bloc
     () => EtherscanService.fetchTokenTxs(WALLET, 101, null, 8453, 100),
     (err) => err.code === 'ETHERSCAN_API_ERROR' && /behind requested block/.test(err.message)
   );
+});
+
+test('a regressed indexed head cannot delete or lower a persisted feed cursor', async (t) => {
+  const { calls } = harness(t, {
+    chainSet: '8453',
+    indexedHead: 199,
+    cursors: {
+      8453: {
+        last_block_normal: 200,
+        last_block_internal: 200,
+        last_block_token: 200,
+        last_block_nft: 200,
+        last_block_1155: 200,
+        last_block_statesync: 200,
+      },
+    },
+  });
+
+  await assert.rejects(
+    () => EthWalletService.syncWallet(7),
+    (error) => error.code === 'ETHERSCAN_API_ERROR'
+      && /behind persisted cursor/.test(error.message)
+  );
+  assert.deepEqual(calls.fetches, []);
+  assert.deepEqual(calls.deletes, []);
+  assert.deepEqual(calls.cursors, []);
+  assert.match(calls.chainErrors[0].message, /behind persisted cursor/);
+  assert.ok(calls.coverage[0].entries.every((entry) => (
+    entry.status === 'not_applicable' || entry.status === 'failed'
+  )));
 });
 
 test('an account feed freezes when the explorer repeats a page outside the advanced range', async (t) => {
@@ -1132,7 +1408,7 @@ test('an account feed freezes when the explorer repeats a page outside the advan
   t.after(() => { EtherscanService._request = original; });
 
   await assert.rejects(
-    () => EtherscanService.fetchTokenTxs(WALLET, 100, null, 8453, 5000),
+    () => EtherscanService.fetchTokenTxs(WALLET, 100, null, 100, 5000),
     (err) => err.code === 'ETHERSCAN_API_ERROR'
       && /outside requested range 1099-5000/.test(err.message)
       && /cursor frozen/.test(err.message)
@@ -1146,7 +1422,7 @@ test('an account feed freezes on malformed or out-of-range block numbers', async
   t.after(() => { EtherscanService._request = original; });
 
   await assert.rejects(
-    () => EtherscanService.fetchNormalTxs(WALLET, 100, null, 8453, 5000),
+    () => EtherscanService.fetchNormalTxs(WALLET, 100, null, 100, 5000),
     (err) => err.code === 'ETHERSCAN_API_ERROR'
       && /block "not-a-block" outside requested range/.test(err.message)
   );
@@ -1166,7 +1442,7 @@ test('a block at the provider 10000-row ceiling freezes instead of dropping an u
   t.after(() => { EtherscanService._request = original; });
 
   await assert.rejects(
-    () => EtherscanService.fetchNormalTxs(WALLET, 42, null, 8453, 5000),
+    () => EtherscanService.fetchNormalTxs(WALLET, 42, null, 100, 5000),
     (err) => err.code === 'ETHERSCAN_API_ERROR'
       && /block 42 reached the 10000-row provider limit/.test(err.message)
       && /cursor frozen/.test(err.message)
@@ -1360,7 +1636,7 @@ test('Etherscan proxy JSON-RPC responses supply the Polygon log coverage head', 
   assert.equal(seen.params.action, 'eth_blockNumber');
 });
 
-test('Blockscout head falls back to the documented legacy explorer endpoint', async (t) => {
+test('legacy Blockscout head falls back to the documented explorer endpoint', async (t) => {
   const axios = require('axios');
   const originalGet = axios.get;
   const calls = [];
@@ -1375,11 +1651,11 @@ test('Blockscout head falls back to the documented legacy explorer endpoint', as
   };
   t.after(() => { axios.get = originalGet; });
 
-  assert.equal(await EtherscanService._latestBlockNumber(null, 8453), 49328373);
-  assert.equal(calls[0].url, 'https://base.blockscout.com/api/v2/blocks?type=block');
-  assert.equal(calls[1].url, 'https://base.blockscout.com/api/v2/blocks?type=block',
+  assert.equal(await EtherscanService._latestBlockNumber(null, 10), 49328373);
+  assert.equal(calls[0].url, 'https://explorer.optimism.io/api/v2/blocks?type=block');
+  assert.equal(calls[1].url, 'https://explorer.optimism.io/api/v2/blocks?type=block',
     'one transient v2 failure is retried before changing endpoints');
-  assert.equal(calls[2].url, 'https://base.blockscout.com/api');
+  assert.equal(calls[2].url, 'https://explorer.optimism.io/api');
   assert.equal(calls[2].params.module, 'block');
   assert.equal(calls[2].params.action, 'eth_block_number');
 });
@@ -1547,15 +1823,20 @@ test('empty OP Stack feeds persist indexed coverage and resume incrementally on 
     'all account and native-credit feeds share one indexed coverage boundary');
 });
 
-test('coverage names the actual Base state-sync provider', async (t) => {
+test('coverage names the actual Base v2 and JSON-RPC providers', async (t) => {
   const { calls } = harness(t, { chainSet: '8453' });
 
   await EthWalletService.syncWallet(7);
 
-  const entry = calls.coverage
-    .find((attempt) => attempt.chainId === 8453)
-    .entries.find((row) => row.feed === 'statesync');
-  assert.equal(entry.provider, 'Blockscout (https://base.blockscout.com/api)');
+  const entries = calls.coverage.find((attempt) => attempt.chainId === 8453).entries;
+  assert.equal(
+    entries.find((row) => row.feed === 'normal').provider,
+    'Blockscout (https://base.blockscout.com/api/v2)'
+  );
+  assert.equal(
+    entries.find((row) => row.feed === 'statesync').provider,
+    'JSON-RPC (https://mainnet.base.org)'
+  );
 });
 
 test('OP Stack deposit reshaping declines every off-shape enriched row', () => {

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -145,9 +145,9 @@ test('Polygon, Gnosis, OP Mainnet, and Base declare verified native-credit logs'
       assert.equal(chain.stateSyncDeposits.userTopicIndex, 2);
       if (chain.id === 8453) {
         assert.deepEqual(chain.stateSyncDeposits.rpcScan, {
-          provider: 'blockscout',
+          provider: 'rpc',
           blockRange: 10000,
-          batchSize: 1,
+          batchSize: 10,
           concurrency: 1,
           allowExtraneousTopics: true,
         });
@@ -240,6 +240,36 @@ test('Base scans bounded RPC windows once for several wallet receiver topics', a
   assert.deepEqual(rowsByAddress.get(WALLET_2).map((row) => row.hash), ['0xwallet2new']);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 19999);
   assert.equal(rowsByAddress.get(WALLET_2).scannedThroughBlock, 19999);
+});
+
+test('Base shared prefetch keeps the oldest cursor when two users track one address', async (t) => {
+  const original = EtherscanService._rpcBatchRequest;
+  EtherscanService._rpcBatchRequest = async (chainId, batch) => {
+    assert.equal(chainId, 8453);
+    if (batch[0].method === 'eth_getLogs') {
+      return batch.map(() => [
+        ethBridgeFinalizedLog({ block: 5000, wallet: WALLET, hash: '0xshared' }),
+      ]);
+    }
+    return batch.map(() => ({ timestamp: '0x65' }));
+  };
+  t.after(() => { EtherscanService._rpcBatchRequest = original; });
+
+  const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
+    [
+      { address: WALLET, startBlock: 0 },
+      { address: WALLET.toUpperCase(), startBlock: 10000 },
+    ],
+    8453,
+    {
+      ...chains.getChain(8453).stateSyncDeposits,
+      rpcScan: { provider: 'rpc', blockRange: 10000, batchSize: 10 },
+    },
+    19999
+  );
+
+  assert.equal(rowsByAddress.size, 1);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), ['0xshared']);
 });
 
 test('Base Blockscout windows share receiver topics and use returned timestamps', async (t) => {

--- a/backend/tests/ethTransfers.test.js
+++ b/backend/tests/ethTransfers.test.js
@@ -64,6 +64,27 @@ test('synthesizes a gas row with gasUsed * gasPrice for sent txs', () => {
   assert.equal(native[0].from_address, WALLET.toLowerCase());
 });
 
+test('uses an exact provider fee when OP Stack L1 data makes gas product incomplete', () => {
+  const rows = EthWalletService.normalizeFeeds(WALLET, {
+    normal: [{
+      blockNumber: '123',
+      timeStamp: '1700000000',
+      hash: '0xexactfee',
+      from: WALLET,
+      to: OTHER,
+      value: '0',
+      gasUsed: '21000',
+      gasPrice: '1000000',
+      feeWei: '21000000123',
+      isError: '0',
+    }],
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].transfer_type, 'gas');
+  assert.equal(rows[0].value_wei, '21000000123');
+});
+
 test('failed sent tx keeps its gas row and flags the value row', () => {
   const rows = EthWalletService.normalizeFeeds(WALLET, {
     normal: [normalTx({ isError: '1' })],


### PR DESCRIPTION
## Summary
- route all five Base account-history feeds through the healthy Blockscout v2 REST API instead of the legacy facade that returns a standing anonymous 429
- move Base native-credit discovery to bounded JSON-RPC log batches at the provider-verified maximum of 10 calls per batch
- preserve exact OP Stack fees, fail closed on malformed/conflicting pages or regressed heads, and handle duplicate public addresses across users safely

## Verification
- backend: 1,054 tests passed
- frontend: 207 tests passed
- backend and frontend lint passed (existing frontend warnings only)
- production frontend build passed
- ledger verifier: 92 checks passed
- live Base canaries passed for all five Blockscout v2 feed shapes, ERC-1155 units/token IDs, exact fee, and JSON-RPC batch ceiling
- independent review completed; all findings addressed; final review returned no findings

## Production plan
- wait for the currently active pre-fix ETH scan to finish
- merge and deploy the exact main SHA
- run one full production ETH scan and require zero failed/deferred/unverified outcomes (standing OP/Gnosis unsupported internal-feed gaps remain explicit)
- run a second scan and verify idempotence and clean coverage