### PR TITLE
fix: harden Base provider pacing

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -276,18 +276,18 @@ const REGISTRY = [
       // away hours of otherwise valid progress. The legacy logs facade handles
       // bounded event-signature windows quickly. Its live response headers
       // expose an anonymous bucket whose advertised size does not describe its
-      // sustained refill rate. Production scan #276 still reached that bucket
-      // at seven-second spacing. Fifteen seconds keeps the genesis walk below
-      // the observed refill rate while remaining inside the three-hour scan
-      // budget. Split every saturated 1,000-row window and distribute validated
-      // receivers locally. Do not send a comma-separated receiver filter: Base
-      // currently ignores it.
+      // sustained refill rate. Production scans #276 and #278 still reached
+      // that bucket at seven- and fifteen-second spacing respectively. Thirty
+      // seconds keeps the genesis walk below the observed sustained rate while
+      // remaining inside the three-hour scan budget. Split every saturated
+      // 1,000-row window and distribute validated receivers locally. Do not
+      // send a comma-separated receiver filter: Base currently ignores it.
       rpcScan: {
         provider: 'blockscout',
         blockRange: 250000,
         batchSize: 1,
         concurrency: 1,
-        requestSpacingMs: 15000,
+        requestSpacingMs: 30000,
         maxRequests: 2000,
         maxElapsedMs: 3 * 60 * 60 * 1000,
         maxResponseRows: 1000000,

--- a/backend/src/config/etherscan.js
+++ b/backend/src/config/etherscan.js
@@ -20,6 +20,16 @@ function envMilliseconds(name, fallback) {
 const REQUEST_SPACING_MS = envMilliseconds('ETHERSCAN_REQUEST_SPACING_MS', 250);
 const BLOCKSCOUT_REQUEST_SPACING_MS = envMilliseconds('BLOCKSCOUT_REQUEST_SPACING_MS', 1500);
 const RPC_REQUEST_SPACING_MS = envMilliseconds('RPC_REQUEST_SPACING_MS', 250);
+// EtherscanService accepts endpoint-specific floors up to one minute. Retain
+// each host's completion timestamp through that whole window so a stricter
+// incoming request cannot arrive after a shorter predecessor's state expired.
+// Operator defaults above one minute extend the retention automatically.
+const MAX_INCOMING_SPACING_MS = Math.max(
+  60_000,
+  REQUEST_SPACING_MS,
+  BLOCKSCOUT_REQUEST_SPACING_MS,
+  RPC_REQUEST_SPACING_MS
+);
 
 // A rate limit is scoped to the provider host (or to an Etherscan key), not to
 // the wallet/feed currently being fetched. Keep queues and cooldowns separate
@@ -49,20 +59,42 @@ function throttled(fn, {
   spacingMs = REQUEST_SPACING_MS,
   bypassPause = false,
 } = {}) {
-  const queue = queues.get(key) || Promise.resolve();
-  const run = queue.then(async () => {
-    const remaining = Math.max(0, (pausedUntil.get(key) || 0) - Date.now());
-    if (remaining > 0 && !bypassPause) throw pausedError(key, remaining);
-    return fn();
+  const requestedSpacingMs = Math.max(0, Number(spacingMs) || 0);
+  const state = queues.get(key) || {
+    tail: Promise.resolve(),
+    completedAt: 0,
+    spacingMs: 0,
+  };
+  const run = state.tail.then(async () => {
+    // Provider limits are host-wide, so a handoff between endpoint classes
+    // must satisfy both sides. Sleeping only the preceding request's floor
+    // lets a 15s account call hand off to a 30s state-sync call after 15s.
+    const requiredSpacingMs = Math.max(state.spacingMs, requestedSpacingMs);
+    const spacingRemainingMs = state.completedAt
+      ? Math.max(0, requiredSpacingMs - (Date.now() - state.completedAt))
+      : 0;
+    if (spacingRemainingMs > 0) await sleep(spacingRemainingMs);
+    try {
+      const pauseRemainingMs = Math.max(0, (pausedUntil.get(key) || 0) - Date.now());
+      if (pauseRemainingMs > 0 && !bypassPause) {
+        throw pausedError(key, pauseRemainingMs);
+      }
+      return await fn();
+    } finally {
+      state.completedAt = Date.now();
+      state.spacingMs = requestedSpacingMs;
+    }
   });
-  const tail = run
-    .catch(() => {})
-    .then(() => sleep(Math.max(0, spacingMs)));
-  queues.set(key, tail);
-  // Do not retain a resolved promise for every provider forever. The identity
-  // check preserves a newer queue when another request arrived meanwhile.
+  const tail = run.catch(() => {});
+  state.tail = tail;
+  queues.set(key, state);
+  // Retain the completed timestamp only while it can still constrain a new
+  // request. The identity checks preserve state when newer work arrived.
   tail.then(() => {
-    if (queues.get(key) === tail) queues.delete(key);
+    const cleanupTimer = setTimeout(() => {
+      if (queues.get(key) === state && state.tail === tail) queues.delete(key);
+    }, Math.max(state.spacingMs, MAX_INCOMING_SPACING_MS));
+    cleanupTimer.unref?.();
   });
   return run;
 }

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -248,7 +248,7 @@ test('Gnosis, OP Mainnet, Base, and zkSync Era use keyless providers', () => {
   assert.equal(EtherscanService._provider(8453).spacingMs, 15000);
   assert.equal(base.stateSyncDeposits.rpcScan.provider, 'blockscout');
   assert.equal(base.stateSyncDeposits.rpcScan.blockRange, 250000);
-  assert.equal(base.stateSyncDeposits.rpcScan.requestSpacingMs, 15000);
+  assert.equal(base.stateSyncDeposits.rpcScan.requestSpacingMs, 30000);
   assert.equal(base.stateSyncDeposits.rpcScan.maxRequests, 2000);
   assert.equal(base.stateSyncDeposits.rpcScan.maxElapsedMs, 3 * 60 * 60 * 1000);
   assert.equal(base.stateSyncDeposits.rpcScan.maxResponseRows, 1000000);
@@ -1079,6 +1079,35 @@ test('provider pauses are isolated by host instead of using one global queue', a
     }),
     (err) => err.code === 'EXPLORER_RATE_LIMITED'
   );
+});
+
+test('a shared provider handoff enforces the stricter incoming and preceding spacing', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 1000 });
+  etherscanConfig.resetRateLimits();
+  t.after(() => { etherscanConfig.resetRateLimits(); });
+  const key = 'account:https://mixed-spacing.test/api';
+  const startedAt = [];
+  const run = (spacingMs) => etherscanConfig.throttled(() => {
+    startedAt.push(Date.now());
+  }, { key, spacingMs });
+
+  await run(15);
+  t.mock.timers.tick(20);
+  const incoming = run(30);
+  await Promise.resolve();
+  assert.equal(startedAt.length, 1,
+    'the stricter incoming floor still waits after the old 15ms floor expired');
+  t.mock.timers.tick(10);
+  await incoming;
+
+  const following = run(10);
+  await Promise.resolve();
+  assert.equal(startedAt.length, 2,
+    'the stricter preceding floor delays the following lower-floor request');
+  t.mock.timers.tick(30);
+  await following;
+
+  assert.deepEqual(startedAt, [1000, 1030, 1060]);
 });
 
 test('the chain id reaches Etherscan as the chainid param', async (t) => {

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -187,7 +187,7 @@ test('Polygon, Gnosis, OP Mainnet, and Base declare verified native-credit logs'
           blockRange: 250000,
           batchSize: 1,
           concurrency: 1,
-          requestSpacingMs: 15000,
+          requestSpacingMs: 30000,
           maxRequests: 2000,
           maxElapsedMs: 3 * 60 * 60 * 1000,
           maxResponseRows: 1000000,
@@ -591,7 +591,7 @@ test('Base uses bounded event-wide Blockscout windows and distributes receivers 
     blockRange: 250000,
     batchSize: 1,
     concurrency: 1,
-    requestSpacingMs: 15000,
+    requestSpacingMs: 30000,
     maxRequests: 2000,
     maxElapsedMs: 3 * 60 * 60 * 1000,
     maxResponseRows: 1000000,
@@ -611,7 +611,7 @@ test('Base uses bounded event-wide Blockscout windows and distributes receivers 
 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].options.chainId, 8453);
-  assert.equal(calls[0].options.spacingMs, 15000);
+  assert.equal(calls[0].options.spacingMs, 30000);
   assert.equal(calls[0].params.fromBlock, 0);
   assert.equal(calls[0].params.toBlock, 249999);
   assert.equal(calls[0].params.topic0, ETH_BRIDGE_FINALIZED_TOPIC0);


### PR DESCRIPTION
## Summary
- lower the sustained Base genesis state-sync request rate from four to two requests per minute
- enforce the stricter of the preceding and incoming request floors when endpoint classes share one provider host
- retain completion state long enough for stricter incoming handoffs, with deterministic controlled-clock coverage

## Production evidence
Production scan #278 proved that Base account feeds are clean at their 15-second floor, but the all-receiver genesis state-sync walk still reached Blockscout's sustained limit and exhausted two 60-second retries. All 24 Base state-sync cursors remain at genesis, so this change targets only that longer walk.

## Validation
- focused provider/state-sync suite: 146 passed, 0 failed
- backend full suite: 1,080 passed, 0 failed
- backend lint: passed
- git diff --check: passed
- two independent final reviews: no actionable findings