### PR TITLE
fix: harden Base state-sync scans

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -266,13 +266,26 @@ const REGISTRY = [
       topic0: '0x31b2166ff604fc5672ea5df08a78081d2bc6d746cadce880747f3643d819e83d',
       userTopicIndex: 2,
       // Base's public JSON-RPC is explicitly rate-limited and not intended for
-      // production history walks. Blockscout v2 serves the StandardBridge's
-      // event-signature stream efficiently, so one shared walk distributes
-      // credits to every tracked receiver. Receiver-topic queries time out on
-      // this instance, while its legacy logs facade is behind a standing
-      // anonymous 429; neither is a safe production fallback.
+      // production history walks. Blockscout v2's cursor walk also proved
+      // unsuitable for a genesis scan: one late 120-second page timeout throws
+      // away hours of otherwise valid progress. The legacy logs facade handles
+      // bounded event-signature windows quickly. Its live response headers
+      // expose a 10-request anonymous bucket; seven-second spacing leaves
+      // headroom even when empty windows return immediately. Split every
+      // saturated 1,000-row window and distribute validated receivers locally.
+      // Do not send a comma-separated receiver filter: Base currently ignores
+      // it.
       rpcScan: {
-        provider: 'blockscout-v2',
+        provider: 'blockscout',
+        blockRange: 250000,
+        batchSize: 1,
+        concurrency: 1,
+        requestSpacingMs: 7000,
+        maxRequests: 2000,
+        maxElapsedMs: 3 * 60 * 60 * 1000,
+        maxResponseRows: 1000000,
+        scanAllReceivers: true,
+        allowExtraneousTopics: true,
       },
     },
   },

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -32,6 +32,17 @@ const MAX_BLOCKSCOUT_V2_PAGES = 5000;
 // million rows, while still stopping a fresh-cursor loop or oversized pages.
 const MAX_BLOCKSCOUT_V2_STATE_SYNC_ROWS = 1_000_000;
 const MAX_BLOCKSCOUT_V2_STATE_SYNC_PAGES = 20_000;
+const DEFAULT_STATE_SYNC_SCAN_MAX_REQUESTS = 2000;
+const DEFAULT_STATE_SYNC_SCAN_MAX_ELAPSED_MS = 3 * 60 * 60 * 1000;
+const DEFAULT_STATE_SYNC_SCAN_MAX_RESPONSE_ROWS = 1_000_000;
+
+// A full event-history walk spans many bounded legacy-log windows. Retrying a
+// failed window in place preserves the already validated in-memory progress;
+// bubbling the first transient 429/timeout would force the job-level retry to
+// replay the whole history. The total pause remains bounded and no persistent
+// cursor moves until every window succeeds.
+const STATE_SYNC_WINDOW_RETRIES = 2;
+const STATE_SYNC_WINDOW_RETRY_MAX_MS = 5 * 60 * 1000;
 
 const BLOCKSCOUT_V2_FEEDS = Object.freeze({
   txlist: { path: 'transactions' },
@@ -116,6 +127,16 @@ const finalizedBlockCache = new Map();
 function rpcQuantity(value) {
   if (typeof value !== 'string' || !/^0x[0-9a-f]+$/i.test(value)) return null;
   try { return BigInt(value); } catch { return null; }
+}
+
+function safeHexInteger(value) {
+  if (typeof value !== 'string' || !/^0x[0-9a-f]+$/i.test(value)) return null;
+  try {
+    const parsed = BigInt(value);
+    return parsed <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(parsed) : null;
+  } catch {
+    return null;
+  }
 }
 
 function buildFinalityBoundary(receipt, finalizedBlock, error = null) {
@@ -442,8 +463,22 @@ class EtherscanService {
     apiKey,
     chainId = etherscan.CHAIN_ID,
     rateLimitState = { attempt: 0 },
+    spacingMs = null,
+    beforeAttempt = null,
   }) {
-    const provider = this._provider(chainId, apiKey);
+    if (spacingMs != null
+        && (!Number.isSafeInteger(Number(spacingMs))
+          || Number(spacingMs) < 0
+          || Number(spacingMs) > 60000)) {
+      throw apiError('Explorer request spacingMs must be an integer between 0 and 60000');
+    }
+    const baseProvider = this._provider(chainId, apiKey);
+    const provider = spacingMs == null
+      ? baseProvider
+      : {
+        ...baseProvider,
+        spacingMs: Math.max(Number(baseProvider.spacingMs) || 0, Number(spacingMs)),
+      };
     if (provider.requiresApiKey && !apiKey) {
       const error = new Error('Etherscan is not configured. Add your Etherscan key under Settings -> API Keys.');
       error.code = 'ETHERSCAN_NOT_CONFIGURED';
@@ -454,14 +489,17 @@ class EtherscanService {
       chainId,
       params,
       rateLimitState,
-      fn: () => axios.get(provider.baseUrl, {
-        timeout: 15000,
-        params: {
-          ...provider.params,
-          ...(provider.requiresApiKey ? { apikey: apiKey } : {}),
-          ...params,
-        },
-      }),
+      fn: () => {
+        if (beforeAttempt) beforeAttempt();
+        return axios.get(provider.baseUrl, {
+          timeout: 15000,
+          params: {
+            ...provider.params,
+            ...(provider.requiresApiKey ? { apikey: apiKey } : {}),
+            ...params,
+          },
+        });
+      },
     });
 
     const payload = response.data || {};
@@ -484,7 +522,7 @@ class EtherscanService {
           rateLimitState,
           error: responseDetailError(detail, response),
           retry: () => this._request(params, {
-            apiKey, chainId, rateLimitState,
+            apiKey, chainId, rateLimitState, spacingMs, beforeAttempt,
           }),
         });
       }
@@ -505,7 +543,7 @@ class EtherscanService {
           response
         ),
         retry: () => this._request(params, {
-          apiKey, chainId, rateLimitState,
+          apiKey, chainId, rateLimitState, spacingMs, beforeAttempt,
         }),
       });
     }
@@ -1876,10 +1914,11 @@ class EtherscanService {
     return parsedByAddress;
   }
 
-  // Provider-specific bulk entrypoint for the state-sync prefetch. Base uses
-  // one event-filtered Blockscout v2 address-log stream; older declarations can
-  // still use bounded Blockscout legacy windows or JSON-RPC batches with all
-  // tracked receiver topics OR-ed into each filter.
+  // Provider-specific bulk entrypoint for the state-sync prefetch. A chain may
+  // use bounded Blockscout legacy windows, a Blockscout v2 cursor stream, or
+  // JSON-RPC batches. Base intentionally uses event-wide legacy windows: its
+  // public instance ignores comma-separated receiver topics, but serves the
+  // event signature efficiently when the block range is bounded.
   //
   // Returns one account-feed-shaped array per lower-cased address. Every array
   // carries the same non-enumerable scannedThroughBlock boundary, including
