### PR TITLE
fix: slow Base scans after live throttling

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -270,17 +270,19 @@ const REGISTRY = [
       // unsuitable for a genesis scan: one late 120-second page timeout throws
       // away hours of otherwise valid progress. The legacy logs facade handles
       // bounded event-signature windows quickly. Its live response headers
-      // expose a 10-request anonymous bucket; seven-second spacing leaves
-      // headroom even when empty windows return immediately. Split every
-      // saturated 1,000-row window and distribute validated receivers locally.
-      // Do not send a comma-separated receiver filter: Base currently ignores
-      // it.
+      // expose an anonymous bucket whose advertised size does not describe its
+      // sustained refill rate. Production scan #276 still reached that bucket
+      // at seven-second spacing. Fifteen seconds keeps the genesis walk below
+      // the observed refill rate while remaining inside the three-hour scan
+      // budget. Split every saturated 1,000-row window and distribute validated
+      // receivers locally. Do not send a comma-separated receiver filter: Base
+      // currently ignores it.
       rpcScan: {
         provider: 'blockscout',
         blockRange: 250000,
         batchSize: 1,
         concurrency: 1,
-        requestSpacingMs: 7000,
+        requestSpacingMs: 15000,
         maxRequests: 2000,
         maxElapsedMs: 3 * 60 * 60 * 1000,
         maxResponseRows: 1000000,

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -465,6 +465,7 @@ class EtherscanService {
     rateLimitState = { attempt: 0 },
     spacingMs = null,
     beforeAttempt = null,
+    malformedResponseAttempt = 0,
   }) {
     if (spacingMs != null
         && (!Number.isSafeInteger(Number(spacingMs))
@@ -523,7 +524,34 @@ class EtherscanService {
           error: responseDetailError(detail, response),
           retry: () => this._request(params, {
             apiKey, chainId, rateLimitState, spacingMs, beforeAttempt,
+            malformedResponseAttempt,
           }),
+        });
+      }
+      // Etherscan occasionally returns a nominal JSON-RPC envelope with
+      // neither a result nor an error for eth_blockNumber. That is not an
+      // authoritative chain response and must not fail every feed sharing the
+      // head immediately. Retry it through the same provider queue exactly as
+      // a transient transport failure, then remain fail-closed if it repeats.
+      if (!payload.error && payload.result == null
+          && malformedResponseAttempt < EXPLORER_TRANSIENT_RETRIES) {
+        const delayMs = EXPLORER_TRANSIENT_RETRY_BASE_MS
+          * (2 ** malformedResponseAttempt);
+        logger.warn({
+          chainId,
+          provider: provider.name,
+          attempt: malformedResponseAttempt + 1,
+          delayMs,
+          params: { module: params?.module, action: params?.action },
+        }, 'Explorer returned a malformed JSON-RPC envelope; retrying');
+        await sleep(delayMs);
+        return this._request(params, {
+          apiKey,
+          chainId,
+          rateLimitState,
+          spacingMs,
+          beforeAttempt,
+          malformedResponseAttempt: malformedResponseAttempt + 1,
         });
       }
       const error = new Error(`${provider.name} JSON-RPC error: ${detail}`);
@@ -544,6 +572,7 @@ class EtherscanService {
         ),
         retry: () => this._request(params, {
           apiKey, chainId, rateLimitState, spacingMs, beforeAttempt,
+          malformedResponseAttempt,
         }),
       });
     }

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -246,7 +246,7 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
   assert.equal(base.accountApi.v2BaseUrl, 'https://base.blockscout.com/api/v2');
   assert.equal(base.stateSyncDeposits.rpcScan.provider, 'blockscout');
   assert.equal(base.stateSyncDeposits.rpcScan.blockRange, 250000);
