### PR TITLE
fix(crypto): resume audits from verified receipts

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -810,6 +810,27 @@ class EvmAudit {
     return rows;
   }
 
+  // A committed consensus receipt is durable proof for a mined transaction.
+  // Restarting an audit must not replay every expensive RPC lookup when the
+  // prior run already verified the same finalized transaction. Reconciliation
+  // still reads all canonical effects below, and a transaction without both a
+  // verified row and a consensus receipt remains eligible for lookup.
+  static async verifiedConsensusReceiptHashes(subjectId, chainId) {
+    const { rows } = await pool.query(
+      `SELECT DISTINCT tx.tx_hash
+         FROM evm_mined_transactions tx
+         JOIN evm_transaction_evidence te ON te.transaction_id = tx.id
+         JOIN evm_provider_observations obs ON obs.id = te.observation_id
+        WHERE tx.subject_id = $1 AND tx.chain_id = $2
+          AND tx.resolution_status = 'verified'
+          AND tx.finality_status = 'finalized'
+          AND obs.provider = 'consensus-rpc'
+          AND obs.evidence_kind = 'receipt'`,
+      [subjectId, chainId]
+    );
+    return new Set(rows.map((row) => row.tx_hash));
+  }
+
   static async transactionConflictCount(subjectId, chainId) {
     const { rows } = await pool.query(
       `SELECT COUNT(*)::int AS count

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -500,7 +500,11 @@ class EvmAuditService {
       chainId, provider: 'consensus-rpc', capability: 'receipt_verification', status: 'running',
       fromBlock: null, throughBlock: boundary.number, throughHash: boundary.hash,
     });
+    const verifiedReceiptHashes = await EvmAudit.verifiedConsensusReceiptHashes(
+      job.subject_id, chainId
+    );
     for (const hash of hashes) {
+      if (verifiedReceiptHashes.has(hash)) continue;
       const renewedBeforeLookup = await EvmAudit.heartbeat(job.id, OWNER, {
         stage: 'canonicalizing',
         progress: { current_tx_hash: hash },


### PR DESCRIPTION
## What changed
Persist the restart boundary for consensus canonicalization by skipping mined transactions that already have a verified finalized consensus receipt. The existing canonical transaction/effect reconciliation still runs for every hash, and unverified or conflict rows continue through RPC lookup.

## Why
After a worker interruption during a long receipt pass, the audit replayed all 87 Gnosis receipts even though their consensus evidence was already committed. That delayed the terminal reconciliation and weakened restart/idempotency behavior.

## Validation
- `node --check src/models/EvmAudit.js`
- `node --check src/services/EvmAuditService.js`
- `npm run lint`
- `node --test tests/evmAudit.test.js` (16 passed)
- Full backend suite: 1,076 passed, 0 failed