### PR TITLE
Fix Base wallet sync bridge-log timeouts

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -266,11 +266,11 @@ const REGISTRY = [
       topic0: '0x31b2166ff604fc5672ea5df08a78081d2bc6d746cadce880747f3643d819e83d',
       userTopicIndex: 2,
       // Base's public JSON-RPC is explicitly rate-limited and not intended for
-      // production history walks. Blockscout v2 can filter the StandardBridge
-      // address-log feed by an indexed receiver topic, so each wallet walks
-      // only its own bridge events through the same paced provider queue as
-      // the account feeds. The legacy Blockscout logs facade is deliberately
-      // not used: it is behind a standing anonymous 429 on this instance.
+      // production history walks. Blockscout v2 serves the StandardBridge's
+      // event-signature stream efficiently, so one shared walk distributes
+      // credits to every tracked receiver. Receiver-topic queries time out on
+      // this instance, while its legacy logs facade is behind a standing
+      // anonymous 429; neither is a safe production fallback.
       rpcScan: {
         provider: 'blockscout-v2',
       },

--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -1416,8 +1416,8 @@ class EthWalletService {
   }
 
   // Prefetch provider-backed state-sync deposits for all wallets before their
-  // ordinary account feeds. EtherscanService applies the provider's supported
-  // receiver filtering and returns one feed-shaped array per wallet.
+  // ordinary account feeds. EtherscanService uses the provider's safest
+  // supported bulk filter and returns one feed-shaped array per wallet.
   //
   // A batch failure is copied to each affected wallet's state-sync slot. The
   // normal per-feed catch then preserves every cursor and stored row while

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -25,6 +25,14 @@ const MAX_ACCOUNT_PAGES = 200;
 const MAX_ACCOUNT_ROWS = PAGE_SIZE * MAX_ACCOUNT_PAGES;
 const MAX_BLOCKSCOUT_V2_PAGES = 5000;
 
+// The Base state-sync path walks one chain-wide event stream rather than one
+// receiver-filtered account stream. Keep it bounded, but do not reuse the
+// per-wallet ceiling: unrelated bridge users legitimately make this stream
+// much larger. At Blockscout's 50-row page size these limits agree at one
+// million rows, while still stopping a fresh-cursor loop or oversized pages.
+const MAX_BLOCKSCOUT_V2_STATE_SYNC_ROWS = 1_000_000;
+const MAX_BLOCKSCOUT_V2_STATE_SYNC_PAGES = 20_000;
+
 const BLOCKSCOUT_V2_FEEDS = Object.freeze({
   txlist: { path: 'transactions' },
   txlistinternal: { path: 'internal-transactions' },
@@ -1681,12 +1689,13 @@ class EtherscanService {
     return result;
   }
 
-  // Blockscout v2's address-log endpoint is newest-first and accepts one
-  // `topic` filter that matches any indexed position. Query the bridge
-  // contract once per distinct receiver topic, then retain only rows whose
-  // event signature and configured receiver position both match. A wallet can
-  // legitimately appear in another indexed position (for example, `from`), so
-  // that case is ignored rather than misclassified as an inbound credit.
+  // Blockscout v2's address-log endpoint is newest-first and accepts a single
+  // `topic` filter that matches any indexed position. Filtering by an individual
+  // receiver topic makes Base's public instance run an expensive query that
+  // can time out even after two minutes. The event signature is indexed
+  // efficiently, so walk that stream ONCE and distribute matching receivers
+  // to every requested wallet. This is both faster and substantially less
+  // provider work than one full-history request per wallet.
   //
   // The endpoint supplies block timestamps directly. This avoids both the
   // production-unsupported public Base RPC history walk and a second request
@@ -1707,136 +1716,147 @@ class EtherscanService {
     }
 
     const path = `addresses/${contract}/logs`;
-    const parsedByAddress = new Map();
-    for (const request of requests) {
-      let cursor = {};
-      let previousBlock = null;
-      let walkedRows = 0;
-      let page = 0;
-      const seenCursors = new Set();
-      const rowsByKey = new Map();
+    const requestsByTopic = new Map(requests.map((request) => [request.topic, request]));
+    const rowsByAddress = new Map(
+      requests.map((request) => [request.address, new Map()])
+    );
+    const minStart = Math.min(...requests.map((request) => request.startBlock));
+    let cursor = {};
+    let previousBlock = null;
+    let walkedRows = 0;
+    let page = 0;
+    const seenCursors = new Set();
 
-      for (;;) {
-        page += 1;
-        if (page > MAX_BLOCKSCOUT_V2_PAGES) {
-          throw apiError(
-            `statesync Blockscout v2 walk exceeded ${MAX_BLOCKSCOUT_V2_PAGES} pages; cursor frozen`
-          );
-        }
-        const { items, nextPageParams } = await this._requestBlockscoutV2(
-          path,
-          { ...cursor, topic: request.topic },
-          { apiKey: null, chainId, timeoutMs: BLOCKSCOUT_V2_LOG_TIMEOUT_MS }
+    for (;;) {
+      page += 1;
+      if (page > MAX_BLOCKSCOUT_V2_STATE_SYNC_PAGES) {
+        throw apiError(
+          `statesync Blockscout v2 walk exceeded ${MAX_BLOCKSCOUT_V2_STATE_SYNC_PAGES} pages; cursor frozen`
         );
-        walkedRows += items.length;
-        if (walkedRows > MAX_ACCOUNT_ROWS) {
-          throw apiError(
-            `statesync Blockscout v2 walk exceeded ${MAX_ACCOUNT_ROWS} rows; cursor frozen`
-          );
-        }
-
-        let reachedStart = false;
-        for (const raw of items) {
-          const blockText = decimalString(raw?.block_number);
-          const block = blockText == null ? NaN : Number(blockText);
-          if (!Number.isSafeInteger(block)) {
-            throw apiError('statesync Blockscout v2 log has invalid block_number; cursor frozen');
-          }
-          if (previousBlock != null && block > previousBlock) {
-            throw apiError(
-              `statesync Blockscout v2 pages are not newest-first at block ${block}; cursor frozen`
-            );
-          }
-          previousBlock = block;
-
-          if (!Array.isArray(raw?.topics)
-              || raw.topics.length < 1
-              || raw.topics.length > 4) {
-            throw apiError('statesync Blockscout v2 log has invalid topics; cursor frozen');
-          }
-          const topics = raw.topics.map((topic) => {
-            if (topic == null) return null;
-            if (!/^0x[0-9a-f]{64}$/i.test(String(topic))) {
-              throw apiError('statesync Blockscout v2 log has invalid topic; cursor frozen');
-            }
-            return String(topic).toLowerCase();
-          });
-          if (!topics.includes(request.topic)) {
-            throw apiError('statesync Blockscout v2 ignored the topic filter; cursor frozen');
-          }
-
-          if (block < request.startBlock) {
-            reachedStart = true;
-            continue;
-          }
-          if (block > indexedHead || topics[0] !== topic0
-              || topics[userTopicIndex] !== request.topic) {
-            continue;
-          }
-
-          // Blockscout's published schema names this object `address_hash`,
-          // while the current Base instance returns the same object as
-          // `address`. Accept both observed contracts, but reject malformed or
-          // contradictory dual fields rather than guessing the emitter.
-          const hasAddressHash = Object.prototype.hasOwnProperty.call(raw || {}, 'address_hash');
-          const hasAddress = Object.prototype.hasOwnProperty.call(raw || {}, 'address');
-          const documentedAddress = hasAddressHash ? addressHash(raw.address_hash) : null;
-          const instanceAddress = hasAddress ? addressHash(raw.address) : null;
-          const address = documentedAddress || instanceAddress;
-          const conflictingAddresses = documentedAddress && instanceAddress
-            && documentedAddress.toLowerCase() !== instanceAddress.toLowerCase();
-          const transactionHash = String(raw?.transaction_hash || '').toLowerCase();
-          const blockHash = String(raw?.block_hash || '').toLowerCase();
-          const timestamp = unixTimestamp(raw?.block_timestamp);
-          const logIndexText = decimalString(raw?.index);
-          const logIndex = logIndexText == null ? NaN : Number(logIndexText);
-          const data = String(raw?.data || '').toLowerCase();
-          if ((hasAddressHash && !documentedAddress)
-              || (hasAddress && !instanceAddress)
-              || conflictingAddresses
-              || String(address || '').toLowerCase() !== contract
-              || !TX_HASH_RE.test(transactionHash)
-              || !TX_HASH_RE.test(blockHash)
-              || timestamp == null
-              || !Number.isSafeInteger(logIndex)
-              || !/^0x(?:[0-9a-f]{2})*$/.test(data)) {
-            throw apiError('statesync Blockscout v2 event row is malformed; cursor frozen');
-          }
-
-          const parsed = this._parseStateSyncLog({
-            address,
-            topics,
-            data,
-            blockNumber: `0x${block.toString(16)}`,
-            timeStamp: `0x${Number(timestamp).toString(16)}`,
-            logIndex: `0x${logIndex.toString(16)}`,
-            transactionHash,
-          }, request.address, feedConfig);
-          const prior = rowsByKey.get(parsed._key);
-          if (prior && JSON.stringify(prior) !== JSON.stringify(parsed)) {
-            throw apiError('statesync Blockscout v2 returned conflicting duplicate rows; cursor frozen');
-          }
-          rowsByKey.set(parsed._key, parsed);
-        }
-
-        if (reachedStart || !nextPageParams
-            || Object.keys(nextPageParams).length === 0) break;
-        if (items.length === 0) {
-          throw apiError('statesync Blockscout v2 returned an empty page with a cursor; cursor frozen');
-        }
-        if (nextPageParams.topic != null
-            && String(nextPageParams.topic).toLowerCase() !== request.topic) {
-          throw apiError('statesync Blockscout v2 returned a conflicting topic cursor; cursor frozen');
-        }
-        const cursorKey = stableCursor(nextPageParams);
-        if (seenCursors.has(cursorKey)) {
-          throw apiError('statesync Blockscout v2 repeated a page cursor; cursor frozen');
-        }
-        seenCursors.add(cursorKey);
-        cursor = nextPageParams;
+      }
+      const { items, nextPageParams } = await this._requestBlockscoutV2(
+        path,
+        { ...cursor, topic: topic0 },
+        { apiKey: null, chainId, timeoutMs: BLOCKSCOUT_V2_LOG_TIMEOUT_MS }
+      );
+      walkedRows += items.length;
+      if (walkedRows > MAX_BLOCKSCOUT_V2_STATE_SYNC_ROWS) {
+        throw apiError(
+          `statesync Blockscout v2 walk exceeded ${MAX_BLOCKSCOUT_V2_STATE_SYNC_ROWS} rows; cursor frozen`
+        );
       }
 
-      const parsed = [...rowsByKey.values()].sort(
+      let reachedStart = false;
+      for (const raw of items) {
+        const blockText = decimalString(raw?.block_number);
+        const block = blockText == null ? NaN : Number(blockText);
+        if (!Number.isSafeInteger(block)) {
+          throw apiError('statesync Blockscout v2 log has invalid block_number; cursor frozen');
+        }
+        if (previousBlock != null && block > previousBlock) {
+          throw apiError(
+            `statesync Blockscout v2 pages are not newest-first at block ${block}; cursor frozen`
+          );
+        }
+        previousBlock = block;
+
+        if (!Array.isArray(raw?.topics)
+            || raw.topics.length < 1
+            || raw.topics.length > 4) {
+          throw apiError('statesync Blockscout v2 log has invalid topics; cursor frozen');
+        }
+        const topics = raw.topics.map((topic) => {
+          if (topic == null) return null;
+          if (!/^0x[0-9a-f]{64}$/i.test(String(topic))) {
+            throw apiError('statesync Blockscout v2 log has invalid topic; cursor frozen');
+          }
+          return String(topic).toLowerCase();
+        });
+        if (!topics.includes(topic0)) {
+          throw apiError('statesync Blockscout v2 ignored the event topic filter; cursor frozen');
+        }
+
+        if (block < minStart) {
+          reachedStart = true;
+          continue;
+        }
+        if (block > indexedHead || topics[0] !== topic0) continue;
+
+        // Blockscout's published schema names this object `address_hash`,
+        // while the current Base instance returns the same object as
+        // `address`. Accept both observed contracts, but reject malformed or
+        // contradictory dual fields rather than guessing the emitter.
+        const hasAddressHash = Object.prototype.hasOwnProperty.call(raw || {}, 'address_hash');
+        const hasAddress = Object.prototype.hasOwnProperty.call(raw || {}, 'address');
+        const documentedAddress = hasAddressHash ? addressHash(raw.address_hash) : null;
+        const instanceAddress = hasAddress ? addressHash(raw.address) : null;
+        const address = documentedAddress || instanceAddress;
+        const conflictingAddresses = documentedAddress && instanceAddress
+          && documentedAddress.toLowerCase() !== instanceAddress.toLowerCase();
+        const transactionHash = String(raw?.transaction_hash || '').toLowerCase();
+        const blockHash = String(raw?.block_hash || '').toLowerCase();
+        const timestamp = unixTimestamp(raw?.block_timestamp);
+        const logIndexText = decimalString(raw?.index);
+        const logIndex = logIndexText == null ? NaN : Number(logIndexText);
+        const data = String(raw?.data || '').toLowerCase();
+        if ((hasAddressHash && !documentedAddress)
+            || (hasAddress && !instanceAddress)
+            || conflictingAddresses
+            || String(address || '').toLowerCase() !== contract
+            || !TX_HASH_RE.test(transactionHash)
+            || !TX_HASH_RE.test(blockHash)
+            || timestamp == null
+            || !Number.isSafeInteger(logIndex)
+            || !/^0x(?:[0-9a-f]{2})*$/.test(data)) {
+          throw apiError('statesync Blockscout v2 event row is malformed; cursor frozen');
+        }
+
+        const receiverTopic = topics[userTopicIndex];
+        const request = requestsByTopic.get(receiverTopic);
+        const receiverAddress = request?.address
+          || (receiverTopic ? `0x${receiverTopic.slice(-40)}` : null);
+        if (!receiverAddress || !ADDRESS_RE.test(receiverAddress)) {
+          throw apiError('statesync Blockscout v2 event has an invalid receiver; cursor frozen');
+        }
+
+        const parsed = this._parseStateSyncLog({
+          address,
+          topics,
+          data,
+          blockNumber: `0x${block.toString(16)}`,
+          timeStamp: `0x${Number(timestamp).toString(16)}`,
+          logIndex: `0x${logIndex.toString(16)}`,
+          transactionHash,
+        }, receiverAddress, feedConfig);
+        if (!request || block < request.startBlock) continue;
+        const rowsByKey = rowsByAddress.get(request.address);
+        const prior = rowsByKey.get(parsed._key);
+        if (prior && JSON.stringify(prior) !== JSON.stringify(parsed)) {
+          throw apiError('statesync Blockscout v2 returned conflicting duplicate rows; cursor frozen');
+        }
+        rowsByKey.set(parsed._key, parsed);
+      }
+
+      if (reachedStart || !nextPageParams
+          || Object.keys(nextPageParams).length === 0) break;
+      if (items.length === 0) {
+        throw apiError('statesync Blockscout v2 returned an empty page with a cursor; cursor frozen');
+      }
+      if (nextPageParams.topic != null
+          && String(nextPageParams.topic).toLowerCase() !== topic0) {
+        throw apiError('statesync Blockscout v2 returned a conflicting topic cursor; cursor frozen');
+      }
+      const cursorKey = stableCursor(nextPageParams);
+      if (seenCursors.has(cursorKey)) {
+        throw apiError('statesync Blockscout v2 repeated a page cursor; cursor frozen');
+      }
+      seenCursors.add(cursorKey);
+      cursor = nextPageParams;
+    }
+
+    const parsedByAddress = new Map();
+    for (const request of requests) {
+      const parsed = [...rowsByAddress.get(request.address).values()].sort(
         (left, right) => (left._block - right._block) || (left._logIndex - right._logIndex)
       );
       const result = parsed.map((row) => ({
@@ -1857,9 +1877,9 @@ class EtherscanService {
   }
 
   // Provider-specific bulk entrypoint for the state-sync prefetch. Base uses
-  // receiver-filtered Blockscout v2 address logs; older declarations can still
-  // use bounded Blockscout legacy windows or JSON-RPC batches with all tracked
-  // receiver topics OR-ed into each filter.
+  // one event-filtered Blockscout v2 address-log stream; older declarations can
+  // still use bounded Blockscout legacy windows or JSON-RPC batches with all
+  // tracked receiver topics OR-ed into each filter.
   //
   // Returns one account-feed-shaped array per lower-cased address. Every array
   // carries the same non-enumerable scannedThroughBlock boundary, including

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -260,36 +260,49 @@ test('Base scans bounded RPC windows once for several wallet receiver topics', a
   assert.equal(rowsByAddress.get(WALLET_2).scannedThroughBlock, 19999);
 });
 
-test('Base Blockscout v2 pages bridge logs by receiver topic and cursor', async (t) => {
+test('Base Blockscout v2 walks one event stream and distributes receiver rows', async (t) => {
   const original = EtherscanService._requestBlockscoutV2;
   const calls = [];
-  const walletTopic = `0x${'0'.repeat(24)}${WALLET.slice(2)}`;
-  const wallet2Topic = `0x${'0'.repeat(24)}${WALLET_2.slice(2)}`;
   const pageCursor = {
     block_number: 100,
     index: 2,
-    topic: walletTopic,
+    topic: ETH_BRIDGE_FINALIZED_TOPIC0,
     items_count: 50,
   };
   EtherscanService._requestBlockscoutV2 = async (path, query, options) => {
     calls.push({ path, query, options });
-    if (query.topic === wallet2Topic) return { items: [], nextPageParams: null };
     if (query.block_number === 100) {
       return {
-        items: [blockscoutV2BridgeLog({
-          block: 90,
-          hash: `0x${'d'.repeat(64)}`,
-          wallet: WALLET,
-        })],
-        nextPageParams: { ...pageCursor, block_number: 50 },
+        items: [
+          blockscoutV2BridgeLog({
+            block: 90,
+            hash: `0x${'d'.repeat(64)}`,
+            wallet: WALLET,
+          }),
+          blockscoutV2BridgeLog({
+            block: 80,
+            hash: `0x${'8'.repeat(64)}`,
+            wallet: WALLET_2,
+          }),
+        ],
+        nextPageParams: null,
       };
     }
-    const unrelated = blockscoutV2BridgeLog({
-      block: 180,
+    const untracked = blockscoutV2BridgeLog({
+      block: 160,
       hash: `0x${'e'.repeat(64)}`,
+      wallet: '0x1111111111111111111111111111111111111111',
+    });
+    const otherSignature = blockscoutV2BridgeLog({
+      block: 170,
+      hash: `0x${'f'.repeat(64)}`,
       wallet: WALLET,
     });
-    unrelated.topics = [`0x${'f'.repeat(64)}`, walletTopic];
+    otherSignature.topics = [
+      `0x${'9'.repeat(64)}`,
+      ETH_BRIDGE_FINALIZED_TOPIC0,
+      otherSignature.topics[2],
+    ];
     const observedBaseShape = blockscoutV2BridgeLog({
       block: 150,
       hash: `0x${'c'.repeat(64)}`,
@@ -304,8 +317,14 @@ test('Base Blockscout v2 pages bridge logs by receiver topic and cursor', async 
           hash: `0x${'a'.repeat(64)}`,
           wallet: WALLET,
         }),
-        unrelated,
+        otherSignature,
+        untracked,
         observedBaseShape,
+        blockscoutV2BridgeLog({
+          block: 140,
+          hash: `0x${'4'.repeat(64)}`,
+          wallet: WALLET_2,
+        }),
       ],
       nextPageParams: pageCursor,
     };
@@ -322,22 +341,71 @@ test('Base Blockscout v2 pages bridge logs by receiver topic and cursor', async 
     200
   );
 
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 2, 'all wallets share one paginated event stream');
   assert.equal(calls[0].path, `addresses/${OP_STACK_BRIDGE}/logs`);
-  assert.deepEqual(calls[0].query, { topic: walletTopic });
+  assert.deepEqual(calls[0].query, { topic: ETH_BRIDGE_FINALIZED_TOPIC0 });
   assert.deepEqual(calls[1].query, pageCursor);
   assert.deepEqual(calls[0].options, {
     apiKey: null,
     chainId: 8453,
     timeoutMs: EXPECTED_BLOCKSCOUT_LOG_TIMEOUT_MS,
   });
-  assert.equal(calls[2].query.topic, wallet2Topic);
   assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
     `0x${'c'.repeat(64)}`,
   ]);
-  assert.deepEqual(rowsByAddress.get(WALLET_2), []);
+  assert.deepEqual(rowsByAddress.get(WALLET_2).map((row) => row.hash), [
+    `0x${'8'.repeat(64)}`,
+    `0x${'4'.repeat(64)}`,
+  ]);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 200);
   assert.equal(rowsByAddress.get(WALLET_2).scannedThroughBlock, 200);
+});
+
+test('Base chain-wide event walk can cross the old per-wallet safety limits', async (t) => {
+  const original = EtherscanService._requestBlockscoutV2;
+  const head = 1000000;
+  const pagesPastOldLimit = 5001;
+  let calls = 0;
+  EtherscanService._requestBlockscoutV2 = async () => {
+    calls += 1;
+    if (calls <= pagesPastOldLimit) {
+      const untracked = blockscoutV2BridgeLog({
+        block: head - calls,
+        wallet: '0x1111111111111111111111111111111111111111',
+      });
+      return {
+        items: Array(40).fill(untracked),
+        nextPageParams: {
+          block_number: head - calls,
+          index: calls,
+          topic: ETH_BRIDGE_FINALIZED_TOPIC0,
+          items_count: 40,
+        },
+      };
+    }
+    return {
+      items: [blockscoutV2BridgeLog({
+        block: 100,
+        hash: `0x${'7'.repeat(64)}`,
+        wallet: WALLET,
+      })],
+      nextPageParams: null,
+    };
+  };
+  t.after(() => { EtherscanService._requestBlockscoutV2 = original; });
+
+  const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
+    [{ address: WALLET, startBlock: 0 }],
+    8453,
+    chains.getChain(8453).stateSyncDeposits,
+    head
+  );
+
+  assert.equal(calls, pagesPastOldLimit + 1);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
+    `0x${'7'.repeat(64)}`,
+  ]);
+  assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, head);
 });
 
 test('Base bridge-log requests use the bounded extended provider timeout', async (t) => {
@@ -365,15 +433,16 @@ test('Base bridge-log requests use the bounded extended provider timeout', async
 
   assert.equal(seen.url, `https://base.blockscout.com/api/v2/addresses/${OP_STACK_BRIDGE}/logs`);
   assert.equal(seen.options.timeout, EXPECTED_BLOCKSCOUT_LOG_TIMEOUT_MS);
-  assert.equal(seen.options.params.topic, `0x${'0'.repeat(24)}${WALLET.slice(2)}`);
+  assert.equal(seen.options.params.topic, ETH_BRIDGE_FINALIZED_TOPIC0);
 });
 
-test('Base Blockscout v2 rejects a response that ignores its wallet topic', async (t) => {
+test('Base Blockscout v2 rejects a response that ignores its event topic', async (t) => {
   const original = EtherscanService._requestBlockscoutV2;
-  EtherscanService._requestBlockscoutV2 = async () => ({
-    items: [blockscoutV2BridgeLog({ wallet: WALLET_2 })],
-    nextPageParams: null,
-  });
+  EtherscanService._requestBlockscoutV2 = async () => {
+    const row = blockscoutV2BridgeLog({ wallet: WALLET_2 });
+    row.topics[0] = `0x${'f'.repeat(64)}`;
+    return { items: [row], nextPageParams: null };
+  };
   t.after(() => { EtherscanService._requestBlockscoutV2 = original; });
 
   await assert.rejects(
@@ -383,14 +452,18 @@ test('Base Blockscout v2 rejects a response that ignores its wallet topic', asyn
       chains.getChain(8453).stateSyncDeposits,
       50000000
     ),
-    /ignored the topic filter/
+    /ignored the event topic filter/
   );
 });
 
 test('Base Blockscout v2 rejects a repeated page cursor', async (t) => {
   const original = EtherscanService._requestBlockscoutV2;
-  const topic = `0x${'0'.repeat(24)}${WALLET.slice(2)}`;
-  const cursor = { block_number: 100, index: 1, topic, items_count: 50 };
+  const cursor = {
+    block_number: 100,
+    index: 1,
+    topic: ETH_BRIDGE_FINALIZED_TOPIC0,
+    items_count: 50,
+  };
   EtherscanService._requestBlockscoutV2 = async () => ({
     items: [blockscoutV2BridgeLog({
       block: 200,
@@ -409,6 +482,34 @@ test('Base Blockscout v2 rejects a repeated page cursor', async (t) => {
       300
     ),
     /repeated a page cursor/
+  );
+});
+
+test('Base Blockscout v2 rejects a cursor that changes the event topic', async (t) => {
+  const original = EtherscanService._requestBlockscoutV2;
+  EtherscanService._requestBlockscoutV2 = async () => ({
+    items: [blockscoutV2BridgeLog({
+      block: 200,
+      hash: `0x${'a'.repeat(64)}`,
+      wallet: WALLET,
+    })],
+    nextPageParams: {
+      block_number: 100,
+      index: 1,
+      topic: `0x${'f'.repeat(64)}`,
+      items_count: 50,
+    },
+  });
+  t.after(() => { EtherscanService._requestBlockscoutV2 = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      300
+    ),
+    /conflicting topic cursor/
   );
 });
 


### PR DESCRIPTION
## Summary
- replace one timeout-prone Base bridge-log request per wallet with one event-signature-filtered Blockscout v2 stream
- distribute validated bridge credits to tracked receivers while preserving each wallet's independent overlap cursor
- keep malformed pages and cursor anomalies fail-closed, with dedicated chain-wide page and row bounds
- add regressions for multi-wallet distribution, stale cursors, provider filter/cursor violations, and streams beyond the old per-wallet limits

## Provider evidence
- Base public JSON-RPC is rate-limited and unsuitable for production history walks
- Base Blockscout receiver-topic queries timed out after 120 seconds
- the event-signature query completed quickly and stays inside the existing provider-host throttle
- Blockscout's CSV implementation has topic filtering internally, but its public API validator rejects topic filters, so it is not a usable production path

## Verification
- backend focused state-sync tests: 44 passed
- backend full suite: 1060 passed
- backend lint: passed
- frontend suite: 207 passed
- frontend lint: passed with 12 pre-existing warnings and 0 errors
- frontend production build: passed
- independent review: one high-severity bound reuse finding addressed; re-review returned no findings