### PR TITLE
fix: match Moralis NFT unit counts

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^5.1.0",
         "express-rate-limit": "^8.4.1",
         "googleapis": "^164.1.0",
+        "json-bigint": "^1.0.0",
         "node-cron": "^4.2.1",
         "pg": "^8.16.3",
         "pino": "^10.3.1",
@@ -2055,6 +2056,8 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^8.4.1",
     "googleapis": "^164.1.0",
+    "json-bigint": "^1.0.0",
     "node-cron": "^4.2.1",
     "pg": "^8.16.3",
     "pino": "^10.3.1",

--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -1032,7 +1032,7 @@ class EvmAudit {
   // coordinate. Upgrade them only when the same receipt effect is proven by
   // consensus RPC and independently corroborated by Moralis at the exact
   // transaction/log coordinate. Economic equality alone remains a gap.
-  static async repairCorroboratedTransferIdentities(userId, subjectId, chainId, throughBlock) {
+  static async repairCorroboratedTransferIdentities(jobId, userId, subjectId, chainId, throughBlock) {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
@@ -1061,20 +1061,22 @@ class EvmAudit {
             AND o.provider = 'moralis'
             AND o.evidence_kind = e.effect_type || '_transfer'
             AND o.tx_hash = e.tx_hash AND o.log_index = e.log_index
+          JOIN evm_job_observations jo
+            ON jo.job_id = $1 AND jo.observation_id = o.id
           JOIN evm_mined_transactions tx
              ON tx.subject_id = e.subject_id AND tx.chain_id = e.chain_id
             AND tx.tx_hash = e.tx_hash
           WHERE EXISTS (
                   SELECT 1 FROM evm_subjects s
-                   WHERE s.id = e.subject_id AND s.user_id = $1
+                   WHERE s.id = e.subject_id AND s.user_id = $2
                 )
-            AND e.subject_id = $2 AND e.chain_id = $3
-            AND tx.block_number <= $4
-            AND e.effect_type = ANY($5::text[])
+            AND e.subject_id = $3 AND e.chain_id = $4
+            AND tx.block_number <= $5
+            AND e.effect_type = ANY($6::text[])
             AND e.resolution_status = 'verified'
             AND tx.resolution_status = 'verified'
           ORDER BY e.id, o.id`,
-        [userId, subjectId, chainId, throughBlock, Object.keys(TRANSFER_TYPES)]
+        [jobId, userId, subjectId, chainId, throughBlock, Object.keys(TRANSFER_TYPES)]
       );
       const legacyResult = await client.query(
         `SELECT * FROM eth_transfers

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -582,7 +582,7 @@ class EvmAuditService {
     // Upgrade only the independently corroborated receipt effects before the
     // strict reconciliation pass; unresolved economic matches remain gaps.
     const identityRepair = await EvmAudit.repairCorroboratedTransferIdentities(
-      job.user_id, job.subject_id, chainId, boundary.number
+      job.id, job.user_id, job.subject_id, chainId, boundary.number
     );
     legacyRows = await EvmAudit.storedTransferRows(
       job.user_id, job.subject_id, chainId, boundary.number

--- a/backend/src/services/evmAudit/MoralisClient.js
+++ b/backend/src/services/evmAudit/MoralisClient.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const crypto = require('node:crypto');
-const JSONbig = require('json-bigint')({ storeAsString: true });
+const JSONbig = require('json-bigint')({ useNativeBigInt: true });
 const { sha256 } = require('./normalizer');
 
 const ROOT = 'https://deep-index.moralis.io/api/v2.2';
@@ -9,7 +9,26 @@ const DEFAULT_SPACING_MS = 250;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const MAX_INLINE_RETRY_MS = 30_000;
 const MAX_ATTEMPTS = 3;
+const NUMERIC_FIELDS = '__evm_json_numeric_fields';
 const queues = new Map();
+
+function normalizeJsonNumbers(value) {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(normalizeJsonNumbers);
+  if (!value || typeof value !== 'object') return value;
+  const normalized = {};
+  const numericFields = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (typeof child === 'bigint') {
+      normalized[key] = child.toString();
+      numericFields.push(key);
+    } else {
+      normalized[key] = normalizeJsonNumbers(child);
+    }
+  }
+  if (numericFields.length) normalized[NUMERIC_FIELDS] = numericFields;
+  return normalized;
+}
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -120,7 +139,7 @@ class MoralisClient {
         }
 
         let body;
-        try { body = JSONbig.parse(text); } catch { body = null; }
+        try { body = normalizeJsonNumbers(JSONbig.parse(text)); } catch { body = null; }
         if (response.ok && body && typeof body === 'object') {
           return {
             body,

--- a/backend/src/services/evmAudit/MoralisClient.js
+++ b/backend/src/services/evmAudit/MoralisClient.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const JSONbig = require('json-bigint')({ storeAsString: true });
 const { sha256 } = require('./normalizer');
 
 const ROOT = 'https://deep-index.moralis.io/api/v2.2';
@@ -119,7 +120,7 @@ class MoralisClient {
         }
 
         let body;
-        try { body = JSON.parse(text); } catch { body = null; }
+        try { body = JSONbig.parse(text); } catch { body = null; }
         if (response.ok && body && typeof body === 'object') {
           return {
             body,

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -11,16 +11,19 @@ function normalizedAddress(value) {
   return /^0x[0-9a-f]{40}$/.test(text) ? text : null;
 }
 
-function quantity(value) {
+function quantity(value, { allowSafeNumber = false } = {}) {
   if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') {
+    return allowSafeNumber && Number.isSafeInteger(value) && value >= 0 ? BigInt(value) : null;
+  }
   if (typeof value !== 'string') return null;
   const text = value.trim();
   if (!/^\d+$/.test(text)) return null;
   try { return BigInt(text); } catch { return null; }
 }
 
-function decimal(value) {
-  const parsed = quantity(value);
+function decimal(value, options) {
+  const parsed = quantity(value, options);
   return parsed == null ? null : parsed.toString();
 }
 
@@ -29,7 +32,10 @@ function moralisTransferFields(effect, payload) {
   const contract = normalizedAddress(payload.address ?? payload.token_address);
   const from = normalizedAddress(payload.from_address ?? payload.from);
   const to = normalizedAddress(payload.to_address ?? payload.to);
-  const value = decimal(standard === 'erc20' ? payload.value : payload.amount);
+  const value = decimal(
+    standard === 'erc20' ? payload.value : payload.amount,
+    { allowSafeNumber: standard === 'erc20' }
+  );
   const tokenId = standard === 'erc20' ? null : decimal(payload.token_id ?? payload.tokenId);
   if (!contract || !from || !to || value == null || (standard !== 'erc20' && tokenId == null)) {
     return null;

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -28,7 +28,9 @@ function moralisTransferFields(effect, payload) {
   const contract = normalizedAddress(payload.address ?? payload.token_address);
   const from = normalizedAddress(payload.from_address ?? payload.from);
   const to = normalizedAddress(payload.to_address ?? payload.to);
-  const value = decimal(payload.value ?? payload.amount ?? payload.value_wei);
+  const value = decimal(standard === 'erc20'
+    ? payload.value ?? payload.value_wei
+    : payload.amount ?? payload.value ?? payload.value_wei);
   const tokenId = standard === 'erc20' ? null : decimal(payload.token_id ?? payload.tokenId);
   if (!contract || !from || !to || value == null || (standard !== 'erc20' && tokenId == null)) {
     return null;

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -29,6 +29,10 @@ function decimal(value, options) {
 
 function moralisTransferFields(effect, payload) {
   const standard = effect.effect_type;
+  const numericFields = payload.__evm_json_numeric_fields;
+  if (standard !== 'erc20' && Array.isArray(numericFields) && numericFields.includes('amount')) {
+    return null;
+  }
   const contract = normalizedAddress(payload.address ?? payload.token_address);
   const from = normalizedAddress(payload.from_address ?? payload.from);
   const to = normalizedAddress(payload.to_address ?? payload.to);

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -13,7 +13,8 @@ function normalizedAddress(value) {
 
 function quantity(value) {
   if (typeof value === 'bigint') return value;
-  const text = String(value ?? '').trim();
+  if (typeof value !== 'string') return null;
+  const text = value.trim();
   if (!/^\d+$/.test(text)) return null;
   try { return BigInt(text); } catch { return null; }
 }

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -30,7 +30,8 @@ function decimal(value, options) {
 function moralisTransferFields(effect, payload) {
   const standard = effect.effect_type;
   const numericFields = payload.__evm_json_numeric_fields;
-  if (standard !== 'erc20' && Array.isArray(numericFields) && numericFields.includes('amount')) {
+  if (standard !== 'erc20' && Array.isArray(numericFields)
+      && numericFields.some((field) => ['amount', 'token_id', 'tokenId'].includes(field))) {
     return null;
   }
   const contract = normalizedAddress(payload.address ?? payload.token_address);

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -28,9 +28,7 @@ function moralisTransferFields(effect, payload) {
   const contract = normalizedAddress(payload.address ?? payload.token_address);
   const from = normalizedAddress(payload.from_address ?? payload.from);
   const to = normalizedAddress(payload.to_address ?? payload.to);
-  const value = decimal(standard === 'erc20'
-    ? payload.value ?? payload.value_wei
-    : payload.amount ?? payload.value ?? payload.value_wei);
+  const value = decimal(standard === 'erc20' ? payload.value : payload.amount);
   const tokenId = standard === 'erc20' ? null : decimal(payload.token_id ?? payload.tokenId);
   if (!contract || !from || !to || value == null || (standard !== 'erc20' && tokenId == null)) {
     return null;

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -354,6 +354,9 @@ test('cross-provider transfer repair requires the exact Moralis log coordinate a
     value_wei: '8', token_contract: CONTRACT, token_id: null,
   };
   assert.equal(matchesMoralisTransfer(effect, moralis), true);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...moralis, payload_json: { ...moralis.payload_json, value: 8 },
+  }), true);
   assert.equal(matchesLegacyTransfer(effect, legacy), true);
   assert.equal(matchesMoralisTransfer(effect, { ...moralis, log_index: 4 }), false);
   assert.equal(matchesMoralisTransfer(effect, {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -362,6 +362,25 @@ test('cross-provider transfer repair requires the exact Moralis log coordinate a
   assert.equal(matchesLegacyTransfer(effect, { ...legacy, token_contract: OTHER }), false);
 });
 
+test('NFT corroboration uses Moralis amount units instead of its non-unit value field', () => {
+  const effect = {
+    effect_type: 'erc1155', effect_key: `erc1155:${HASH}:3:7`, log_index: 3,
+    tx_hash: HASH, from_address: OTHER, to_address: WALLET, value_units: '2',
+    token_contract: CONTRACT, token_id: '7',
+  };
+  const observation = {
+    provider: 'moralis', evidence_kind: 'erc1155_transfer', tx_hash: HASH, log_index: 3,
+    payload_json: {
+      token_address: CONTRACT, from_address: OTHER, to_address: WALLET,
+      amount: '2', value: '0.000000000000000001', token_id: '7',
+    },
+  };
+  assert.equal(matchesMoralisTransfer(effect, observation), true);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...observation, payload_json: { ...observation.payload_json, amount: '3' },
+  }), false);
+});
+
 test('audit migration is additive, fail-closed, user-owned, and retires only Base routine state sync', () => {
   const sql = fs.readFileSync(path.join(__dirname, '../migrations/077_evm_audit_evidence.sql'), 'utf8');
   assert.match(sql, /user_id INT NOT NULL REFERENCES users\(id\) ON DELETE CASCADE/);

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -382,6 +382,9 @@ test('NFT corroboration uses Moralis amount units instead of its non-unit value 
   assert.equal(matchesMoralisTransfer(effect, {
     ...observation, payload_json: { ...observation.payload_json, amount: null, value: '2' },
   }), false);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...observation, payload_json: { ...observation.payload_json, amount: [2] },
+  }), false);
 });
 
 test('audit migration is additive, fail-closed, user-owned, and retires only Base routine state sync', () => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -61,8 +61,9 @@ test('identity repair keeps its canonical-effect query user-scoped', () => {
   const methodStart = source.indexOf('static async repairCorroboratedTransferIdentities');
   const methodEnd = source.indexOf('\n  static async', methodStart + 1);
   const method = source.slice(methodStart, methodEnd);
-  assert.match(method, /s\.user_id = \$1/);
-  assert.match(method, /\[userId, subjectId, chainId, throughBlock/);
+  assert.match(method, /jo\.job_id = \$1/);
+  assert.match(method, /s\.user_id = \$2/);
+  assert.match(method, /\[jobId, userId, subjectId, chainId, throughBlock/);
 });
 
 test('Moralis history keeps receipt, log, internal and token evidence independently', () => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -224,6 +224,21 @@ test('Moralis pagination advances opaque cursors and exhausts exactly once', asy
   }
 });
 
+test('Moralis JSON parsing preserves large numeric token quantities', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => new Response(
+    '{"result":[{"value":650000000000000000}],"cursor":null}',
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  );
+  try {
+    const response = await new MoralisClient('test-key', { spacingMs: 0 })
+      .activeChains(WALLET, ['base']);
+    assert.equal(response.body.result[0].value, '650000000000000000');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test('Moralis requests have an explicit deadline even when fetch never settles', async () => {
   const originalFetch = global.fetch;
   const signals = [];

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -411,6 +411,13 @@ test('NFT corroboration uses Moralis amount units instead of its non-unit value 
       __evm_json_numeric_fields: ['amount'],
     },
   }), false);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...observation,
+    payload_json: {
+      ...observation.payload_json, token_id: '9007199254740992',
+      __evm_json_numeric_fields: ['token_id'],
+    },
+  }), false);
 });
 
 test('audit migration is additive, fail-closed, user-owned, and retires only Base routine state sync', () => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -379,6 +379,9 @@ test('NFT corroboration uses Moralis amount units instead of its non-unit value 
   assert.equal(matchesMoralisTransfer(effect, {
     ...observation, payload_json: { ...observation.payload_json, amount: '3' },
   }), false);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...observation, payload_json: { ...observation.payload_json, amount: null, value: '2' },
+  }), false);
 });
 
 test('audit migration is additive, fail-closed, user-owned, and retires only Base routine state sync', () => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -234,6 +234,7 @@ test('Moralis JSON parsing preserves large numeric token quantities', async () =
     const response = await new MoralisClient('test-key', { spacingMs: 0 })
       .activeChains(WALLET, ['base']);
     assert.equal(response.body.result[0].value, '650000000000000000');
+    assert.deepEqual(response.body.result[0].__evm_json_numeric_fields, ['value']);
   } finally {
     global.fetch = originalFetch;
   }
@@ -402,6 +403,13 @@ test('NFT corroboration uses Moralis amount units instead of its non-unit value 
   }), false);
   assert.equal(matchesMoralisTransfer(effect, {
     ...observation, payload_json: { ...observation.payload_json, amount: [2] },
+  }), false);
+  assert.equal(matchesMoralisTransfer(effect, {
+    ...observation,
+    payload_json: {
+      ...observation.payload_json, amount: '9007199254740992',
+      __evm_json_numeric_fields: ['amount'],
+    },
   }), false);
 });
 


### PR DESCRIPTION
## Summary
- use Moralis amount as the required unit count for ERC-721/ERC-1155
- continue using Moralis value for ERC-20 base units
- fail closed when NFT amount is missing or malformed
- add positive and negative regression coverage

## Evidence
Production audit evidence showed exact transaction/log matches for all Base/Gnosis NFT effects, but every NFT payload failed value corroboration because the matcher selected value instead of amount.

## Validation
- backend npm test (1084 passed)
- backend npm run lint
- git diff --check