@@ -1894,13 +1933,61 @@ class EtherscanService {
     const scan = feedConfig?.rpcScan;
     const useBlockscout = scan?.provider === 'blockscout';
     const useBlockscoutV2 = scan?.provider === 'blockscout-v2';
+    const scanAllReceivers = scan?.scanAllReceivers === true;
     const blockRange = Number(scan?.blockRange);
     const batchSize = Number(scan?.batchSize);
     const concurrency = Number(scan?.concurrency ?? 1);
+    const requestSpacingMs = Number(scan?.requestSpacingMs);
+    const maxRequests = Number(
+      scan?.maxRequests ?? DEFAULT_STATE_SYNC_SCAN_MAX_REQUESTS
+    );
+    const maxElapsedMs = Number(
+      scan?.maxElapsedMs ?? DEFAULT_STATE_SYNC_SCAN_MAX_ELAPSED_MS
+    );
+    const maxResponseRows = Number(
+      scan?.maxResponseRows ?? DEFAULT_STATE_SYNC_SCAN_MAX_RESPONSE_ROWS
+    );
     if (!useBlockscoutV2 && (!Number.isSafeInteger(blockRange) || blockRange < 1
         || !Number.isSafeInteger(batchSize) || batchSize < 1 || batchSize > 100
         || !Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 8)) {
       const error = new Error('statesync rpcScan requires blockRange >= 1, batchSize between 1 and 100, and concurrency between 1 and 8');
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
+    }
+    if (scanAllReceivers
+        && (!useBlockscout || scan?.allowExtraneousTopics !== true)) {
+      const error = new Error(
+        'statesync scanAllReceivers requires Blockscout windows with allowExtraneousTopics'
+      );
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
+    }
+    if (scanAllReceivers
+        && (!Number.isSafeInteger(requestSpacingMs)
+          || requestSpacingMs < 1000
+          || requestSpacingMs > 60000)) {
+      const error = new Error(
+        'statesync scanAllReceivers requires requestSpacingMs between 1000 and 60000'
+      );
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
+    }
+    if (scanAllReceivers
+        && (!Number.isSafeInteger(maxRequests) || maxRequests < 1 || maxRequests > 10000
+          || !Number.isSafeInteger(maxElapsedMs) || maxElapsedMs < 1000
+          || maxElapsedMs > 12 * 60 * 60 * 1000
+          || !Number.isSafeInteger(maxResponseRows) || maxResponseRows < 1
+          || maxResponseRows > 5_000_000)) {
+      const error = new Error(
+        'statesync scanAllReceivers requires bounded maxRequests, maxElapsedMs, and maxResponseRows'
+      );
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
+    }
+    if (useBlockscoutV2 && scan?.allowKnownSlowFullHistoryWalk !== true) {
+      const error = new Error(
+        'statesync blockscout-v2 is quarantined from production full-history scans'
+      );
       error.code = 'ETHERSCAN_API_ERROR';
       throw error;
     }
@@ -1918,10 +2005,16 @@ class EtherscanService {
         error.code = 'ETHERSCAN_API_ERROR';
         throw error;
       }
+      const numericStartBlock = Number(startBlock);
+      if (!Number.isSafeInteger(numericStartBlock) || numericStartBlock < 0) {
+        const error = new Error(`Invalid state-sync start block: ${startBlock}`);
+        error.code = 'ETHERSCAN_API_ERROR';
+        throw error;
+      }
       const candidate = {
         address: normalizedAddress,
         topic: addressTopic(normalizedAddress),
-        startBlock: Math.max(0, Number(startBlock) || 0),
+        startBlock: numericStartBlock,
       };
       const prior = requestsByAddress.get(normalizedAddress);
       if (!prior || candidate.startBlock < prior.startBlock) {
@@ -1930,6 +2023,11 @@ class EtherscanService {
     }
     const normalized = [...requestsByAddress.values()];
     const head = indexedHead ?? await this._latestBlockNumber(null, chainId);
+    if (!Number.isSafeInteger(head) || head < 0) {
+      const error = new Error(`statesync provider returned invalid head ${head}; cursor frozen`);
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
+    }
     for (const request of normalized) {
       if (head < request.startBlock) {
         const error = new Error(
@@ -1977,8 +2075,44 @@ class EtherscanService {
       error.code = 'ETHERSCAN_API_ERROR';
       throw error;
     }
+    if (useBlockscout && filters.length > maxRequests) {
+      const error = new Error(
+        `statesync Blockscout walk requires at least ${filters.length} requests, exceeding the ${maxRequests}-request budget; cursor frozen`
+      );
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
+    }
 
     const logs = [];
+    const parsedByAddress = new Map(normalized.map((request) => [request.address, []]));
+    const seen = new Map();
+    const observeParsed = (parsed, request = null, retain = true) => {
+      const priorEntry = seen.get(parsed._key);
+      const fields = ['hash', 'blockNumber', 'timeStamp', 'from', 'to', 'value'];
+      const fingerprint = fields.map((field) => parsed[field]).join('\u0000');
+      if (priorEntry) {
+        if (priorEntry.fingerprint !== fingerprint) {
+          const error = new Error(
+            `statesync provider returned conflicting duplicate log ${parsed._key}; cursor frozen`
+          );
+          error.code = 'ETHERSCAN_API_ERROR';
+          throw error;
+        }
+        if (request) priorEntry.wanted = true;
+        if (request && retain && !priorEntry.retained) {
+          priorEntry.retained = true;
+          parsedByAddress.get(request.address).push(parsed);
+        }
+        return;
+      }
+      const retained = Boolean(request && retain);
+      seen.set(parsed._key, {
+        fingerprint,
+        wanted: Boolean(request),
+        retained,
+      });
+      if (retained) parsedByAddress.get(request.address).push(parsed);
+    };
     if (useBlockscout) {
       // Blockscout's Etherscan-compatible logs endpoint returns the log
       // timestamp in the same hex shape as the RPC result, so it avoids one
@@ -1988,25 +2122,146 @@ class EtherscanService {
       const userTopicParam = `topic${userTopicIndex}`;
       const topicOperatorParam = `topic0_${userTopicIndex}_opr`;
       const topicParam = [...topicToRequest.keys()].join(',');
+      let windowRetryWaitMs = 0;
+      let walkedRows = 0;
+      let requestCount = 0;
+      const scanStartedAt = Date.now();
+      const assertScanBudget = () => {
+        if (requestCount >= maxRequests) {
+          const error = new Error(
+            `statesync Blockscout getLogs exceeded ${maxRequests} requests; cursor frozen`
+          );
+          error.code = 'ETHERSCAN_API_ERROR';
+          throw error;
+        }
+        if (Date.now() - scanStartedAt > maxElapsedMs) {
+          const error = new Error(
+            `statesync Blockscout getLogs exceeded ${maxElapsedMs}ms; cursor frozen`
+          );
+          error.code = 'ETHERSCAN_API_ERROR';
+          throw error;
+        }
+      };
+      const requestBlockscoutWindow = async (params) => {
+        for (let attempt = 0; ; attempt++) {
+          try {
+            const rows = await this._request(params, {
+              apiKey: null,
+              chainId,
+              ...(scan?.requestSpacingMs == null ? {} : {
+                spacingMs: requestSpacingMs,
+              }),
+              beforeAttempt: () => {
+                assertScanBudget();
+                requestCount += 1;
+              },
+            });
+            if (Date.now() - scanStartedAt > maxElapsedMs) {
+              const error = new Error(
+                `statesync Blockscout getLogs exceeded ${maxElapsedMs}ms; cursor frozen`
+              );
+              error.code = 'ETHERSCAN_API_ERROR';
+              throw error;
+            }
+            return rows;
+          } catch (error) {
+            const rateLimited = error?.code === 'EXPLORER_RATE_LIMITED';
+            if (!rateLimited || attempt >= STATE_SYNC_WINDOW_RETRIES) throw error;
+            const delayMs = Math.min(
+              MAX_EXPLORER_PAUSE_MS,
+              Math.max(1, Number(error.retryAfterMs) || BLOCKSCOUT_DEFERRED_RETRY_MIN_MS)
+            );
+            if (windowRetryWaitMs + delayMs > STATE_SYNC_WINDOW_RETRY_MAX_MS) throw error;
+            windowRetryWaitMs += delayMs;
+            logger.warn({
+              chainId,
+              attempt: attempt + 1,
+              delayMs,
+              waitedMs: windowRetryWaitMs,
+              fromBlock: params.fromBlock,
+              toBlock: params.toBlock,
+              code: error.code,
+            }, 'Retrying the current state-sync window after a provider failure');
+            await sleep(delayMs);
+          }
+        }
+      };
+      const processBlockscoutRows = (rows, fromBlock, toBlock, retainTracked) => {
+        for (const log of rows) {
+          const block = safeHexInteger(log?.blockNumber);
+          if (block == null || block < fromBlock || block > toBlock || block > head) {
+            const error = new Error(
+              'statesync Blockscout getLogs returned a log outside the requested window; cursor frozen'
+            );
+            error.code = 'ETHERSCAN_API_ERROR';
+            throw error;
+          }
+          const receiverTopic = String(log?.topics?.[userTopicIndex] || '').toLowerCase();
+          const validReceiverTopic = /^0x[0-9a-f]{64}$/.test(receiverTopic);
+          const request = topicToRequest.get(receiverTopic);
+          if (!request && (!feedConfig.rpcScan?.allowExtraneousTopics || !validReceiverTopic)) {
+            const error = new Error('statesync RPC returned a receiver outside the requested topic set');
+            error.code = 'ETHERSCAN_API_ERROR';
+            throw error;
+          }
+          const receiverAddress = `0x${receiverTopic.slice(-40)}`;
+          const parsed = this._parseStateSyncLog(log, receiverAddress, feedConfig);
+          observeParsed(
+            parsed,
+            request && block >= request.startBlock ? request : null,
+            retainTracked
+          );
+        }
+      };
       const fetchBlockscoutWindow = async (fromBlock, toBlock, depth = 0) => {
-        if (fromBlock > toBlock) return [];
-        const rows = await this._request({
-          module: 'logs',
-          action: 'getLogs',
-          address: feedConfig.contract,
-          topic0: feedConfig.topic0,
-          [userTopicParam]: topicParam,
-          [topicOperatorParam]: 'and',
-          fromBlock,
-          toBlock,
-          page: 1,
-          offset: LOG_PAGE_SIZE,
-        }, { apiKey: null, chainId });
+        if (fromBlock > toBlock) return;
+        let rows;
+        try {
+          rows = await requestBlockscoutWindow({
+            module: 'logs',
+            action: 'getLogs',
+            address: feedConfig.contract,
+            topic0: feedConfig.topic0,
+            ...(scanAllReceivers ? {} : {
+              [userTopicParam]: topicParam,
+              [topicOperatorParam]: 'and',
+            }),
+            fromBlock,
+            toBlock,
+            page: 1,
+            offset: LOG_PAGE_SIZE,
+          });
+        } catch (error) {
+          // Repeated timeout/5xx responses can be caused by a dense range even
+          // when a successful response never arrives to advertise saturation.
+          // Bisect that range after the transport's own bounded retry, while a
+          // 429 continues to cool down rather than multiplying requests.
+          if (!isTransientExplorerError(error) || fromBlock === toBlock || depth >= 12) {
+            throw error;
+          }
+          const midpoint = Math.floor((fromBlock + toBlock) / 2);
+          await fetchBlockscoutWindow(fromBlock, midpoint, depth + 1);
+          await fetchBlockscoutWindow(midpoint + 1, toBlock, depth + 1);
+          return;
+        }
         if (!Array.isArray(rows)) {
           const error = new Error('statesync Blockscout getLogs returned a non-array result');
           error.code = 'ETHERSCAN_API_ERROR';
           throw error;
         }
+        walkedRows += rows.length;
+        if (walkedRows > maxResponseRows) {
+          const error = new Error(
+            `statesync Blockscout getLogs exceeded ${maxResponseRows} response rows; cursor frozen`
+          );
+          error.code = 'ETHERSCAN_API_ERROR';
+          throw error;
+        }
+        // Validate the provider's window, event shape and coordinates before
+        // treating a full page as evidence of density. Otherwise a provider
+        // that ignored the filters could force recursive pressure instead of
+        // failing immediately.
+        processBlockscoutRows(rows, fromBlock, toBlock, rows.length < LOG_PAGE_SIZE);
         // A full response is not proof that the range is complete. Split the
         // range rather than trusting page/offset, which this endpoint ignores.
         if (rows.length >= LOG_PAGE_SIZE) {
@@ -2018,20 +2273,21 @@ class EtherscanService {
             throw error;
           }
           const midpoint = Math.floor((fromBlock + toBlock) / 2);
-          const [left, right] = await Promise.all([
-            fetchBlockscoutWindow(fromBlock, midpoint, depth + 1),
-            fetchBlockscoutWindow(midpoint + 1, toBlock, depth + 1),
-          ]);
-          return left.concat(right);
+          // Keep split children strictly sequential. Both use one host-scoped
+          // queue; scheduling the sibling while the first branch handles a
+          // cooldown creates competing retry loops without increasing
+          // throughput.
+          await fetchBlockscoutWindow(fromBlock, midpoint, depth + 1);
+          await fetchBlockscoutWindow(midpoint + 1, toBlock, depth + 1);
+          return;
         }
-        return rows;
       };
       for (let offset = 0; offset < filters.length; offset++) {
         const filter = filters[offset].params[0];
-        logs.push(...await fetchBlockscoutWindow(
+        await fetchBlockscoutWindow(
           parseInt(filter.fromBlock, 16),
           parseInt(filter.toBlock, 16)
-        ));
+        );
       }
     } else for (let offset = 0; offset < filters.length; offset += batchSize * concurrency) {
       const chunks = [];
@@ -2100,11 +2356,11 @@ class EtherscanService {
       });
     }
 
-    const parsedByAddress = new Map(normalized.map((request) => [request.address, []]));
-    const seen = new Set();
     for (const log of logs) {
       const receiverTopic = String(log?.topics?.[userTopicIndex] || '').toLowerCase();
       const request = topicToRequest.get(receiverTopic);
+      const blockHex = String(log?.blockNumber || '').toLowerCase();
+      const timeStamp = timestamps.get(blockHex);
       if (!request) {
         // A few public log endpoints return valid events outside a large OR
         // filter. They cannot belong to any requested wallet, so retaining
@@ -2118,22 +2374,41 @@ class EtherscanService {
         if (feedConfig.rpcScan?.allowExtraneousTopics
             && topic0 === String(feedConfig.topic0).toLowerCase()
             && validReceiverTopic && validContract) {
+          // Event-wide Blockscout scans intentionally see every receiver. A
+          // syntactically valid topic is not enough evidence to skip a row:
+          // validate its block, timestamp, transaction coordinate and ABI data
+          // with the same parser used for tracked receivers before discarding
+          // it. Otherwise one malformed untracked event could sit behind a
+          // cursor that was incorrectly certified complete.
+          const receiverAddress = `0x${receiverTopic.slice(-40)}`;
+          const parsed = this._parseStateSyncLog(
+            { ...log, timeStamp }, receiverAddress, feedConfig
+          );
+          observeParsed(parsed);
           continue;
         }
         const error = new Error('statesync RPC returned a receiver outside the requested topic set');
         error.code = 'ETHERSCAN_API_ERROR';
         throw error;
       }
-      const blockHex = String(log.blockNumber).toLowerCase();
       const block = parseInt(blockHex, 16);
       if (block < request.startBlock) continue;
       const parsed = this._parseStateSyncLog({
         ...log,
-        timeStamp: timestamps.get(blockHex),
+        timeStamp,
       }, request.address, feedConfig);
-      if (seen.has(parsed._key)) continue;
-      seen.add(parsed._key);
-      parsedByAddress.get(request.address).push(parsed);
+      observeParsed(parsed, request);
+    }
+
+    const missingAfterSplit = [...seen.values()].some(
+      (entry) => entry.wanted && !entry.retained
+    );
+    if (missingAfterSplit) {
+      const error = new Error(
+        'statesync provider omitted a saturated-page log from its split windows; cursor frozen'
+      );
+      error.code = 'ETHERSCAN_API_ERROR';
+      throw error;
     }
 
     for (const [address, parsed] of parsedByAddress) {
@@ -2171,6 +2446,8 @@ class EtherscanService {
     const data = typeof log?.data === 'string' ? log.data : '';
     const contract = String(feedConfig.contract).toLowerCase();
     if (String(log?.address || '').toLowerCase() !== contract) fail('wrong emitting contract');
+    if (String(log?.topics?.[0] || '').toLowerCase()
+        !== String(feedConfig.topic0 || '').toLowerCase()) fail('wrong event topic');
     const userTopicIndex = Number(feedConfig.userTopicIndex ?? 2);
     if (String(log?.topics?.[userTopicIndex] || '').toLowerCase() !== addressTopic(walletAddress)) {
       fail('wrong receiver topic');
@@ -2181,15 +2458,16 @@ class EtherscanService {
     // The format is ENFORCED because a decimal still parses "successfully" --
     // parseInt('84421264', 16) is 2.2 billion, past any real tip -- which would
     // poison the cursor and stamp block_time centuries ahead.
-    if (!/^0x[0-9a-fA-F]+$/.test(String(log.blockNumber || ''))) fail('non-hex blockNumber');
-    if (!/^0x[0-9a-fA-F]+$/.test(String(log.timeStamp || ''))) fail('non-hex timeStamp');
-    const block = parseInt(log.blockNumber, 16);
-    const timeStamp = parseInt(log.timeStamp, 16);
-    if (!Number.isFinite(block) || !Number.isFinite(timeStamp)) fail('unreadable blockNumber/timeStamp');
-    const logIndex = /^0x[0-9a-fA-F]+$/.test(String(log.logIndex || '')) ? parseInt(log.logIndex, 16) : 0;
-    if (!log.transactionHash) fail('missing transactionHash');
+    const block = safeHexInteger(log?.blockNumber);
+    const timeStamp = safeHexInteger(log?.timeStamp);
+    const logIndex = safeHexInteger(log?.logIndex);
+    if (block == null) fail('invalid blockNumber');
+    if (timeStamp == null) fail('invalid timeStamp');
+    if (logIndex == null) fail('invalid logIndex');
+    const transactionHash = String(log?.transactionHash || '').toLowerCase();
+    if (!TX_HASH_RE.test(transactionHash)) fail('invalid transactionHash');
     return {
-      hash: log.transactionHash,
+      hash: transactionHash,
       blockNumber: String(block),
       timeStamp: String(timeStamp),
       from: contract,
@@ -2197,7 +2475,7 @@ class EtherscanService {
       value: BigInt(amountHex).toString(),
       _block: block,
       _logIndex: logIndex,
-      _key: `${log.transactionHash}:${logIndex}`,
+      _key: `${transactionHash}:${logIndex}`,
     };
   }
 }

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -244,7 +244,14 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
   const base = chains.getChain(8453);
   assert.equal(base.accountApi.apiStyle, 'blockscout-v2');
   assert.equal(base.accountApi.v2BaseUrl, 'https://base.blockscout.com/api/v2');
-  assert.equal(base.stateSyncDeposits.rpcScan.provider, 'blockscout-v2');
+  assert.equal(base.stateSyncDeposits.rpcScan.provider, 'blockscout');
+  assert.equal(base.stateSyncDeposits.rpcScan.blockRange, 250000);
+  assert.equal(base.stateSyncDeposits.rpcScan.requestSpacingMs, 7000);
+  assert.equal(base.stateSyncDeposits.rpcScan.maxRequests, 2000);
+  assert.equal(base.stateSyncDeposits.rpcScan.maxElapsedMs, 3 * 60 * 60 * 1000);
+  assert.equal(base.stateSyncDeposits.rpcScan.maxResponseRows, 1000000);
+  assert.equal(base.stateSyncDeposits.rpcScan.scanAllReceivers, true);
+  assert.equal(base.stateSyncDeposits.rpcScan.allowExtraneousTopics, true);
   const lite = chains.getChain(32401);
   assert.equal(lite.historyProvider, 'zksync-lite');
   assert.equal(lite.requiresApiKey, false);
@@ -1589,6 +1596,53 @@ test('HTTP and body-level throttles share one bounded retry budget', async (t) =
     'an explicit Retry-After remains authoritative instead of using the anonymous-IP floor');
 });
 
+test('a stricter host spacing wins and survives a body-level throttle retry', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  const originalThrottled = etherscanConfig.throttled;
+  const originalProvider = EtherscanService._provider;
+  const spacings = [];
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    if (requests === 1) {
+      return {
+        headers: { 'retry-after': '0' },
+        data: { status: '0', message: 'Too many requests', result: 'rate limit reached' },
+      };
+    }
+    return { data: { status: '1', message: 'OK', result: [] } };
+  };
+  etherscanConfig.throttled = async (fn, options) => {
+    spacings.push(options.spacingMs);
+    return fn();
+  };
+  EtherscanService._provider = () => ({
+    name: 'Blockscout',
+    baseUrl: 'https://base.blockscout.com/api',
+    requiresApiKey: false,
+    params: {},
+    key: 'account:https://base.blockscout.com/api',
+    spacingMs: 9000,
+  });
+  t.after(() => {
+    axios.get = originalGet;
+    etherscanConfig.throttled = originalThrottled;
+    EtherscanService._provider = originalProvider;
+    etherscanConfig.resetRateLimits();
+  });
+
+  assert.deepEqual(
+    await EtherscanService._request(
+      { module: 'logs', action: 'getLogs' },
+      { apiKey: null, chainId: 8453, spacingMs: 7000 }
+    ),
+    []
+  );
+  assert.equal(requests, 2);
+  assert.deepEqual(spacings, [9000, 9000]);
+});
+
 test('anonymous Blockscout throttles defer for a full minute bucket', async (t) => {
   const axios = require('axios');
   const originalGet = axios.get;
@@ -1823,7 +1877,7 @@ test('empty OP Stack feeds persist indexed coverage and resume incrementally on 
     'all account and native-credit feeds share one indexed coverage boundary');
 });
 
-test('coverage names the actual Base v2 providers', async (t) => {
+test('coverage names the actual Base providers per feed', async (t) => {
   const { calls } = harness(t, { chainSet: '8453' });
 
   await EthWalletService.syncWallet(7);
@@ -1835,7 +1889,7 @@ test('coverage names the actual Base v2 providers', async (t) => {
   );
   assert.equal(
     entries.find((row) => row.feed === 'statesync').provider,
-    'Blockscout (https://base.blockscout.com/api/v2)'
+    'Blockscout (https://base.blockscout.com/api)'
   );
 });
 

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -77,6 +77,22 @@ const DEPOSIT_TX = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd
 const DEPOSIT_WEI = '47250000000000000000'; // 47.25 POL
 const WALLET_2 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 
+function testTxHash(value) {
+  const text = String(value).toLowerCase();
+  if (/^0x[0-9a-f]{64}$/.test(text)) return text;
+  return `0x${Buffer.from(text).toString('hex').slice(0, 64).padEnd(64, '0')}`;
+}
+
+function baseV2StateSyncConfig() {
+  return {
+    ...chains.getChain(8453).stateSyncDeposits,
+    rpcScan: {
+      provider: 'blockscout-v2',
+      allowKnownSlowFullHistoryWalk: true,
+    },
+  };
+}
+
 const sqlOf = (query) => query.text.replace(/--[^\n]*/g, '').replace(/\s+/g, ' ').trim();
 
 function stubScanHead(t, block = 90000000) {
@@ -96,7 +112,7 @@ function depositLog({ amountWei = DEPOSIT_WEI, block = 84000001, ts = 1742000000
     blockNumber: `0x${block.toString(16)}`,
     timeStamp: `0x${ts.toString(16)}`,
     logIndex: `0x${logIndex.toString(16)}`,
-    transactionHash: hash,
+    transactionHash: testTxHash(hash),
   };
 }
 
@@ -129,7 +145,7 @@ function ethBridgeFinalizedLog({
     blockNumber: `0x${block.toString(16)}`,
     timeStamp: `0x${ts.toString(16)}`,
     logIndex: `0x${logIndex.toString(16)}`,
-    transactionHash: hash,
+    transactionHash: testTxHash(hash),
   };
 }
 
@@ -167,7 +183,16 @@ test('Polygon, Gnosis, OP Mainnet, and Base declare verified native-credit logs'
       assert.equal(chain.stateSyncDeposits.userTopicIndex, 2);
       if (chain.id === 8453) {
         assert.deepEqual(chain.stateSyncDeposits.rpcScan, {
-          provider: 'blockscout-v2',
+          provider: 'blockscout',
+          blockRange: 250000,
+          batchSize: 1,
+          concurrency: 1,
+          requestSpacingMs: 7000,
+          maxRequests: 2000,
+          maxElapsedMs: 3 * 60 * 60 * 1000,
+          maxResponseRows: 1000000,
+          scanAllReceivers: true,
+          allowExtraneousTopics: true,
         });
       }
     } else {
@@ -254,8 +279,8 @@ test('Base scans bounded RPC windows once for several wallet receiver topics', a
   assert.deepEqual(calls[0].batch.map((call) => call.params[0].fromBlock), ['0x0', '0x2710']);
   assert.equal(calls[0].batch[0].params[0].topics[2].length, 2,
     'both receiver topics are OR-ed inside each bounded filter');
-  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), ['0xwallet1']);
-  assert.deepEqual(rowsByAddress.get(WALLET_2).map((row) => row.hash), ['0xwallet2new']);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [testTxHash('0xwallet1')]);
+  assert.deepEqual(rowsByAddress.get(WALLET_2).map((row) => row.hash), [testTxHash('0xwallet2new')]);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 19999);
   assert.equal(rowsByAddress.get(WALLET_2).scannedThroughBlock, 19999);
 });
@@ -337,7 +362,7 @@ test('Base Blockscout v2 walks one event stream and distributes receiver rows', 
       { address: WALLET_2, startBlock: 0 },
     ],
     8453,
-    chains.getChain(8453).stateSyncDeposits,
+    baseV2StateSyncConfig(),
     200
   );
 
@@ -397,7 +422,7 @@ test('Base chain-wide event walk can cross the old per-wallet safety limits', as
   const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
     [{ address: WALLET, startBlock: 0 }],
     8453,
-    chains.getChain(8453).stateSyncDeposits,
+    baseV2StateSyncConfig(),
     head
   );
 
@@ -427,7 +452,7 @@ test('Base bridge-log requests use the bounded extended provider timeout', async
   await EtherscanService.fetchStateSyncDepositsBatch(
     [{ address: WALLET, startBlock: 0 }],
     8453,
-    chains.getChain(8453).stateSyncDeposits,
+    baseV2StateSyncConfig(),
     200
   );
 
@@ -449,7 +474,7 @@ test('Base Blockscout v2 rejects a response that ignores its event topic', async
     EtherscanService.fetchStateSyncDepositsBatch(
       [{ address: WALLET, startBlock: 0 }],
       8453,
-      chains.getChain(8453).stateSyncDeposits,
+      baseV2StateSyncConfig(),
       50000000
     ),
     /ignored the event topic filter/
@@ -478,7 +503,7 @@ test('Base Blockscout v2 rejects a repeated page cursor', async (t) => {
     EtherscanService.fetchStateSyncDepositsBatch(
       [{ address: WALLET, startBlock: 0 }],
       8453,
-      chains.getChain(8453).stateSyncDeposits,
+      baseV2StateSyncConfig(),
       300
     ),
     /repeated a page cursor/
@@ -506,7 +531,7 @@ test('Base Blockscout v2 rejects a cursor that changes the event topic', async (
     EtherscanService.fetchStateSyncDepositsBatch(
       [{ address: WALLET, startBlock: 0 }],
       8453,
-      chains.getChain(8453).stateSyncDeposits,
+      baseV2StateSyncConfig(),
       300
     ),
     /conflicting topic cursor/
@@ -540,7 +565,467 @@ test('Base shared prefetch keeps the oldest cursor when two users track one addr
   );
 
   assert.equal(rowsByAddress.size, 1);
-  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), ['0xshared']);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [testTxHash('0xshared')]);
+});
+
+test('Base uses bounded event-wide Blockscout windows and distributes receivers locally', async (t) => {
+  const original = EtherscanService._request;
+  const calls = [];
+  EtherscanService._request = async (params, options) => {
+    calls.push({ params, options });
+    return [
+      ethBridgeFinalizedLog({ block: 100000, wallet: WALLET, hash: '0xwallet1' }),
+      ethBridgeFinalizedLog({ block: 200000, wallet: WALLET_2, hash: '0xwallet2' }),
+      ethBridgeFinalizedLog({
+        block: 225000,
+        wallet: '0x1111111111111111111111111111111111111111',
+        hash: '0xuntracked',
+      }),
+    ];
+  };
+  t.after(() => { EtherscanService._request = original; });
+
+  const config = chains.getChain(8453).stateSyncDeposits;
+  assert.deepEqual(config.rpcScan, {
+    provider: 'blockscout',
+    blockRange: 250000,
+    batchSize: 1,
+    concurrency: 1,
+    requestSpacingMs: 7000,
+    maxRequests: 2000,
+    maxElapsedMs: 3 * 60 * 60 * 1000,
+    maxResponseRows: 1000000,
+    scanAllReceivers: true,
+    allowExtraneousTopics: true,
+  });
+
+  const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
+    [
+      { address: WALLET, startBlock: 0 },
+      { address: WALLET_2, startBlock: 150000 },
+    ],
+    8453,
+    config,
+    249999
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].options.chainId, 8453);
+  assert.equal(calls[0].options.spacingMs, 7000);
+  assert.equal(calls[0].params.fromBlock, 0);
+  assert.equal(calls[0].params.toBlock, 249999);
+  assert.equal(calls[0].params.topic0, ETH_BRIDGE_FINALIZED_TOPIC0);
+  assert.equal(calls[0].params.topic2, undefined,
+    'the provider never receives tracked receiver addresses');
+  assert.equal(calls[0].params.topic0_2_opr, undefined);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [testTxHash('0xwallet1')]);
+  assert.deepEqual(rowsByAddress.get(WALLET_2).map((row) => row.hash), [testTxHash('0xwallet2')]);
+  assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 249999);
+  assert.equal(rowsByAddress.get(WALLET_2).scannedThroughBlock, 249999);
+});
+
+test('event-wide state-sync scans require the extraneous-row validation gate', async () => {
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      {
+        ...chains.getChain(8453).stateSyncDeposits,
+        rpcScan: {
+          provider: 'blockscout',
+          blockRange: 250000,
+          batchSize: 1,
+          concurrency: 1,
+          scanAllReceivers: true,
+        },
+      },
+      249999
+    ),
+    /scanAllReceivers requires Blockscout windows with allowExtraneousTopics/
+  );
+});
+
+test('event-wide state-sync scans require a bounded endpoint spacing', async () => {
+  for (const requestSpacingMs of [undefined, 999, 60001, 1.5]) {
+    await assert.rejects(
+      EtherscanService.fetchStateSyncDepositsBatch(
+        [{ address: WALLET, startBlock: 0 }],
+        8453,
+        {
+          ...chains.getChain(8453).stateSyncDeposits,
+          rpcScan: {
+            provider: 'blockscout',
+            blockRange: 250000,
+            batchSize: 1,
+            concurrency: 1,
+            requestSpacingMs,
+            scanAllReceivers: true,
+            allowExtraneousTopics: true,
+          },
+        },
+        249999
+      ),
+      /scanAllReceivers requires requestSpacingMs between 1000 and 60000/
+    );
+  }
+});
+
+test('the retired Blockscout v2 history walk requires an explicit quarantine bypass', async () => {
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      {
+        ...chains.getChain(8453).stateSyncDeposits,
+        rpcScan: { provider: 'blockscout-v2' },
+      },
+      249999
+    ),
+    /blockscout-v2 is quarantined/
+  );
+});
+
+test('Base event-wide windows reject a malformed untracked event before advancing', async (t) => {
+  const original = EtherscanService._request;
+  EtherscanService._request = async () => [{
+    ...ethBridgeFinalizedLog({
+      block: 200000,
+      wallet: '0x1111111111111111111111111111111111111111',
+      hash: '0xuntracked-malformed',
+    }),
+    data: '0x1234',
+  }];
+  t.after(() => { EtherscanService._request = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      249999
+    ),
+    /malformed/
+  );
+});
+
+test('Base event-wide windows reject a tracked row when the event filter is ignored', async (t) => {
+  const original = EtherscanService._request;
+  EtherscanService._request = async () => {
+    const row = ethBridgeFinalizedLog({ wallet: WALLET, block: 100000 });
+    row.topics[0] = `0x${'f'.repeat(64)}`;
+    return [row];
+  };
+  t.after(() => { EtherscanService._request = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      249999
+    ),
+    /wrong event topic/
+  );
+});
+
+test('Base event-wide windows reject rows outside the requested block window', async (t) => {
+  const original = EtherscanService._request;
+  EtherscanService._request = async () => [ethBridgeFinalizedLog({
+    wallet: WALLET,
+    block: 250000,
+  })];
+  t.after(() => { EtherscanService._request = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      249999
+    ),
+    /outside the requested window/
+  );
+});
+
+test('Base event-wide windows reject malformed tracked and untracked coordinates', async (t) => {
+  const original = EtherscanService._request;
+  t.after(() => { EtherscanService._request = original; });
+
+  for (const row of [
+    {
+      ...ethBridgeFinalizedLog({ wallet: WALLET, block: 100000 }),
+      transactionHash: '0x1234',
+    },
+    {
+      ...ethBridgeFinalizedLog({
+        wallet: '0x1111111111111111111111111111111111111111',
+        block: 100000,
+      }),
+      logIndex: null,
+    },
+  ]) {
+    EtherscanService._request = async () => [row];
+    await assert.rejects(
+      EtherscanService.fetchStateSyncDepositsBatch(
+        [{ address: WALLET, startBlock: 0 }],
+        8453,
+        chains.getChain(8453).stateSyncDeposits,
+        249999
+      ),
+      /malformed \(invalid (transactionHash|logIndex)\)/
+    );
+  }
+});
+
+test('Base event-wide windows fail on conflicting duplicate coordinates', async (t) => {
+  const original = EtherscanService._request;
+  const first = ethBridgeFinalizedLog({ wallet: WALLET, block: 100000 });
+  const conflict = ethBridgeFinalizedLog({
+    wallet: WALLET,
+    block: 100000,
+    amountWei: '2',
+    hash: first.transactionHash,
+    logIndex: parseInt(first.logIndex, 16),
+  });
+  EtherscanService._request = async () => [first, conflict];
+  t.after(() => { EtherscanService._request = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      249999
+    ),
+    /conflicting duplicate log/
+  );
+});
+
+test('Base detects a conflicting coordinate even when one receiver is untracked', async (t) => {
+  const original = EtherscanService._request;
+  const untracked = ethBridgeFinalizedLog({
+    wallet: '0x1111111111111111111111111111111111111111',
+    block: 100000,
+  });
+  const tracked = ethBridgeFinalizedLog({
+    wallet: WALLET,
+    block: 100000,
+    hash: untracked.transactionHash,
+    logIndex: parseInt(untracked.logIndex, 16),
+  });
+  EtherscanService._request = async () => [untracked, tracked];
+  t.after(() => { EtherscanService._request = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      249999
+    ),
+    /conflicting duplicate log/
+  );
+});
+
+test('Base validates a saturated response before considering a split', async (t) => {
+  const original = EtherscanService._request;
+  let calls = 0;
+  const outside = ethBridgeFinalizedLog({ wallet: WALLET, block: 250000 });
+  EtherscanService._request = async () => {
+    calls += 1;
+    return Array(1000).fill(outside);
+  };
+  t.after(() => { EtherscanService._request = original; });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      chains.getChain(8453).stateSyncDeposits,
+      249999
+    ),
+    /outside the requested window/
+  );
+  assert.equal(calls, 1, 'invalid saturation never multiplies provider calls');
+});
+
+test('Base bisects a persistently timing-out window and accepts successful children', async (t) => {
+  const original = EtherscanService._request;
+  const calls = [];
+  EtherscanService._request = async (params) => {
+    calls.push([params.fromBlock, params.toBlock]);
+    if (params.fromBlock === 0 && params.toBlock === 249999) {
+      const error = new Error('timeout of 15000ms exceeded');
+      error.code = 'ECONNABORTED';
+      throw error;
+    }
+    return params.fromBlock === 0
+      ? [ethBridgeFinalizedLog({ wallet: WALLET, block: 100000, hash: '0xchild' })]
+      : [];
+  };
+  t.after(() => { EtherscanService._request = original; });
+
+  const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
+    [{ address: WALLET, startBlock: 0 }],
+    8453,
+    chains.getChain(8453).stateSyncDeposits,
+    249999
+  );
+
+  assert.deepEqual(calls, [[0, 249999], [0, 124999], [125000, 249999]]);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
+    testTxHash('0xchild'),
+  ]);
+});
+
+test('Base event-wide scans fail closed when a scan-wide budget is exhausted', async (t) => {
+  const original = EtherscanService._request;
+  const originalNow = Date.now;
+  t.after(() => {
+    EtherscanService._request = original;
+    Date.now = originalNow;
+  });
+
+  let calls = 0;
+  EtherscanService._request = async () => { calls += 1; return []; };
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      {
+        ...chains.getChain(8453).stateSyncDeposits,
+        rpcScan: {
+          ...chains.getChain(8453).stateSyncDeposits.rpcScan,
+          maxRequests: 1,
+        },
+      },
+      499999
+    ),
+    /exceeding the 1-request budget/
+  );
+  assert.equal(calls, 0, 'a predictably impossible scan is rejected before provider work');
+
+  let now = 1000;
+  Date.now = () => now;
+  EtherscanService._request = async () => { now += 1001; return []; };
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      {
+        ...chains.getChain(8453).stateSyncDeposits,
+        rpcScan: {
+          ...chains.getChain(8453).stateSyncDeposits.rpcScan,
+          maxElapsedMs: 1000,
+        },
+      },
+      249999
+    ),
+    /exceeded 1000ms/
+  );
+
+  Date.now = originalNow;
+  EtherscanService._request = async () => [
+    ethBridgeFinalizedLog({ wallet: WALLET, block: 1 }),
+    ethBridgeFinalizedLog({ wallet: WALLET, block: 2, hash: '0xsecond-row' }),
+  ];
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      {
+        ...chains.getChain(8453).stateSyncDeposits,
+        rpcScan: {
+          ...chains.getChain(8453).stateSyncDeposits.rpcScan,
+          maxResponseRows: 1,
+        },
+      },
+      249999
+    ),
+    /exceeded 1 response rows/
+  );
+});
+
+test('the Base request budget counts transport-level retry attempts', async (t) => {
+  const axios = require('axios');
+  const etherscanConfig = require('../src/config/etherscan');
+  const originalGet = axios.get;
+  const originalThrottled = etherscanConfig.throttled;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    return {
+      headers: { 'retry-after': '0' },
+      data: { status: '0', message: 'Too many requests', result: 'rate limit reached' },
+    };
+  };
+  etherscanConfig.throttled = (fn) => fn();
+  t.after(() => {
+    axios.get = originalGet;
+    etherscanConfig.throttled = originalThrottled;
+    etherscanConfig.resetRateLimits();
+  });
+
+  await assert.rejects(
+    EtherscanService.fetchStateSyncDepositsBatch(
+      [{ address: WALLET, startBlock: 0 }],
+      8453,
+      {
+        ...chains.getChain(8453).stateSyncDeposits,
+        rpcScan: {
+          ...chains.getChain(8453).stateSyncDeposits.rpcScan,
+          maxRequests: 1,
+        },
+      },
+      249999
+    ),
+    /exceeded 1 requests/
+  );
+  assert.equal(requests, 1, 'the retry is blocked before issuing a second HTTP request');
+});
+
+test('Base retries only the failed bounded window and retains prior progress', async (t) => {
+  const original = EtherscanService._request;
+  const calls = [];
+  let secondWindowAttempts = 0;
+  EtherscanService._request = async (params) => {
+    calls.push(params.fromBlock);
+    if (params.fromBlock === 0) {
+      return [ethBridgeFinalizedLog({
+        block: 100000,
+        wallet: WALLET,
+        hash: '0xfirst-window',
+      })];
+    }
+    secondWindowAttempts += 1;
+    if (secondWindowAttempts === 1) {
+      const error = new Error('Blockscout rate limit reached; retry after 1s');
+      error.code = 'EXPLORER_RATE_LIMITED';
+      error.retryAfterMs = 1;
+      throw error;
+    }
+    return [ethBridgeFinalizedLog({
+      block: 300000,
+      wallet: WALLET,
+      hash: '0xsecond-window',
+    })];
+  };
+  t.after(() => { EtherscanService._request = original; });
+
+  const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
+    [{ address: WALLET, startBlock: 0 }],
+    8453,
+    chains.getChain(8453).stateSyncDeposits,
+    499999
+  );
+
+  assert.deepEqual(calls, [0, 250000, 250000],
+    'the completed first window is not replayed');
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
+    testTxHash('0xfirst-window'),
+    testTxHash('0xsecond-window'),
+  ]);
+  assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 499999);
 });
 
 test('Base Blockscout windows share receiver topics and use returned timestamps', async (t) => {
@@ -548,7 +1033,9 @@ test('Base Blockscout windows share receiver topics and use returned timestamps'
   const calls = [];
   EtherscanService._request = async (params, options) => {
     calls.push({ params, options });
-    return [ethBridgeFinalizedLog({ wallet: WALLET, block: 5000, hash: '0xblockscout' })];
+    return params.fromBlock === 0
+      ? [ethBridgeFinalizedLog({ wallet: WALLET, block: 5000, hash: '0xblockscout' })]
+      : [];
   };
   t.after(() => { EtherscanService._request = original; });
 
@@ -573,7 +1060,7 @@ test('Base Blockscout windows share receiver topics and use returned timestamps'
   assert.equal(calls[0].params.topic0_2_opr, 'and');
   assert.match(calls[0].params.topic2, new RegExp(WALLET.slice(2)));
   assert.match(calls[0].params.topic2, new RegExp(WALLET_2.slice(2)));
-  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), ['0xblockscout']);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [testTxHash('0xblockscout')]);
   assert.deepEqual(rowsByAddress.get(WALLET_2), []);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 19999);
 });
