### PR TITLE
fix: repair corroborated EVM transfer identities

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -2,6 +2,11 @@
 
 const crypto = require('node:crypto');
 const pool = require('../config/database');
+const {
+  matchesLegacyTransfer,
+  matchesMoralisTransfer,
+  TRANSFER_TYPES,
+} = require('../services/evmAudit/corroboratedIdentity');
 
 const ACTIVE_JOB_STATUSES = ['queued', 'running', 'deferred'];
 const OBSERVATION_BATCH_SIZE = 500;
@@ -1021,6 +1026,125 @@ class EvmAudit {
       [userId, subjectId, chainId, throughBlock]
     );
     return rows;
+  }
+
+  // Legacy explorer rows normally have economics but no immutable log
+  // coordinate. Upgrade them only when the same receipt effect is proven by
+  // consensus RPC and independently corroborated by Moralis at the exact
+  // transaction/log coordinate. Economic equality alone remains a gap.
+  static async repairCorroboratedTransferIdentities(userId, subjectId, chainId, throughBlock) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const walletResult = await client.query(
+        `SELECT w.id, w.address
+           FROM evm_subjects s
+           JOIN eth_wallets w ON w.user_id = s.user_id AND w.address = s.address
+          WHERE s.id = $2 AND s.user_id = $1
+          FOR UPDATE OF w`,
+        [userId, subjectId]
+      );
+      const wallet = walletResult.rows[0];
+      if (!wallet) throw new Error('Tracked wallet is unavailable for identity repair');
+
+      const effectsResult = await client.query(
+        `SELECT e.*,
+                o.id AS moralis_observation_id,
+                o.provider AS moralis_provider,
+                o.evidence_kind AS moralis_evidence_kind,
+                o.tx_hash AS moralis_tx_hash,
+                o.log_index AS moralis_log_index,
+                o.payload_json AS moralis_payload_json
+           FROM evm_canonical_effects e
+           JOIN evm_provider_observations o
+             ON o.subject_id = e.subject_id AND o.chain_id = e.chain_id
+            AND o.provider = 'moralis'
+            AND o.evidence_kind = e.effect_type || '_transfer'
+            AND o.tx_hash = e.tx_hash AND o.log_index = e.log_index
+          JOIN evm_mined_transactions tx
+             ON tx.subject_id = e.subject_id AND tx.chain_id = e.chain_id
+            AND tx.tx_hash = e.tx_hash
+          WHERE e.subject_id = $2 AND e.chain_id = $3
+            AND tx.block_number <= $4
+            AND e.effect_type = ANY($5::text[])
+            AND e.resolution_status = 'verified'
+            AND tx.resolution_status = 'verified'
+          ORDER BY e.id, o.id`,
+        [userId, subjectId, chainId, throughBlock, Object.keys(TRANSFER_TYPES)]
+      );
+      const legacyResult = await client.query(
+        `SELECT * FROM eth_transfers
+          WHERE wallet_id = $1 AND chain_id = $2 AND block_number <= $3
+            AND transfer_type = ANY($4::text[])
+            AND audit_effect_key IS NULL
+          ORDER BY id
+          FOR UPDATE`,
+        [wallet.id, chainId, throughBlock, Object.values(TRANSFER_TYPES)]
+      );
+
+      const legacyRows = legacyResult.rows;
+      const byEffect = new Map();
+      for (const row of effectsResult.rows) {
+        const list = byEffect.get(row.id) || [];
+        list.push(row);
+        byEffect.set(row.id, list);
+      }
+      const repaired = [];
+      for (const [effectId, observations] of byEffect) {
+        const effect = observations[0];
+        const moralisMatches = observations.filter((observation) => matchesMoralisTransfer(
+          effect,
+          {
+            provider: observation.moralis_provider,
+            evidence_kind: observation.moralis_evidence_kind,
+            tx_hash: observation.moralis_tx_hash,
+            log_index: observation.moralis_log_index,
+            payload_json: observation.moralis_payload_json,
+          }
+        ));
+        if (moralisMatches.length !== 1) continue;
+        const candidates = legacyRows.filter((row) => matchesLegacyTransfer(effect, row)
+          && (row.source_log_index == null || Number(row.source_log_index) === Number(effect.log_index)));
+        if (candidates.length !== 1) continue;
+        const legacy = candidates[0];
+        const conflict = await client.query(
+          `SELECT 1 FROM eth_transfers
+            WHERE wallet_id = $1 AND chain_id = $2 AND audit_effect_key = $3
+            LIMIT 1`,
+          [wallet.id, chainId, effect.effect_key]
+        );
+        if (conflict.rowCount) continue;
+        const updated = await client.query(
+          `UPDATE eth_transfers
+              SET source_log_index = $2,
+                  source_trace_address = $3::jsonb,
+                  audit_effect_key = $4,
+                  audit_observation_id = $5
+            WHERE id = $1 AND audit_effect_key IS NULL
+            RETURNING id`,
+          [
+            legacy.id, effect.log_index,
+            effect.trace_address == null ? null : JSON.stringify(effect.trace_address),
+            effect.effect_key, effect.selected_observation_id,
+          ]
+        );
+        if (!updated.rowCount) continue;
+        await client.query(
+          `INSERT INTO evm_effect_evidence (effect_id, subject_id, chain_id, observation_id)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT DO NOTHING`,
+          [effectId, subjectId, chainId, moralisMatches[0].moralis_observation_id]
+        );
+        repaired.push({ effectId: Number(effectId), transferId: legacy.id });
+      }
+      await client.query('COMMIT');
+      return { repaired: repaired.length, transferIds: repaired.map((row) => row.transferId) };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   static async storedFeedCoverage(userId, subjectId, chainId) {

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -578,6 +578,15 @@ class EvmAuditService {
       await EvmAudit.linkEffectEvidence(stored.id, effect.evidenceObservationIds);
     }
 
+    // Legacy rows may have the right economics but no immutable log index.
+    // Upgrade only the independently corroborated receipt effects before the
+    // strict reconciliation pass; unresolved economic matches remain gaps.
+    const identityRepair = await EvmAudit.repairCorroboratedTransferIdentities(
+      job.user_id, job.subject_id, chainId, boundary.number
+    );
+    legacyRows = await EvmAudit.storedTransferRows(
+      job.user_id, job.subject_id, chainId, boundary.number
+    );
     let canonicalEffects = await EvmAudit.canonicalEffects(job.subject_id, chainId, boundary.number);
     let effectReconciliation = reconcileEffects(canonicalEffects, legacyRows, job.address, chain);
     if (effectReconciliation.missing.length) {
@@ -705,6 +714,7 @@ class EvmAuditService {
           nonce_gaps: nonceGapCount,
           native_balance_match: delta === 0n,
           token_balance_gaps: tokenMismatches,
+          corroborated_identity_repairs: identityRepair.repaired,
           missing_activity: missingActivity,
           unresolved_bridges: bridgeAudit.unresolved,
           provisional_effects: provisionalEffects,

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const TRANSFER_TYPES = {
+  erc20: 'token',
+  erc721: 'nft',
+  erc1155: 'nft1155',
+};
+
+function normalizedAddress(value) {
+  const text = String(value || '').toLowerCase();
+  return /^0x[0-9a-f]{40}$/.test(text) ? text : null;
+}
+
+function quantity(value) {
+  if (typeof value === 'bigint') return value;
+  const text = String(value ?? '').trim();
+  if (!/^\d+$/.test(text)) return null;
+  try { return BigInt(text); } catch { return null; }
+}
+
+function decimal(value) {
+  const parsed = quantity(value);
+  return parsed == null ? null : parsed.toString();
+}
+
+function moralisTransferFields(effect, payload) {
+  const standard = effect.effect_type;
+  const contract = normalizedAddress(payload.address ?? payload.token_address);
+  const from = normalizedAddress(payload.from_address ?? payload.from);
+  const to = normalizedAddress(payload.to_address ?? payload.to);
+  const value = decimal(payload.value ?? payload.amount ?? payload.value_wei);
+  const tokenId = standard === 'erc20' ? null : decimal(payload.token_id ?? payload.tokenId);
+  if (!contract || !from || !to || value == null || (standard !== 'erc20' && tokenId == null)) {
+    return null;
+  }
+  return { contract, from, to, value, tokenId };
+}
+
+function matchesMoralisTransfer(effect, observation) {
+  if (!effect || !observation || !TRANSFER_TYPES[effect.effect_type]) return false;
+  if (observation.provider !== 'moralis') return false;
+  const expectedKind = `${effect.effect_type}_transfer`;
+  if (observation.evidence_kind !== expectedKind
+      || String(observation.tx_hash || '').toLowerCase() !== String(effect.tx_hash).toLowerCase()
+      || Number(observation.log_index) !== Number(effect.log_index)) return false;
+  const fields = moralisTransferFields(effect, observation.payload_json || {});
+  return Boolean(fields)
+    && fields.contract === String(effect.token_contract || '').toLowerCase()
+    && fields.from === String(effect.from_address || '').toLowerCase()
+    && fields.to === String(effect.to_address || '').toLowerCase()
+    && fields.value === decimal(effect.value_units)
+    && fields.tokenId === (effect.effect_type === 'erc20' ? null : decimal(effect.token_id));
+}
+
+function matchesLegacyTransfer(effect, row) {
+  return Boolean(effect && row)
+    && TRANSFER_TYPES[effect.effect_type] === row.transfer_type
+    && String(row.tx_hash || '').toLowerCase() === String(effect.tx_hash).toLowerCase()
+    && String(row.from_address || '').toLowerCase() === String(effect.from_address || '').toLowerCase()
+    && String(row.to_address || '').toLowerCase() === String(effect.to_address || '').toLowerCase()
+    && decimal(row.value_wei) === decimal(effect.value_units)
+    && String(row.token_contract || '').toLowerCase() === String(effect.token_contract || '').toLowerCase()
+    && (effect.effect_type === 'erc20'
+      ? row.token_id == null
+      : decimal(row.token_id) === decimal(effect.token_id));
+}
+
+module.exports = {
+  TRANSFER_TYPES,
+  matchesLegacyTransfer,
+  matchesMoralisTransfer,
+};

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -14,6 +14,9 @@ const {
   TOPICS, effectsFromInternalObservations, effectsFromRpc,
 } = require('../src/services/evmAudit/effectDecoder');
 const chains = require('../src/config/chains');
+const {
+  matchesLegacyTransfer, matchesMoralisTransfer,
+} = require('../src/services/evmAudit/corroboratedIdentity');
 
 const WALLET = '0x1111111111111111111111111111111111111111';
 const OTHER = '0x2222222222222222222222222222222222222222';
@@ -276,6 +279,31 @@ test('effect reconciliation counts missing or duplicate economic legs, not just 
   assert.ok(EvmAuditService._unmatchedEffectCount(
     canonical, [uncoordinated], WALLET, chains.getChain(8453)
   ) > 0, 'economic equality without immutable log identity remains a gap');
+});
+
+test('cross-provider transfer repair requires the exact Moralis log coordinate and payload', () => {
+  const effect = {
+    effect_type: 'erc20', effect_key: `erc20:${HASH}:3`, log_index: 3,
+    tx_hash: HASH, from_address: OTHER, to_address: WALLET, value_units: '8',
+    token_contract: CONTRACT, token_id: null,
+  };
+  const moralis = {
+    provider: 'moralis', evidence_kind: 'erc20_transfer', tx_hash: HASH, log_index: 3,
+    payload_json: {
+      address: CONTRACT, from_address: OTHER, to_address: WALLET, value: '8', log_index: 3,
+    },
+  };
+  const legacy = {
+    tx_hash: HASH, transfer_type: 'token', from_address: OTHER, to_address: WALLET,
+    value_wei: '8', token_contract: CONTRACT, token_id: null,
+  };
+  assert.equal(matchesMoralisTransfer(effect, moralis), true);
+  assert.equal(matchesLegacyTransfer(effect, legacy), true);
+  assert.equal(matchesMoralisTransfer(effect, { ...moralis, log_index: 4 }), false);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...moralis, payload_json: { ...moralis.payload_json, value: '9' },
+  }), false);
+  assert.equal(matchesLegacyTransfer(effect, { ...legacy, token_contract: OTHER }), false);
 });
 
 test('audit migration is additive, fail-closed, user-owned, and retires only Base routine state sync', () => {


### PR DESCRIPTION
## What changed

Adds a fail-closed identity-repair pass for legacy EVM transfer rows. A row is upgraded only when the canonical consensus-RPC receipt effect and Moralis independently agree on the exact transaction/log coordinate and economic payload. The existing rule that economic equality alone is insufficient remains unchanged.

The audit records the repair count in durable progress, links Moralis evidence to the canonical effect, and preserves raw evidence and existing rows. Conflicting or ambiguous candidates remain gaps.

## Why

The post-key Base/Gnosis audit still showed legacy-to-canonical identity gaps even though Moralis history was complete, so provider authentication was not the remaining cause.

## Validation

- Focused EVM audit tests: 19 passed
- Full backend test suite: 1,080 passed
- Backend ESLint: passed
- `git diff --check`: passed

Production full audits will be rerun after deployment.