### PR TITLE
fix(crypto): make wallet audit action full-history

### DIFF
--- a/frontend/src/components/crypto/WalletsPanel.jsx
+++ b/frontend/src/components/crypto/WalletsPanel.jsx
@@ -534,7 +534,7 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = s
     setAuditStartingId(wallet.id);
     onError(null);
     try {
-      const { job } = await ethAPI.startHistoryAudit(wallet.id);
+      const { job } = await ethAPI.startHistoryAudit(wallet.id, { mode: 'full' });
       setAuditByWallet((current) => ({ ...current, [wallet.id]: job }));
       showNotice('History audit queued. You can leave this page; progress and evidence are saved.');
     } catch (err) {

--- a/frontend/src/pages/CryptoWallets.test.jsx
+++ b/frontend/src/pages/CryptoWallets.test.jsx
@@ -425,7 +425,7 @@ describe('Crypto -> Wallets tab', () => {
     await openEthereumTab([wallet(report())]);
 
     fireEvent.click((await screen.findAllByRole('button', { name: /audit mined history for main/i }))[0]);
-    await waitFor(() => expect(apiMocks.eth.startHistoryAudit).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(apiMocks.eth.startHistoryAudit).toHaveBeenCalledWith(1, { mode: 'full' }));
     expect(apiMocks.eth.syncWallet).not.toHaveBeenCalled();
     await expandWallet();
     expect(await screen.findByText(/History audit: queued/i)).toBeInTheDocument();


### PR DESCRIPTION
The Wallets audit action was calling the audit endpoint without a mode, which defaults to incremental. This makes the user-facing audit action satisfy the required genesis/full-history audit criterion. The focused UI test now asserts the explicit full mode.\n\nValidation: focused frontend test (24 passing), frontend lint (0 errors; existing warnings), and production build passing.