-  assert.equal(base.stateSyncDeposits.rpcScan.requestSpacingMs, 7000);
+  assert.equal(base.stateSyncDeposits.rpcScan.requestSpacingMs, 15000);
   assert.equal(base.stateSyncDeposits.rpcScan.maxRequests, 2000);
   assert.equal(base.stateSyncDeposits.rpcScan.maxElapsedMs, 3 * 60 * 60 * 1000);
   assert.equal(base.stateSyncDeposits.rpcScan.maxResponseRows, 1000000);
@@ -1688,6 +1688,39 @@ test('Etherscan proxy JSON-RPC responses supply the Polygon log coverage head', 
   assert.equal(seen.params.chainid, 137);
   assert.equal(seen.params.module, 'proxy');
   assert.equal(seen.params.action, 'eth_blockNumber');
+});
+
+test('Polygon head retries one malformed JSON-RPC envelope before succeeding', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    if (requests === 1) return { data: { jsonrpc: '2.0', id: 83 } };
+    return { data: { jsonrpc: '2.0', id: 83, result: '0x56f00de' } };
+  };
+  t.after(() => { axios.get = originalGet; });
+
+  assert.equal(await EtherscanService._latestBlockNumber('test-key', 137), 91160798);
+  assert.equal(requests, 2);
+});
+
+test('Polygon head remains fail-closed after repeated malformed JSON-RPC envelopes', async (t) => {
+  const axios = require('axios');
+  const originalGet = axios.get;
+  let requests = 0;
+  axios.get = async () => {
+    requests += 1;
+    return { data: { jsonrpc: '2.0', id: 83 } };
+  };
+  t.after(() => { axios.get = originalGet; });
+
+  await assert.rejects(
+    () => EtherscanService._latestBlockNumber('test-key', 137),
+    (error) => error.code === 'ETHERSCAN_API_ERROR'
+      && /invalid JSON-RPC response/.test(error.message)
+  );
+  assert.equal(requests, 2);
 });
 
 test('legacy Blockscout head falls back to the documented explorer endpoint', async (t) => {

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -187,7 +187,7 @@ test('Polygon, Gnosis, OP Mainnet, and Base declare verified native-credit logs'
           blockRange: 250000,
           batchSize: 1,
           concurrency: 1,
-          requestSpacingMs: 7000,
+          requestSpacingMs: 15000,
           maxRequests: 2000,
           maxElapsedMs: 3 * 60 * 60 * 1000,
           maxResponseRows: 1000000,
@@ -591,7 +591,7 @@ test('Base uses bounded event-wide Blockscout windows and distributes receivers 
     blockRange: 250000,
     batchSize: 1,
     concurrency: 1,
-    requestSpacingMs: 7000,
+    requestSpacingMs: 15000,
     maxRequests: 2000,
     maxElapsedMs: 3 * 60 * 60 * 1000,
     maxResponseRows: 1000000,
@@ -611,7 +611,7 @@ test('Base uses bounded event-wide Blockscout windows and distributes receivers 
 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].options.chainId, 8453);
-  assert.equal(calls[0].options.spacingMs, 7000);
+  assert.equal(calls[0].options.spacingMs, 15000);
   assert.equal(calls[0].params.fromBlock, 0);
   assert.equal(calls[0].params.toBlock, 249999);
   assert.equal(calls[0].params.topic0, ETH_BRIDGE_FINALIZED_TOPIC0);


### PR DESCRIPTION
## Summary
- raise Base legacy state-sync spacing from 7s to 15s after production scan #276 still exhausted the sustained anonymous bucket
- retry one malformed Etherscan JSON-RPC envelope through the normal provider queue before failing closed
- preserve rate-limit state, request accounting, cursors, and stored rows across both retry paths

## Production evidence
- scan #276: Base state-sync deferred with a 60s Blockscout cooldown at 7s spacing
- one Polygon head response was JSON-RPC 2.0 with neither result nor error and temporarily failed all six Polygon feeds

## Verification
- focused wallet/provider suite: 144 passed
- full backend suite: 1,078 passed
- backend lint passed
- git diff --check passed
- two independent reviews: no actionable findings