@@ -602,7 +1089,7 @@ test('Base ignores only well-formed out-of-scope receivers from a public log res
     9999
   );
 
-  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), ['0xrequested']);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [testTxHash('0xrequested')]);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 9999);
 });
 
@@ -637,11 +1124,19 @@ test('a saturated Blockscout window splits before accepting a cursor', async (t)
   EtherscanService._request = async (params) => {
     calls.push(params);
     if (params.fromBlock === 0 && params.toBlock === 99999) {
-      return Array.from({ length: 1000 }, (_, index) =>
-        ethBridgeFinalizedLog({ block: index + 1, hash: `0xfull${index}` }));
+      return [
+        ethBridgeFinalizedLog({ block: 5000, hash: '0xleft' }),
+        ethBridgeFinalizedLog({ block: 75000, hash: '0xright' }),
+        ...Array.from({ length: 998 }, (_, index) => ethBridgeFinalizedLog({
+          block: index + 1,
+          wallet: '0x1111111111111111111111111111111111111111',
+          hash: `0xfull${index}`,
+          logIndex: index + 2,
+        })),
+      ];
     }
     return [ethBridgeFinalizedLog({
-      block: params.fromBlock === 0 ? 5000 : 15000,
+      block: params.fromBlock === 0 ? 5000 : 75000,
       hash: params.fromBlock === 0 ? '0xleft' : '0xright',
     })];
   };
@@ -652,13 +1147,22 @@ test('a saturated Blockscout window splits before accepting a cursor', async (t)
     8453,
     {
       ...chains.getChain(8453).stateSyncDeposits,
-      rpcScan: { provider: 'blockscout', blockRange: 100000, batchSize: 1, concurrency: 1 },
+      rpcScan: {
+        provider: 'blockscout',
+        blockRange: 100000,
+        batchSize: 1,
+        concurrency: 1,
+        allowExtraneousTopics: true,
+      },
     },
     99999
   );
 
   assert.equal(calls.length, 3, 'one full window plus two split windows');
-  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), ['0xleft', '0xright']);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
+    testTxHash('0xleft'),
+    testTxHash('0xright'),
+  ]);
   assert.equal(rowsByAddress.get(WALLET).scannedThroughBlock, 99999);
 });
 
@@ -1361,7 +1865,7 @@ test('a decimal blockNumber is rejected, not misparsed as hex', async (t) => {
   t.after(() => { axios.get = original; });
   await assert.rejects(
     EtherscanService.fetchStateSyncDeposits(WALLET, 0, 'key', 137, chains.getChain(137).stateSyncDeposits),
-    /non-hex blockNumber/
+    /invalid blockNumber/
   );
 });
 


### PR DESCRIPTION
## Summary
- replace Base state-sync's unbounded Blockscout v2 history walk with bounded legacy log windows
- apply endpoint-specific throttling, in-window rate-limit retry, sequential timeout splitting, and hard request/time/row budgets
- validate every provider row fail-closed, including discarded and saturated-page rows, while preserving cursors until the full scan succeeds
- quarantine the known-slow v2 full-history path from production configuration

## Verification
- backend: 1,076 tests passed
- backend lint passed
- frontend: 207 tests passed
- frontend lint passed with 12 pre-existing warnings
- frontend production build passed
- two independent final reviews: no actionable findings