### PR TITLE
fix(audit): finalize Moralis history scope after lookups

### DIFF
--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -506,6 +506,11 @@ class EvmAuditService {
         if (error.code === 'MORALIS_RATE_LIMITED' || error.code === 'MORALIS_AUTH_FAILED') throw error;
       }
     }
+    // Transaction lookups use the same durable scope as the paginated history
+    // stream. commitPage() correctly reopens a scope when it appends evidence,
+    // so close it again after the lookup pass; otherwise a finite, exhausted
+    // history can be reported as still running even though all pages committed.
+    await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
 
     await EvmAudit.heartbeat(job.id, OWNER, { stage: 'canonicalizing' });
     const rpcScope = await EvmAudit.upsertScope(job.id, {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -212,6 +212,19 @@ test('Moralis pagination advances opaque cursors and exhausts exactly once', asy
   }
 });
 
+test('Moralis history scope is finalized after transaction lookup pages', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
+  const lookupPass = source.indexOf("for (const hash of hashes) {\n      if (moralisHashes.has(hash)) continue;");
+  const canonicalization = source.indexOf("await EvmAudit.heartbeat(job.id, OWNER, { stage: 'canonicalizing' });", lookupPass);
+  const finalization = source.indexOf(
+    "await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });",
+    lookupPass
+  );
+  assert.ok(lookupPass >= 0);
+  assert.ok(finalization > lookupPass && finalization < canonicalization,
+    'lookup evidence must be followed by a final complete status before canonicalization');
+});
+
 test('consensus RPC requires matching receipt identity and canonical block membership', async () => {
   const rpc = new RpcClient(8453, { spacingMs: 0 });
   rpc.request = async (method) => ({


### PR DESCRIPTION
## What changed
- Re-finalize the Moralis wallet-history scope after transaction-by-hash evidence is appended.
- Add a regression test requiring finalization before canonicalization.

## Root cause
The transaction lookup pass reuses the paginated history scope. `commitPage()` correctly reopens a scope when it appends evidence, but the service did not close it again, leaving an exhausted scope reported as running.

## Validation
- Backend full test suite: 1,079 passed, 0 failed
- Backend lint: passed
- Targeted Moralis scope tests: 2 passed

Production data is not modified by this PR; it corrects future audit finalization.