### PR TITLE
fix: retry malformed Polygon head responses

### DIFF
--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -231,6 +231,9 @@ const EXPLORER_RETRY_JITTER_MS = boundedEnvInteger(
 const EXPLORER_TRANSIENT_RETRIES = boundedEnvInteger(
   'EXPLORER_TRANSIENT_RETRIES', 1, 3
 );
+const EXPLORER_MALFORMED_RESPONSE_RETRIES = boundedEnvInteger(
+  'EXPLORER_MALFORMED_RESPONSE_RETRIES', 2, 3
+);
 const EXPLORER_TRANSIENT_RETRY_BASE_MS = boundedEnvInteger(
   'EXPLORER_TRANSIENT_RETRY_BASE_MS', 500, 10000
 );
@@ -539,10 +542,11 @@ class EtherscanService {
       // Etherscan occasionally returns a nominal JSON-RPC envelope with
       // neither a result nor an error for eth_blockNumber. That is not an
       // authoritative chain response and must not fail every feed sharing the
-      // head immediately. Retry it through the same provider queue exactly as
-      // a transient transport failure, then remain fail-closed if it repeats.
+      // head immediately. Retry it through the same provider queue as a
+      // transient transport failure, then remain fail-closed after the small
+      // bounded retry budget is exhausted.
       if (!payload.error && payload.result == null
-          && malformedResponseAttempt < EXPLORER_TRANSIENT_RETRIES) {
+          && malformedResponseAttempt < EXPLORER_MALFORMED_RESPONSE_RETRIES) {
         const delayMs = EXPLORER_TRANSIENT_RETRY_BASE_MS
           * (2 ** malformedResponseAttempt);
         logger.warn({

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -1729,19 +1729,19 @@ test('Etherscan proxy JSON-RPC responses supply the Polygon log coverage head', 
   assert.equal(seen.params.action, 'eth_blockNumber');
 });
 
-test('Polygon head retries one malformed JSON-RPC envelope before succeeding', async (t) => {
+test('Polygon head retries repeated malformed JSON-RPC envelopes before succeeding', async (t) => {
   const axios = require('axios');
   const originalGet = axios.get;
   let requests = 0;
   axios.get = async () => {
     requests += 1;
-    if (requests === 1) return { data: { jsonrpc: '2.0', id: 83 } };
+    if (requests <= 2) return { data: { jsonrpc: '2.0', id: 83 } };
     return { data: { jsonrpc: '2.0', id: 83, result: '0x56f00de' } };
   };
   t.after(() => { axios.get = originalGet; });
 
   assert.equal(await EtherscanService._latestBlockNumber('test-key', 137), 91160798);
-  assert.equal(requests, 2);
+  assert.equal(requests, 3);
 });
 
 test('Polygon head remains fail-closed after repeated malformed JSON-RPC envelopes', async (t) => {
@@ -1759,7 +1759,7 @@ test('Polygon head remains fail-closed after repeated malformed JSON-RPC envelop
     (error) => error.code === 'ETHERSCAN_API_ERROR'
       && /invalid JSON-RPC response/.test(error.message)
   );
-  assert.equal(requests, 2);
+  assert.equal(requests, 3);
 });
 
 test('legacy Blockscout head falls back to the documented explorer endpoint', async (t) => {


### PR DESCRIPTION
## Summary
- give malformed explorer JSON-RPC envelopes their own bounded retry budget
- retry two malformed Polygon head responses before failing closed
- leave ordinary HTTP/transport retry behavior unchanged

## Production evidence
- diagnostic scan #278 received repeated malformed `eth_blockNumber` envelopes and failed all six Polygon feeds
- the prior one-retry budget was therefore insufficient for the observed provider behavior

## Validation
- targeted Polygon and Blockscout fallback tests: 3 passing
- full backend suite: 1081 passing
- backend lint passed
- `git diff --check` passed
- two independent code reviews found no actionable issues