### PR TITLE
fix(crypto): allow long audit phases to finish

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -5,6 +5,7 @@ const pool = require('../config/database');
 
 const ACTIVE_JOB_STATUSES = ['queued', 'running', 'deferred'];
 const OBSERVATION_BATCH_SIZE = 500;
+const AUDIT_LEASE_SECONDS = 600;
 
 function observationIdentity(observation) {
   return JSON.stringify([
@@ -207,7 +208,7 @@ class EvmAudit {
     return rows;
   }
 
-  static async claim(jobId, owner, leaseSeconds = 120) {
+  static async claim(jobId, owner, leaseSeconds = AUDIT_LEASE_SECONDS) {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
@@ -253,7 +254,7 @@ class EvmAudit {
     }
   }
 
-  static async heartbeat(jobId, owner, { stage = null, progress = null, leaseSeconds = 120 } = {}) {
+  static async heartbeat(jobId, owner, { stage = null, progress = null, leaseSeconds = AUDIT_LEASE_SECONDS } = {}) {
     const { rows } = await pool.query(
       `UPDATE evm_audit_jobs
           SET stage = COALESCE($3, stage),


### PR DESCRIPTION
## What changed
Increase the EVM audit claim/heartbeat lease from 120 seconds to 600 seconds while retaining the 30-second renewal timer.

## Why
Receipt verification is now bulk-written, but the subsequent derived-ledger rebuild and bridge reconciliation can still exceed two minutes. The job was correctly durable but could be reclaimed before writing its terminal verdict.

## Validation
- `node --check src/models/EvmAudit.js`
- `npm run lint`
- `node --test tests/evmAudit.test.js` (16 passed)
- Full backend suite: 1,076 passed, 0 failed

This preserves automatic recovery for workers stuck longer than the bounded lease while allowing legitimate long audit phases to complete.