### PR TITLE
fix: classify Moralis quota exhaustion

### DIFF
--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -329,7 +329,10 @@ class EvmAuditService {
         progress: { chains_finished: requested.length, gaps },
       });
     } catch (error) {
-      const deferred = ['MORALIS_RATE_LIMITED', 'MORALIS_TRANSPORT_ERROR', 'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR']
+      const deferred = [
+        'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
+        'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR',
+      ]
         .includes(error.code);
       if (String(error.code || '').startsWith('MORALIS_') || String(error.code || '').startsWith('RPC_')) {
         try {
@@ -499,11 +502,12 @@ class EvmAuditService {
           jobId: job.id, scopeId: historyScope.id, provider: 'moralis',
           endpoint: 'transaction-lookup',
           requestParams: { chain: providerConfig.moralis, transaction_hash: hash },
-          outcome: error.code === 'MORALIS_RATE_LIMITED' ? 'deferred' : 'failed',
+          outcome: ['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED'].includes(error.code)
+            ? 'deferred' : 'failed',
           httpStatus: error.httpStatus || null, errorCode: error.code || 'MORALIS_LOOKUP_FAILED',
           errorDetail: publicErrorDetail(error), requestId: error.requestId || null,
         });
-        if (error.code === 'MORALIS_RATE_LIMITED' || error.code === 'MORALIS_AUTH_FAILED') throw error;
+        if (['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_AUTH_FAILED'].includes(error.code)) throw error;
       }
     }
     // Transaction lookups use the same durable scope as the paginated history

--- a/backend/src/services/evmAudit/MoralisClient.js
+++ b/backend/src/services/evmAudit/MoralisClient.js
@@ -48,6 +48,10 @@ function providerError(message, code, extra = {}) {
   return error;
 }
 
+function isQuotaExceeded(detail) {
+  return /(?:plan|quota|usage).*(?:consum|exhaust|limit)|(?:consum|exhaust|limit).*(?:plan|quota|usage)/i.test(detail);
+}
+
 class MoralisClient {
   constructor(apiKey, {
     spacingMs = DEFAULT_SPACING_MS,
@@ -150,12 +154,14 @@ class MoralisClient {
         }
 
         const detail = String(body?.message || body?.error || '').slice(0, 500);
+        const quotaExceeded = isQuotaExceeded(detail);
         const retryable = response.status === 429 && attempt < MAX_ATTEMPTS;
         await this.onFailedAttempt?.({
           provider: 'moralis', endpoint, method: 'GET', attemptNo: attempt,
-          requestParams: params || {}, outcome: retryable ? 'deferred' : 'failed',
+          requestParams: params || {}, outcome: retryable || quotaExceeded ? 'deferred' : 'failed',
           httpStatus: response.status,
           errorCode: response.status === 429 ? 'MORALIS_RATE_LIMITED'
+            : quotaExceeded ? 'MORALIS_QUOTA_EXHAUSTED'
             : [401, 403].includes(response.status) ? 'MORALIS_AUTH_FAILED' : 'MORALIS_API_ERROR',
           errorDetail: detail || `HTTP ${response.status}`,
           requestId: response.headers.get('x-request-id') || null,
@@ -174,6 +180,13 @@ class MoralisClient {
           );
         }
         if (response.status === 401 || response.status === 403) {
+          if (quotaExceeded) {
+            throw providerError(
+              'Moralis daily plan quota is exhausted; audit deferred',
+              'MORALIS_QUOTA_EXHAUSTED',
+              { httpStatus: response.status, retryAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }
+            );
+          }
           throw providerError(
             'Moralis rejected the configured credential',
             'MORALIS_AUTH_FAILED',

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -241,6 +241,30 @@ test('Moralis JSON parsing preserves large numeric token quantities', async () =
   }
 });
 
+test('Moralis plan quota exhaustion is deferred instead of reported as bad credentials', async () => {
+  const originalFetch = global.fetch;
+  const attempts = [];
+  global.fetch = async () => new Response(
+    JSON.stringify({ message: 'Validation service blocked: Your plan: free-plan-daily total included usage has been consumed' }),
+    { status: 401, headers: { 'content-type': 'application/json' } }
+  );
+  try {
+    await assert.rejects(
+      new MoralisClient('test-key', {
+        spacingMs: 0,
+        onFailedAttempt: async (attempt) => attempts.push(attempt),
+      }).activeChains(WALLET, ['base']),
+      (error) => error.code === 'MORALIS_QUOTA_EXHAUSTED'
+        && error.retryAt instanceof Date
+    );
+    assert.equal(attempts.length, 1);
+    assert.equal(attempts[0].errorCode, 'MORALIS_QUOTA_EXHAUSTED');
+    assert.equal(attempts[0].outcome, 'deferred');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test('Moralis requests have an explicit deadline even when fetch never settles', async () => {
   const originalFetch = global.fetch;
   const signals = [];


### PR DESCRIPTION
## Summary
- classify Moralis free-plan quota exhaustion separately from invalid credentials
- defer quota-exhausted audits for the next retry window and retain deferred provider evidence
- add regression coverage for the provider response observed in production

## Validation
- `node --test tests/evmAudit.test.js --test-name-pattern='Moralis plan quota|Moralis JSON parsing|Moralis Retry-After'`
- `npm test` (1086 passed)
- `npm run lint`
