### PR TITLE
fix(crypto): renew audit lease during receipt verification

### DIFF
--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -501,6 +501,12 @@ class EvmAuditService {
       fromBlock: null, throughBlock: boundary.number, throughHash: boundary.hash,
     });
     for (const hash of hashes) {
+      const renewedBeforeLookup = await EvmAudit.heartbeat(job.id, OWNER, {
+        stage: 'canonicalizing',
+        progress: { current_tx_hash: hash },
+      });
+      if (!renewedBeforeLookup) leaseState.lost = true;
+      assertLease(leaseState);
       const { transaction, receipt } = await rpc.transactionAndReceipt(hash);
       assertLease(leaseState);
       if (Number(BigInt(transaction.blockNumber)) > boundary.number) continue;
@@ -531,6 +537,11 @@ class EvmAuditService {
         job.subject_id, chainId, hash, rpcEffects.map((effect) => effect.effectKey),
         observationIds.get(`receipt:${hash}`) || null
       );
+      const renewedAfterCommit = await EvmAudit.heartbeat(job.id, OWNER, {
+        stage: 'canonicalizing',
+      });
+      if (!renewedAfterCommit) leaseState.lost = true;
+      assertLease(leaseState);
     }
     await EvmAudit.completeScope(rpcScope.id, {
       status: 'unverified', paginationExhausted: false,


### PR DESCRIPTION
## What changed
Renew the EVM audit lease before and after each consensus-RPC transaction/receipt canonicalization step, and fail closed if ownership is lost.

## Why
A large receipt can keep the worker inside one canonicalization loop long enough to approach the lease deadline. The durable job was resumable, but it could retry the scope unnecessarily.

## Validation
- `node --check src/services/EvmAuditService.js`
- `npm run lint`
- `node --test tests/evmAudit.test.js` (16 passed)
- Full backend suite passed on the immediately preceding audit evidence batching commit (1,076 passed).