### PR TITLE
fix(crypto): checkpoint existing ledger audit feeds

### DIFF
--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -446,6 +446,18 @@ class EvmAuditService {
         throughBlock: coverage?.covered_through_block ?? boundary.number,
         throughHash: null,
       });
+      // The page and its raw evidence are already durable for this job. A
+      // restarted worker must not replay even an empty/unsupported feed page;
+      // only restore the same finite coverage verdict and continue.
+      if (scope.pages_committed > 0) {
+        await EvmAudit.completeScope(scope.id, {
+          status: coverageComplete ? 'complete' : 'unverified',
+          paginationExhausted: coverageComplete,
+          errorCode: coverageComplete ? null : (coverage?.error_code || 'LEDGER_COVERAGE_UNPROVEN'),
+          errorDetail: coverageComplete ? null : (coverage?.error_message || `Stored ${feed} coverage is not proven complete.`),
+        });
+        continue;
+      }
       const observations = normalizer.legacyTransferObservations(
         { ...context, provider: 'existing-ledger' }, rows
       );


### PR DESCRIPTION
## What changed
When an existing-ledger audit scope already has a committed page for the job, restore its complete or unverified finite coverage verdict without replaying the page.

## Why
A restart was re-entering an already committed empty internal-feed page and could stall before reaching canonicalization. This makes the existing-ledger fallback explicitly restart/idempotent while preserving the raw evidence already linked to the job.

## Validation
- `node --check src/services/EvmAuditService.js`
- `npm run lint`
- `node --test tests/evmAudit.test.js` (16 passed)
- Full backend suite: 1,076 passed, 0 failed