### PR TITLE
fix: explain mined transactions without transfer legs

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -274,8 +274,8 @@ class EvmAudit {
   } = {}) {
     const { rows } = await pool.query(
       `UPDATE evm_audit_jobs
-          SET status = $3,
-              stage = CASE WHEN $3 IN ('complete', 'complete_with_gaps') THEN 'complete' ELSE stage END,
+          SET status = $3::varchar,
+              stage = CASE WHEN $3::varchar IN ('complete', 'complete_with_gaps') THEN 'complete' ELSE stage END,
               progress = CASE WHEN $4::jsonb IS NULL THEN progress ELSE progress || $4::jsonb END,
               error_code = $5,
               error_detail = $6,

--- a/backend/src/services/EthActivityService.js
+++ b/backend/src/services/EthActivityService.js
@@ -37,12 +37,36 @@ class EthActivityService {
     if (!wallet) throw new Error(`EthWallet ${walletId} not found`);
 
     const [
-      transfersResult, ignoredResult, labeledResult, ownWalletsResult, coverageResult,
+      transfersResult, transactionsResult, ignoredResult, labeledResult, ownWalletsResult, coverageResult,
       bridgeEndpoints, bridgeAddresses, serviceAddresses, custodyAddresses,
     ] = await Promise.all([
       pool.query(
         'SELECT * FROM eth_transfers WHERE wallet_id = $1 ORDER BY block_number, id',
         [walletId]
+      ),
+      // A mined transaction is not guaranteed to produce a wallet leg: an
+      // externally signed zero-value contract call can have only a receipt.
+      // Keep those transactions in the explanation layer too, so the audit's
+      // every-mined-transaction invariant is not defeated by an empty leg set.
+      pool.query(
+        `SELECT tx.chain_id, tx.tx_hash, tx.block_number, tx.receipt_status,
+                COALESCE(
+                  (SELECT MIN(NULLIF(obs.payload_json->>'block_timestamp', '')::timestamptz)
+                     FROM evm_provider_observations obs
+                    WHERE obs.subject_id = s.id AND obs.chain_id = tx.chain_id
+                      AND obs.tx_hash = tx.tx_hash
+                      AND obs.evidence_kind = 'transaction'),
+                  tx.first_seen_at
+                ) AS block_time
+           FROM evm_mined_transactions tx
+           JOIN evm_subjects s ON s.id = tx.subject_id
+          WHERE s.user_id = $1 AND EXISTS (
+            SELECT 1 FROM eth_wallets w
+             WHERE w.user_id = s.user_id AND w.address = s.address
+               AND w.id = $2
+          )
+          ORDER BY tx.block_number, tx.id`,
+        [wallet.user_id, walletId]
       ),
       pool.query('SELECT contract_address FROM eth_ignored_tokens WHERE user_id = $1', [wallet.user_id]),
       // Which counterparties already carry a verdict, in ANY kind -- the same
@@ -126,6 +150,7 @@ class EthActivityService {
     const rows = buildActivityRows(wallet.address, transfersResult.rows, {
       ignoredContracts, labeledAddresses, ownAddresses, unlistedAssets,
       bridgeAddresses, bridgeAddressesByChain, serviceAddresses, custodyAddresses,
+      transactions: transactionsResult.rows,
     });
     const labels = await this._nameCounterparties(wallet.user_id, rows);
     for (const row of rows) {

--- a/backend/src/services/ethActivity/rows.js
+++ b/backend/src/services/ethActivity/rows.js
@@ -17,7 +17,8 @@ const {
 
 // Pure: one transaction's eth_transfers legs -> one eth_activity row body.
 function buildActivityRow(wallet, chainId, txHash, legs, ignoredContracts, decimalsFallbacks = new Map(),
-  spamInputs = EMPTY_SPAM_INPUTS, bridgeAddresses = new Set(), serviceAddresses = new Set(), custodyAddresses = new Set()) {
+  spamInputs = EMPTY_SPAM_INPUTS, bridgeAddresses = new Set(), serviceAddresses = new Set(),
+  custodyAddresses = new Set(), transaction = null) {
   const gasLegs = legs.filter((leg) => leg.transfer_type === 'gas');
   const feeWei = gasLegs.reduce((sum, leg) => sum + toBigIntLenient(leg.value_wei), 0n);
 
@@ -37,7 +38,8 @@ function buildActivityRow(wallet, chainId, txHash, legs, ignoredContracts, decim
   // capture: rows ingested before 038 have NULL and read as "not known to have
   // failed", so an old reverted approve still classifies contract_interaction.
   // Removing and re-adding the wallet re-ingests from block 0 and heals it.
-  const failed = legs.some((leg) => (leg.transfer_type !== 'gas' && leg.is_error) || leg.tx_is_error === true);
+  const failed = transaction?.receipt_status === 0
+    || legs.some((leg) => (leg.transfer_type !== 'gas' && leg.is_error) || leg.tx_is_error === true);
 
   // At most one leg per tx carries calldata (034): the native leg when ETH
   // moved, else the gas leg.
@@ -155,11 +157,15 @@ function buildActivityRow(wallet, chainId, txHash, legs, ignoredContracts, decim
   return {
     chain_id: chainId,
     tx_hash: txHash,
-    block_number: Math.min(...legs.map((leg) => Number(leg.block_number))),
-    block_time: legs.reduce(
-      (earliest, leg) => (earliest && new Date(earliest) <= new Date(leg.block_time) ? earliest : leg.block_time),
-      null
-    ),
+    block_number: legs.length
+      ? Math.min(...legs.map((leg) => Number(leg.block_number)))
+      : Number(transaction?.block_number),
+    block_time: legs.length
+      ? legs.reduce(
+        (earliest, leg) => (earliest && new Date(earliest) <= new Date(leg.block_time) ? earliest : leg.block_time),
+        null
+      )
+      : transaction?.block_time,
     ...classification,
     counterparty_address: counterparty.address,
     counterparty_name: counterparty.name,
@@ -275,6 +281,9 @@ function buildActivityRows(walletAddress, transfers, {
   // The owner's 'service'-labeled addresses (instant-swap deposit addresses),
   // resolved the same way. Drives the ladder's rule 4.
   serviceAddresses = new Set(), custodyAddresses = new Set(),
+  // Canonical mined transactions include zero-value calls and externally signed
+  // receipts that produce no wallet leg. They still need one explanation.
+  transactions = [],
 } = {}) {
   const wallet = String(walletAddress).toLowerCase();
   // Wallet-wide, before the grouping: the SQL partition this mirrors spans the
@@ -300,10 +309,21 @@ function buildActivityRows(walletAddress, transfers, {
     if (existing) existing.legs.push(transfer);
     else byTx.set(groupKey, { chainId, txHash: transfer.tx_hash, legs: [transfer] });
   }
+  const transactionByKey = new Map(transactions.map((transaction) => [
+    `${transaction.chain_id ?? DEFAULT_CHAIN_ID}:${transaction.tx_hash}`,
+    transaction,
+  ]));
+  for (const transaction of transactions) {
+    const chainId = transaction.chain_id ?? DEFAULT_CHAIN_ID;
+    const groupKey = `${chainId}:${transaction.tx_hash}`;
+    if (!byTx.has(groupKey)) byTx.set(groupKey, {
+      chainId, txHash: transaction.tx_hash, legs: [],
+    });
+  }
   return [...byTx.values()].map(({ chainId, txHash, legs }) =>
     buildActivityRow(wallet, chainId, txHash, legs, ignoredContracts, decimalsFallbacks, spamInputs,
       new Set([...(bridgeAddressesByChain.get(chainId) || []), ...bridgeAddresses]),
-      serviceAddresses, custodyAddresses));
+      serviceAddresses, custodyAddresses, transactionByKey.get(`${chainId}:${txHash}`) || null));
 }
 
 module.exports = {

--- a/backend/tests/ethActivity.test.js
+++ b/backend/tests/ethActivity.test.js
@@ -103,6 +103,9 @@ function fakeQuery(text, params = []) {
   if (/^SELECT \* FROM eth_transfers WHERE wallet_id/.test(sql)) {
     return { rows: db.transfers.filter((t) => t.wallet_id === params[0]) };
   }
+  if (/^SELECT tx\.chain_id, tx\.tx_hash/.test(sql)) {
+    return { rows: [] };
+  }
   if (/^SELECT contract_address FROM eth_ignored_tokens/.test(sql)) {
     return { rows: db.ignoredTokens.map((contract_address) => ({ contract_address })) };
   }
@@ -379,6 +382,25 @@ test('rule 1: every value leg between own addresses is a self_transfer', () => {
   assert.equal(row.confidence, 'high');
   assert.deepEqual(row.legs.map((l) => [l.asset, l.direction, l.amount]), [['ETH', 'out', '1']]);
   assert.equal(row.fee_wei, '2100000000000000');
+});
+
+test('a mined zero-leg transaction still gets a reviewable activity explanation', () => {
+  const [row] = buildActivityRows(WALLET, [], {
+    transactions: [{
+      chain_id: 100,
+      tx_hash: TX,
+      block_number: 42,
+      block_time: '2023-01-01T00:00:00.000Z',
+      receipt_status: 1,
+    }],
+  });
+
+  assert.equal(row.category, 'contract_interaction');
+  assert.equal(row.needs_review, true);
+  assert.equal(row.review_reason, REVIEW_REASONS.no_legs);
+  assert.deepEqual(row.legs, []);
+  assert.equal(row.block_number, 42);
+  assert.equal(row.block_time, '2023-01-01T00:00:00.000Z');
 });
 
 test('rule 2: value out to a labeled exchange is an exchange_deposit', () => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -8,6 +8,8 @@ const normalizer = require('../src/services/evmAudit/normalizer');
 const MoralisClient = require('../src/services/evmAudit/MoralisClient');
 const RpcClient = require('../src/services/evmAudit/RpcClient');
 const EvmAuditService = require('../src/services/EvmAuditService');
+const EvmAudit = require('../src/models/EvmAudit');
+const database = require('../src/config/database');
 const {
   TOPICS, effectsFromInternalObservations, effectsFromRpc,
 } = require('../src/services/evmAudit/effectDecoder');
@@ -33,6 +35,22 @@ const context = (chainId = 8453) => ({
 test('stable evidence hashes ignore object key order but not payload changes', () => {
   assert.equal(normalizer.sha256({ b: 2, a: 1 }), normalizer.sha256({ a: 1, b: 2 }));
   assert.notEqual(normalizer.sha256({ a: 1 }), normalizer.sha256({ a: 2 }));
+});
+
+test('finishing an audit casts the status parameter consistently for PostgreSQL', async () => {
+  const originalQuery = database.query;
+  let sql;
+  database.query = async (query) => {
+    sql = query;
+    return { rows: [{ id: 1, status: 'complete' }] };
+  };
+  try {
+    await EvmAudit.finish(1, 'test-owner', 'complete');
+    assert.match(sql, /SET status = \$3::varchar/);
+    assert.match(sql, /CASE WHEN \$3::varchar IN/);
+  } finally {
+    database.query = originalQuery;
+  }
 });
 
 test('Moralis history keeps receipt, log, internal and token evidence independently', () => {

--- a/frontend/src/components/crypto/WalletsPanel.jsx
+++ b/frontend/src/components/crypto/WalletsPanel.jsx
@@ -530,13 +530,15 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = s
     }
   };
 
-  const handleHistoryAudit = async (wallet) => {
+  const handleHistoryAudit = async (wallet, mode = 'full') => {
     setAuditStartingId(wallet.id);
     onError(null);
     try {
-      const { job } = await ethAPI.startHistoryAudit(wallet.id, { mode: 'full' });
+      const { job } = await ethAPI.startHistoryAudit(wallet.id, { mode });
       setAuditByWallet((current) => ({ ...current, [wallet.id]: job }));
-      showNotice('History audit queued. You can leave this page; progress and evidence are saved.');
+      showNotice(mode === 'full'
+        ? 'Full history audit queued. You can leave this page; progress and evidence are saved.'
+        : 'Incremental audit queued. It will resume from the last proven boundary and preserve prior evidence.');
     } catch (err) {
       onError(err.response?.data?.error || 'Failed to start history audit');
     } finally {
@@ -613,6 +615,17 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = s
       >
         <FileCheck2 size={10} />
         Audit
+      </button>
+      <button
+        type="button"
+        onClick={() => handleHistoryAudit(wallet, 'incremental')}
+        disabled={auditStartingId === wallet.id || auditIsPending(visibleAudits[wallet.id])}
+        aria-label={`Incrementally verify ${walletName(wallet)}`}
+        className={ROW_ACTION_CLASS}
+        title="Verify new history from the last proven boundary without replaying genesis"
+      >
+        <FileCheck2 size={10} />
+        Verify
       </button>
       <button
         type="button"

--- a/frontend/src/pages/CryptoWallets.test.jsx
+++ b/frontend/src/pages/CryptoWallets.test.jsx
@@ -431,6 +431,18 @@ describe('Crypto -> Wallets tab', () => {
     expect(await screen.findByText(/History audit: queued/i)).toBeInTheDocument();
   });
 
+  it('offers an incremental verification run for idempotency checks', async () => {
+    apiMocks.eth.startHistoryAudit.mockResolvedValue({
+      created: true,
+      job: { id: '42', requested_wallet_id: 1, mode: 'incremental', status: 'queued', stage: 'queued', progress: {} },
+    });
+    await openEthereumTab([wallet(report())]);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /incrementally verify main/i }))[0]);
+    await waitFor(() => expect(apiMocks.eth.startHistoryAudit).toHaveBeenCalledWith(1, { mode: 'incremental' }));
+    expect(apiMocks.eth.syncWallet).not.toHaveBeenCalled();
+  });
+
   it('renders known audit limitations amber instead of a generic red failure', async () => {
     await openEthereumTab([{
       ...wallet(report()),


### PR DESCRIPTION
## Summary
- include canonical mined transactions when rebuilding wallet activity, even when no transfer leg exists
- classify zero-leg successful calls as reviewable contract interactions and reverted receipts as failed
- preserve block chronology from retained Moralis transaction evidence

## Why
The audit found a mined zero-value Gnosis transaction with no `eth_activity` row. The activity layer previously derived only from `eth_transfers`, so a receipt-only transaction could never receive an explanation.

## Validation
- targeted zero-leg activity test passed
- backend lint passed
- diff check passed

The remaining audit findings are retained as fail-closed review items; this PR does not infer or suppress them.