### PR TITLE
fix: split rate-limited Base log windows

### DIFF
--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -278,10 +278,11 @@ const REGISTRY = [
       // expose an anonymous bucket whose advertised size does not describe its
       // sustained refill rate. Production scans #276 and #278 still reached
       // that bucket at seven- and fifteen-second spacing respectively. Thirty
-      // seconds keeps the genesis walk below the observed sustained rate while
-      // remaining inside the three-hour scan budget. Split every saturated
-      // 1,000-row window and distribute validated receivers locally. Do not
-      // send a comma-separated receiver filter: Base currently ignores it.
+      // seconds lowers the sustained rate while remaining inside the three-hour
+      // scan budget. Split every saturated 1,000-row window, and bisect a dense
+      // window that remains rate-limited after its bounded cooldown retries.
+      // Distribute validated receivers locally. Do not send a comma-separated
+      // receiver filter: Base currently ignores it.
       rpcScan: {
         provider: 'blockscout',
         blockRange: 250000,

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -2270,9 +2270,14 @@ class EtherscanService {
         } catch (error) {
           // Repeated timeout/5xx responses can be caused by a dense range even
           // when a successful response never arrives to advertise saturation.
-          // Bisect that range after the transport's own bounded retry, while a
-          // 429 continues to cool down rather than multiplying requests.
-          if (!isTransientExplorerError(error) || fromBlock === toBlock || depth >= 12) {
+          // A dense legacy-log window can likewise remain rate-limited after
+          // requestBlockscoutWindow has already honored its bounded cooldown
+          // retries. Bisect either persistent condition instead of replaying
+          // the same expensive query forever; a one-block leaf still fails
+          // closed and every child remains inside the scan-wide budgets.
+          const splittableProviderFailure = isTransientExplorerError(error)
+            || error?.code === 'EXPLORER_RATE_LIMITED';
+          if (!splittableProviderFailure || fromBlock === toBlock || depth >= 12) {
             throw error;
           }
           const midpoint = Math.floor((fromBlock + toBlock) / 2);

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -878,6 +878,39 @@ test('Base bisects a persistently timing-out window and accepts successful child
   ]);
 });
 
+test('Base cools down then bisects a persistently rate-limited dense window', async (t) => {
+  const original = EtherscanService._request;
+  const calls = [];
+  EtherscanService._request = async (params) => {
+    calls.push([params.fromBlock, params.toBlock]);
+    if (params.fromBlock === 0 && params.toBlock === 249999) {
+      const error = new Error('Blockscout rate limit reached; retry after 1ms');
+      error.code = 'EXPLORER_RATE_LIMITED';
+      error.retryAfterMs = 1;
+      throw error;
+    }
+    return params.fromBlock === 0
+      ? [ethBridgeFinalizedLog({ wallet: WALLET, block: 100000, hash: '0xchild' })]
+      : [];
+  };
+  t.after(() => { EtherscanService._request = original; });
+
+  const rowsByAddress = await EtherscanService.fetchStateSyncDepositsBatch(
+    [{ address: WALLET, startBlock: 0 }],
+    8453,
+    chains.getChain(8453).stateSyncDeposits,
+    249999
+  );
+
+  assert.deepEqual(calls, [
+    [0, 249999], [0, 249999], [0, 249999],
+    [0, 124999], [125000, 249999],
+  ]);
+  assert.deepEqual(rowsByAddress.get(WALLET).map((row) => row.hash), [
+    testTxHash('0xchild'),
+  ]);
+});
+
 test('Base event-wide scans fail closed when a scan-wide budget is exhausted', async (t) => {
   const original = EtherscanService._request;
   const originalNow = Date.now;


### PR DESCRIPTION
## Summary
- split persistently rate-limited Base state-sync log windows after the existing bounded cooldown retries
- keep child scans sequential and preserve the existing depth, request, and row budgets
- document the distinction between sustained provider throttling and dense-window bisection

## Production evidence
- scans #278 and #279 continued to rate-limit the same Base state-sync window at 15s and 30s request spacing
- account feeds remained healthy, indicating the failure is specific to dense log queries rather than ordinary request cadence

## Validation
- focused state-sync suite: 60 passing
- full backend suite: 1081 passing
- backend lint passed
- `git diff --check` passed
- two independent code reviews found no remaining actionable issues