### PR TITLE
fix: extend Base bridge log timeout

### DIFF
--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -202,6 +202,14 @@ const EXPLORER_TRANSIENT_RETRIES = boundedEnvInteger(
 const EXPLORER_TRANSIENT_RETRY_BASE_MS = boundedEnvInteger(
   'EXPLORER_TRANSIENT_RETRY_BASE_MS', 500, 10000
 );
+// Topic-filtered bridge-history lookups are substantially heavier than the
+// ordinary address feeds on Base. Production observed the provider exceed the
+// generic 30-second transport timeout twice while still serving the other five
+// feeds normally. Keep the longer allowance scoped to this endpoint and
+// bounded; the existing transient retry count still prevents an endless walk.
+const BLOCKSCOUT_V2_LOG_TIMEOUT_MS = Math.max(30000, boundedEnvInteger(
+  'BLOCKSCOUT_V2_LOG_TIMEOUT_MS', 120000, 5 * 60 * 1000
+));
 
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -534,6 +542,7 @@ class EtherscanService {
     apiKey,
     chainId,
     rateLimitState = { attempt: 0 },
+    timeoutMs = 30000,
   }) {
     const chain = chains.getChain(chainId);
     const config = chain?.accountApi;
@@ -552,7 +561,7 @@ class EtherscanService {
       chainId,
       params,
       rateLimitState,
-      fn: () => axios.get(url, { timeout: 30000, params: query }),
+      fn: () => axios.get(url, { timeout: timeoutMs, params: query }),
     });
     const payload = response.data;
     if (!Array.isArray(payload?.items) && isRateLimitedDetail(payload)) {
@@ -566,7 +575,7 @@ class EtherscanService {
           response
         ),
         retry: () => this._requestBlockscoutV2(path, query, {
-          apiKey, chainId, rateLimitState,
+          apiKey, chainId, rateLimitState, timeoutMs,
         }),
       });
     }
@@ -1717,7 +1726,7 @@ class EtherscanService {
         const { items, nextPageParams } = await this._requestBlockscoutV2(
           path,
           { ...cursor, topic: request.topic },
-          { apiKey: null, chainId }
+          { apiKey: null, chainId, timeoutMs: BLOCKSCOUT_V2_LOG_TIMEOUT_MS }
         );
         walkedRows += items.length;
         if (walkedRows > MAX_ACCOUNT_ROWS) {

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -19,6 +19,14 @@ const assert = require('node:assert/strict');
 process.env.NODE_ENV = 'test';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost/test';
 
+const configuredBlockscoutLogTimeout = Number(process.env.BLOCKSCOUT_V2_LOG_TIMEOUT_MS);
+const EXPECTED_BLOCKSCOUT_LOG_TIMEOUT_MS = Math.max(
+  30000,
+  Number.isInteger(configuredBlockscoutLogTimeout) && configuredBlockscoutLogTimeout >= 0
+    ? Math.min(configuredBlockscoutLogTimeout, 5 * 60 * 1000)
+    : 120000
+);
+
 const queries = [];
 const pgModulePath = require.resolve('pg');
 require.cache[pgModulePath] = {
@@ -318,7 +326,11 @@ test('Base Blockscout v2 pages bridge logs by receiver topic and cursor', async 
   assert.equal(calls[0].path, `addresses/${OP_STACK_BRIDGE}/logs`);
   assert.deepEqual(calls[0].query, { topic: walletTopic });
   assert.deepEqual(calls[1].query, pageCursor);
-  assert.deepEqual(calls[0].options, { apiKey: null, chainId: 8453 });
+  assert.deepEqual(calls[0].options, {
+    apiKey: null,
+    chainId: 8453,
+    timeoutMs: EXPECTED_BLOCKSCOUT_LOG_TIMEOUT_MS,
+  });
   assert.equal(calls[2].query.topic, wallet2Topic);
   assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
     `0x${'c'.repeat(64)}`,
@@ -326,6 +338,34 @@ test('Base Blockscout v2 pages bridge logs by receiver topic and cursor', async 
   assert.deepEqual(rowsByAddress.get(WALLET_2), []);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 200);
   assert.equal(rowsByAddress.get(WALLET_2).scannedThroughBlock, 200);
+});
+
+test('Base bridge-log requests use the bounded extended provider timeout', async (t) => {
+  const axios = require('axios');
+  const etherscanConfig = require('../src/config/etherscan');
+  const originalGet = axios.get;
+  const originalThrottled = etherscanConfig.throttled;
+  let seen;
+  axios.get = async (url, options) => {
+    seen = { url, options };
+    return { data: { items: [], next_page_params: null } };
+  };
+  etherscanConfig.throttled = (fn) => fn();
+  t.after(() => {
+    axios.get = originalGet;
+    etherscanConfig.throttled = originalThrottled;
+  });
+
+  await EtherscanService.fetchStateSyncDepositsBatch(
+    [{ address: WALLET, startBlock: 0 }],
+    8453,
+    chains.getChain(8453).stateSyncDeposits,
+    200
+  );
+
+  assert.equal(seen.url, `https://base.blockscout.com/api/v2/addresses/${OP_STACK_BRIDGE}/logs`);
+  assert.equal(seen.options.timeout, EXPECTED_BLOCKSCOUT_LOG_TIMEOUT_MS);
+  assert.equal(seen.options.params.topic, `0x${'0'.repeat(24)}${WALLET.slice(2)}`);
 });
 
 test('Base Blockscout v2 rejects a response that ignores its wallet topic', async (t) => {


### PR DESCRIPTION
## Summary
- give Base Blockscout v2 bridge-log history requests a bounded 120-second default timeout
- preserve the existing 30-second default for ordinary Blockscout requests
- preserve the endpoint timeout across rate-limit retries
- make timeout assertions honor valid bounded environment overrides

## Why
The first production full scan after moving Base state-sync history to Blockscout v2 completed all five account feeds but timed out the topic-filtered bridge-log request twice at the generic 30-second transport limit.

## Verification
- backend focused state-sync tests: 42 passed
- backend full suite: 1,058 passed
- backend lint: passed
- git diff --check: passed
- independent review: no findings