### PR TITLE
fix: throttle Base account feeds

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -255,6 +255,11 @@ const REGISTRY = [
       apiStyle: 'blockscout-v2',
       v2BaseUrl: 'https://base.blockscout.com/api/v2',
       requiresApiKey: false,
+      // The legacy state-sync walk and v2 account feeds share one host/IP
+      // bucket. Production scan #277 proved that dropping back to the generic
+      // 1.5s Blockscout spacing at that handoff can 429 the first wallet even
+      // after the 15s state-sync walk itself succeeds.
+      requestSpacingMs: 15000,
     },
     rpcUrl: 'https://mainnet.base.org',
     ingestVersion: 1,

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -22,6 +22,9 @@ const MAX_ACCOUNT_PAGES = 200;
 // Blockscout v2 address feeds use cursor pagination with 50 rows per page.
 // Preserve the legacy walk's 200,000-row safety envelope while also bounding
 // a hostile endpoint that returns one row and a fresh cursor forever.
+// Keep these as request/data bounds rather than a wall-clock limit: at a
+// provider-safe pace, a valid deep history can exceed hours, and the opaque
+// cursor cannot be persisted safely midway through an atomic overlap rebuild.
 const MAX_ACCOUNT_ROWS = PAGE_SIZE * MAX_ACCOUNT_PAGES;
 const MAX_BLOCKSCOUT_V2_PAGES = 5000;
 
@@ -434,16 +437,21 @@ class EtherscanService {
   static _provider(chainId, apiKey = null) {
     const custom = chains.getChain(chainId)?.accountApi;
     if (custom) {
+      const providerDefaultSpacing = custom.provider === 'Blockscout'
+        ? etherscan.BLOCKSCOUT_REQUEST_SPACING_MS
+        : etherscan.REQUEST_SPACING_MS;
       return {
         name: custom.provider || 'chain explorer',
         baseUrl: custom.baseUrl,
         requiresApiKey: custom.requiresApiKey !== false,
         params: {},
         key: `account:${custom.baseUrl}`,
-        spacingMs: custom.requestSpacingMs
-          ?? (custom.provider === 'Blockscout'
-            ? etherscan.BLOCKSCOUT_REQUEST_SPACING_MS
-            : etherscan.REQUEST_SPACING_MS),
+        // A chain may raise the shared provider floor, but it must never
+        // weaken a stricter operator override.
+        spacingMs: Math.max(
+          Number(custom.requestSpacingMs) || 0,
+          providerDefaultSpacing
+        ),
       };
     }
     return {
@@ -879,7 +887,6 @@ class EtherscanService {
         `account provider head ${end} is behind requested block ${start}; cursor frozen`
       );
     }
-
     const path = `addresses/${String(address).toLowerCase()}/${feed.path}`;
     const fixedQuery = feed.type ? { type: feed.type } : {};
     let cursor = {};

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -244,6 +244,8 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
   const base = chains.getChain(8453);
   assert.equal(base.accountApi.apiStyle, 'blockscout-v2');
   assert.equal(base.accountApi.v2BaseUrl, 'https://base.blockscout.com/api/v2');
+  assert.equal(base.accountApi.requestSpacingMs, 15000);
+  assert.equal(EtherscanService._provider(8453).spacingMs, 15000);
   assert.equal(base.stateSyncDeposits.rpcScan.provider, 'blockscout');
   assert.equal(base.stateSyncDeposits.rpcScan.blockRange, 250000);
   assert.equal(base.stateSyncDeposits.rpcScan.requestSpacingMs, 15000);
@@ -261,6 +263,14 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
 test('anonymous Blockscout requests stay below a conservative minute bucket', () => {
   assert.equal(etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS, 1500);
   assert.ok(60_000 / etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS <= 40);
+});
+
+test('a chain-specific Blockscout floor preserves stricter operator pacing', (t) => {
+  const original = etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS;
+  etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS = 20000;
+  t.after(() => { etherscanConfig.BLOCKSCOUT_REQUEST_SPACING_MS = original; });
+
+  assert.equal(EtherscanService._provider(8453).spacingMs, 20000);
 });
 
 test('all live-probed chains default on through their configured providers', () => {


### PR DESCRIPTION
## Summary
- pace Base Blockscout v2 account feeds at the same 15-second host floor as the legacy state-sync scan
- preserve stricter operator-provided Blockscout spacing instead of overriding it
- document why opaque account cursor walks retain finite page/row bounds rather than a wall-clock cap

## Production evidence
Scan #277 completed the shared Base state-sync prefetch without a 429, then the first Base account-feed handoff fell back to the generic 1.5-second pace and received 429 responses. This change closes that remaining shared-host gap.

## Validation
- backend full suite: 1,079 passed, 0 failed
- backend lint: passed
- git diff --check: passed
- two independent final reviews: no actionable findings