### PR TITLE
fix: cast audit completion status

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -274,8 +274,8 @@ class EvmAudit {
   } = {}) {
     const { rows } = await pool.query(
       `UPDATE evm_audit_jobs
-          SET status = $3,
-              stage = CASE WHEN $3 IN ('complete', 'complete_with_gaps') THEN 'complete' ELSE stage END,
+          SET status = $3::varchar,
+              stage = CASE WHEN $3::varchar IN ('complete', 'complete_with_gaps') THEN 'complete' ELSE stage END,
               progress = CASE WHEN $4::jsonb IS NULL THEN progress ELSE progress || $4::jsonb END,
               error_code = $5,
               error_detail = $6,

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -8,6 +8,8 @@ const normalizer = require('../src/services/evmAudit/normalizer');
 const MoralisClient = require('../src/services/evmAudit/MoralisClient');
 const RpcClient = require('../src/services/evmAudit/RpcClient');
 const EvmAuditService = require('../src/services/EvmAuditService');
+const EvmAudit = require('../src/models/EvmAudit');
+const database = require('../src/config/database');
 const {
   TOPICS, effectsFromInternalObservations, effectsFromRpc,
 } = require('../src/services/evmAudit/effectDecoder');
@@ -33,6 +35,22 @@ const context = (chainId = 8453) => ({
 test('stable evidence hashes ignore object key order but not payload changes', () => {
   assert.equal(normalizer.sha256({ b: 2, a: 1 }), normalizer.sha256({ a: 1, b: 2 }));
   assert.notEqual(normalizer.sha256({ a: 1 }), normalizer.sha256({ a: 2 }));
+});
+
+test('finishing an audit casts the status parameter consistently for PostgreSQL', async () => {
+  const originalQuery = database.query;
+  let sql;
+  database.query = async (query) => {
+    sql = query;
+    return { rows: [{ id: 1, status: 'complete' }] };
+  };
+  try {
+    await EvmAudit.finish(1, 'test-owner', 'complete');
+    assert.match(sql, /SET status = \$3::varchar/);
+    assert.match(sql, /CASE WHEN \$3::varchar IN/);
+  } finally {
+    database.query = originalQuery;
+  }
 });
 
 test('Moralis history keeps receipt, log, internal and token evidence independently', () => {


### PR DESCRIPTION
## Summary
- cast the audit status parameter consistently in `EvmAudit.finish`
- add a regression test for PostgreSQL parameter inference

## Validation
- `node --check src/models/EvmAudit.js`
- `npm run lint`
- `node --test tests/evmAudit.test.js` (17 passing)