### PR TITLE
feat: audit zkSync Era with bounded Blockscout evidence

### DIFF
--- a/backend/migrations/078_evm_account_feed_evidence.sql
+++ b/backend/migrations/078_evm_account_feed_evidence.sql
@@ -1,0 +1,34 @@
+-- Blockscout account feeds are retained as a distinct raw evidence kind.
+-- Internal traces already have their own semantic kind; normal and token feed
+-- rows must not be relabeled as transactions or logs because their provider
+-- identity and coverage semantics are different.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    WHERE c.conrelid = 'evm_provider_observations'::regclass
+      AND c.conname = 'evm_provider_observations_evidence_kind_check'
+      AND pg_get_constraintdef(c.oid) LIKE '%account_feed%'
+  ) THEN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conrelid = 'evm_provider_observations'::regclass
+        AND conname = 'evm_provider_observations_evidence_kind_check'
+    ) THEN
+      ALTER TABLE evm_provider_observations
+        DROP CONSTRAINT evm_provider_observations_evidence_kind_check;
+    END IF;
+
+    ALTER TABLE evm_provider_observations
+      ADD CONSTRAINT evm_provider_observations_evidence_kind_check CHECK (
+        evidence_kind IN (
+          'active_chain', 'transaction', 'receipt', 'log', 'native_transfer', 'gas',
+          'internal_trace', 'account_feed', 'erc20_transfer', 'erc721_transfer',
+          'erc1155_transfer', 'native_balance', 'token_balance'
+        )
+      );
+  END IF;
+END
+$$;

--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -858,7 +858,7 @@ class EvmAudit {
           SELECT 1 FROM evm_audit_scopes sc
            WHERE sc.job_id = $1 AND sc.chain_id = $2
              AND sc.capability = r.capability
-             AND sc.provider IN ('moralis', 'existing-ledger')
+             AND sc.provider IN ('moralis', 'blockscout', 'existing-ledger')
              AND sc.status = 'complete' AND sc.pagination_exhausted = TRUE
         )`,
       [jobId, chainId]

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -5,6 +5,7 @@ const EvmAudit = require('../models/EvmAudit');
 const EthWallet = require('../models/EthWallet');
 const SecretsService = require('./SecretsService');
 const EthDerivedPipeline = require('./EthDerivedPipeline');
+const EtherscanService = require('./EtherscanService');
 const chains = require('../config/chains');
 const logger = require('../config/logger');
 const MoralisClient = require('./evmAudit/MoralisClient');
@@ -23,9 +24,8 @@ const AUDIT_CHAINS = new Map([
   [100, { moralis: 'gnosis', activeIds: new Set(['0x64', '100', 'gnosis']) }],
   [137, { moralis: 'polygon', activeIds: new Set(['0x89', '137', 'polygon']) }],
   [324, {
-    unsupported: true,
-    errorCode: 'MORALIS_CHAIN_UNSUPPORTED',
-    errorDetail: 'Moralis wallet history does not support zkSync Era; existing ledger coverage remains separate and unproven by this audit.',
+    auditProvider: 'blockscout',
+    errorDetail: 'Moralis does not enumerate zkSync Era; the configured Blockscout account feeds provide finite indexed coverage, while consensus RPC verifies mined transactions and effects.',
   }],
   [8453, { moralis: 'base', activeIds: new Set(['0x2105', '8453', 'base']) }],
   [42161, { moralis: 'arbitrum', activeIds: new Set(['0xa4b1', '42161', 'arbitrum']) }],
@@ -37,6 +37,13 @@ const AUDIT_CHAINS = new Map([
   }],
 ]);
 const OVERLAP_BLOCKS = 64;
+const EXPLORER_FEEDS = Object.freeze([
+  { capability: 'normal', feed: 'normal', method: 'fetchNormalTxs' },
+  { capability: 'internal', feed: 'internal', method: 'fetchInternalTxs' },
+  { capability: 'erc20', feed: 'erc20', method: 'fetchTokenTxs' },
+  { capability: 'erc721', feed: 'erc721', method: 'fetchNftTxs' },
+  { capability: 'erc1155', feed: 'erc1155', method: 'fetch1155Txs' },
+]);
 const OWNER = `${process.pid}:${crypto.randomUUID()}`;
 const queuedLocally = new Set();
 let resumeTimer = null;
@@ -193,6 +200,14 @@ function publicErrorDetail(error) {
   return String(error?.message || 'Audit failed').slice(0, 500);
 }
 
+function isBlockscoutTransient(error) {
+  const status = Number(error?.response?.status || error?.status);
+  return [408, 425].includes(status)
+    || (status >= 500 && status <= 599)
+    || ['EXPLORER_RATE_LIMITED', 'ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET', 'EAI_AGAIN', 'ERR_NETWORK']
+      .includes(error?.code);
+}
+
 function assertLease(leaseState) {
   if (!leaseState?.lost) return;
   const error = new Error('EVM audit lease ownership was lost; this worker stopped before further writes.');
@@ -291,7 +306,9 @@ class EvmAuditService {
     heartbeatTimer.unref?.();
     try {
       const requested = (job.requested_chains || []).map(Number).filter((id) => AUDIT_CHAINS.has(id));
-      const providerRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).moralis);
+      const moralisRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).moralis);
+      const explorerRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).auditProvider);
+      const providerRequested = [...new Set([...moralisRequested, ...explorerRequested])];
       const unsupportedRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).unsupported);
       if (!requested.length) {
         return EvmAudit.finish(jobId, OWNER, 'unsupported', {
@@ -300,7 +317,7 @@ class EvmAuditService {
       }
 
       let key = null;
-      if (providerRequested.length) {
+      if (moralisRequested.length) {
         key = await SecretsService.getUserKey(job.user_id, 'moralis');
         if (!key) {
           return EvmAudit.finish(jobId, OWNER, 'deferred', {
@@ -314,7 +331,7 @@ class EvmAuditService {
         }
       }
       const credentialGeneration = await EvmAudit.credentialGeneration(job.user_id);
-      if (providerRequested.length && job.credential_generation
+      if (moralisRequested.length && job.credential_generation
           && credentialGeneration
           && new Date(job.credential_generation).getTime() !== new Date(credentialGeneration).getTime()) {
         return EvmAudit.finish(jobId, OWNER, 'failed', {
@@ -330,14 +347,14 @@ class EvmAuditService {
           logger.warn({ err: error, auditJobId: jobId }, 'Failed to retain provider attempt evidence');
         }
       };
-      const moralis = providerRequested.length ? new MoralisClient(key, { onFailedAttempt: retainAttempt }) : null;
+      const moralis = moralisRequested.length ? new MoralisClient(key, { onFailedAttempt: retainAttempt }) : null;
 
       let activeResponse = { body: { active_chains: [] } };
       let activeRows = [];
-      if (providerRequested.length) {
+      if (moralisRequested.length) {
         await EvmAudit.heartbeat(jobId, OWNER, { stage: 'discovering' });
         activeResponse = await moralis.activeChains(
-          job.address, providerRequested.map((id) => AUDIT_CHAINS.get(id).moralis)
+          job.address, moralisRequested.map((id) => AUDIT_CHAINS.get(id).moralis)
         );
         assertLease(leaseState);
         activeRows = Array.isArray(activeResponse.body.active_chains) ? activeResponse.body.active_chains : [];
@@ -348,6 +365,13 @@ class EvmAuditService {
           return {
             chain_id: chainId, active_hint: false, bounded: false,
             status: 'unsupported', error_code: config.errorCode, error_detail: config.errorDetail,
+          };
+        }
+        if (config.auditProvider) {
+          return {
+            chain_id: chainId, active_hint: null, bounded: false,
+            status: 'configured', source: config.auditProvider,
+            detail: config.errorDetail,
           };
         }
         const row = activeRows.find((candidate) => activeRowMatches(candidate, config));
@@ -379,13 +403,18 @@ class EvmAuditService {
     } catch (error) {
       const deferred = [
         'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
-        'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR',
+        'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED',
+        'BLOCKSCOUT_TRANSPORT_ERROR',
       ]
         .includes(error.code);
-      if (String(error.code || '').startsWith('MORALIS_') || String(error.code || '').startsWith('RPC_')) {
+      const errorCode = String(error.code || '');
+      const provider = errorCode.startsWith('MORALIS_') ? 'moralis'
+        : errorCode.startsWith('RPC_') ? 'consensus-rpc' : 'blockscout';
+      if (errorCode.startsWith('MORALIS_') || errorCode.startsWith('RPC_')
+          || errorCode.startsWith('BLOCKSCOUT_')) {
         try {
           await EvmAudit.recordProviderAttempt({
-            jobId, provider: String(error.code).startsWith('MORALIS_') ? 'moralis' : 'consensus-rpc',
+            jobId, provider,
             endpoint: job.stage || 'audit-worker', requestParams: { requested_chains: job.requested_chains || [] },
             outcome: deferred ? 'deferred' : 'failed', httpStatus: error.httpStatus || null,
             errorCode: error.code || 'EVM_AUDIT_FAILED', errorDetail: publicErrorDetail(error),
@@ -420,73 +449,219 @@ class EvmAuditService {
   static async runChain({ job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt }) {
     const chain = chains.getChain(chainId);
     const providerConfig = AUDIT_CHAINS.get(chainId);
+    const auditProvider = providerConfig.moralis ? 'moralis' : providerConfig.auditProvider;
     const rpc = new RpcClient(chainId, { onFailedAttempt: retainAttempt });
     const boundary = await rpc.finalizedBoundary();
     const context = {
       jobId: job.id, subjectId: job.subject_id, chainId,
-      address: job.address, provider: 'moralis', chain,
+      address: job.address, provider: auditProvider, chain,
     };
     await EvmAudit.heartbeat(job.id, OWNER, {
       stage: 'fetching', progress: { current_chain: chainId, boundary_block: boundary.number },
     });
 
     const activeScope = await EvmAudit.upsertScope(job.id, {
-      chainId, provider: 'moralis', capability: 'active_chain', status: 'running',
+      chainId, provider: auditProvider, capability: 'active_chain', status: 'running',
       fromBlock: 0, throughBlock: boundary.number, throughHash: boundary.hash,
     });
-    const activeBody = {
-      active_chains: (activeResponse.body.active_chains || [])
-        .filter((row) => activeRowMatches(row, providerConfig)),
-    };
-    await EvmAudit.commitPage(activeScope.id, pageRecord(
-      'moralis', 'active-chain-discovery', {
-        chains: (job.requested_chains || []).map((id) => AUDIT_CHAINS.get(Number(id))?.moralis).filter(Boolean),
-      },
-      activeResponse, null, null, activeBody.active_chains.length
-    ), normalizer.activeChainObservations(context, activeBody));
-    // Active-chain discovery is a hint, not proof of historical absence.
-    await EvmAudit.completeScope(activeScope.id, { status: 'unverified', paginationExhausted: false });
+    if (providerConfig.moralis) {
+      const activeBody = {
+        active_chains: (activeResponse.body.active_chains || [])
+          .filter((row) => activeRowMatches(row, providerConfig)),
+      };
+      await EvmAudit.commitPage(activeScope.id, pageRecord(
+        'moralis', 'active-chain-discovery', {
+          chains: (job.requested_chains || []).map((id) => AUDIT_CHAINS.get(Number(id))?.moralis).filter(Boolean),
+        },
+        activeResponse, null, null, activeBody.active_chains.length
+      ), normalizer.activeChainObservations(context, activeBody));
+      // Active-chain discovery is a hint, not proof of historical absence.
+      await EvmAudit.completeScope(activeScope.id, { status: 'unverified', paginationExhausted: false });
+    } else {
+      await EvmAudit.commitPage(activeScope.id, pageRecord(
+        auditProvider, 'indexed-account-feed-boundary', {
+          chain_id: chainId, boundary_block: boundary.number,
+        },
+        { body: { chain_id: chainId, boundary_block: boundary.number, active_discovery: 'not_supported' } },
+        null, null, 0
+      ), []);
+      await EvmAudit.completeScope(activeScope.id, {
+        status: 'unverified', paginationExhausted: false,
+        errorCode: 'ACTIVE_DISCOVERY_UNSUPPORTED',
+        errorDetail: 'This explorer exposes finite account-feed coverage but no active-chain discovery endpoint.',
+      });
+    }
 
+    let indexedBoundary = null;
+    if (!providerConfig.moralis) {
+      try {
+        indexedBoundary = await EtherscanService.coverageBoundary(null, chainId);
+      } catch (error) {
+        const transient = isBlockscoutTransient(error);
+        const rateLimited = error.code === 'EXPLORER_RATE_LIMITED';
+        const wrapped = new Error(`Blockscout indexed boundary failed: ${publicErrorDetail(error)}`);
+        wrapped.code = rateLimited ? 'BLOCKSCOUT_RATE_LIMITED'
+          : transient ? 'BLOCKSCOUT_TRANSPORT_ERROR' : 'BLOCKSCOUT_BOUNDARY_FAILED';
+        wrapped.httpStatus = error.response?.status || error.httpStatus || null;
+        wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
+        await EvmAudit.recordProviderAttempt({
+          jobId: job.id, scopeId: activeScope.id, provider: auditProvider,
+          endpoint: 'indexed-boundary', requestParams: { chain_id: chainId },
+          outcome: transient ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
+          errorCode: wrapped.code, errorDetail: publicErrorDetail(wrapped),
+        });
+        throw wrapped;
+      }
+    }
+    const sourceThroughBlock = providerConfig.moralis
+      ? boundary.number : Math.min(boundary.number, indexedBoundary.throughBlock);
     const prior = job.mode === 'incremental'
-      ? await EvmAudit.latestCoverage(job.subject_id, chainId, 'moralis', 'wallet_history')
+      ? await EvmAudit.latestCoverage(job.subject_id, chainId, auditProvider, 'wallet_history')
       : null;
     const fromBlock = prior ? Math.max(0, Number(prior.through_block) - OVERLAP_BLOCKS) : 0;
     const historyScope = await EvmAudit.upsertScope(job.id, {
-      chainId, provider: 'moralis', capability: 'wallet_history', status: 'running',
-      fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
+      chainId, provider: auditProvider, capability: 'wallet_history', status: 'running',
+      fromBlock, throughBlock: sourceThroughBlock,
+      throughHash: providerConfig.moralis ? boundary.hash : null,
     });
     const hashes = new Set();
-    let cursor = historyScope.provider_cursor || null;
-    for await (const page of moralis.walletHistoryPages(job.address, {
-      chain: providerConfig.moralis, fromBlock, throughBlock: boundary.number, cursor,
-    })) {
-      assertLease(leaseState);
-      const observations = page.items.flatMap((item) => normalizer.historyObservations(context, item));
-      for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
-      await EvmAudit.commitPage(historyScope.id, pageRecord(
-        'moralis', 'wallet-history', {
-          chain: providerConfig.moralis, from_block: fromBlock, to_block: boundary.number,
-        }, page, page.cursorIn, page.cursorOut, page.items.length
-      ), observations);
-      cursor = page.cursorOut;
-      await EvmAudit.heartbeat(job.id, OWNER, { progress: { current_cursor: cursor, transactions_seen: hashes.size } });
-    }
-    await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
-    await EvmAudit.acceptCoverage({
-      subjectId: job.subject_id, chainId, provider: 'moralis', capability: 'wallet_history',
-      fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
-      paginationExhausted: true, status: 'complete', jobId: job.id,
-    });
-    // One exhausted Moralis history stream carries these six ordinary
-    // capabilities. Keep their finite bounds explicit; RPC receipt lookups
-    // remain a separate non-enumerating scope.
-    for (const capability of ['normal', 'internal', 'erc20', 'erc721', 'erc1155', 'native_credit']) {
-      const capabilityScope = await EvmAudit.upsertScope(job.id, {
-        chainId, provider: 'moralis', capability, status: 'running',
+    if (providerConfig.moralis) {
+      let cursor = historyScope.provider_cursor || null;
+      for await (const page of moralis.walletHistoryPages(job.address, {
+        chain: providerConfig.moralis, fromBlock, throughBlock: boundary.number, cursor,
+      })) {
+        assertLease(leaseState);
+        const observations = page.items.flatMap((item) => normalizer.historyObservations(context, item));
+        for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
+        await EvmAudit.commitPage(historyScope.id, pageRecord(
+          'moralis', 'wallet-history', {
+            chain: providerConfig.moralis, from_block: fromBlock, to_block: boundary.number,
+          }, page, page.cursorIn, page.cursorOut, page.items.length
+        ), observations);
+        cursor = page.cursorOut;
+        await EvmAudit.heartbeat(job.id, OWNER, { progress: { current_cursor: cursor, transactions_seen: hashes.size } });
+      }
+      await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
+      await EvmAudit.acceptCoverage({
+        subjectId: job.subject_id, chainId, provider: 'moralis', capability: 'wallet_history',
         fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
+        paginationExhausted: true, status: 'complete', jobId: job.id,
       });
-      await EvmAudit.completeScope(capabilityScope.id, {
+      // One exhausted Moralis history stream carries these six ordinary
+      // capabilities. Keep their finite bounds explicit; RPC receipt lookups
+      // remain a separate non-enumerating scope.
+      for (const capability of ['normal', 'internal', 'erc20', 'erc721', 'erc1155', 'native_credit']) {
+        const capabilityScope = await EvmAudit.upsertScope(job.id, {
+          chainId, provider: 'moralis', capability, status: 'running',
+          fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
+        });
+        await EvmAudit.completeScope(capabilityScope.id, {
+          status: 'complete', paginationExhausted: true,
+        });
+      }
+    } else {
+      for (const feedSpec of EXPLORER_FEEDS) {
+        assertLease(leaseState);
+        const feedPrior = job.mode === 'incremental'
+          ? await EvmAudit.latestCoverage(job.subject_id, chainId, auditProvider, feedSpec.capability)
+          : null;
+        const feedFromBlock = feedPrior
+          ? Math.max(0, Number(feedPrior.through_block) - OVERLAP_BLOCKS) : 0;
+        const feedScope = await EvmAudit.upsertScope(job.id, {
+          chainId, provider: auditProvider, capability: feedSpec.capability, status: 'running',
+          fromBlock: feedFromBlock, throughBlock: sourceThroughBlock, throughHash: null,
+        });
+        let rows;
+        try {
+          rows = await EtherscanService[feedSpec.method](
+            job.address, feedFromBlock, null, chainId, sourceThroughBlock
+          );
+        } catch (error) {
+          const transient = isBlockscoutTransient(error);
+          const rateLimited = error.code === 'EXPLORER_RATE_LIMITED';
+          const wrapped = new Error(`Blockscout ${feedSpec.feed} audit feed failed: ${publicErrorDetail(error)}`);
+          wrapped.code = rateLimited ? 'BLOCKSCOUT_RATE_LIMITED'
+            : transient ? 'BLOCKSCOUT_TRANSPORT_ERROR' : 'BLOCKSCOUT_FEED_FAILED';
+          wrapped.httpStatus = error.response?.status || error.httpStatus || null;
+          wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
+          await EvmAudit.recordProviderAttempt({
+            jobId: job.id, scopeId: feedScope.id, provider: auditProvider,
+            endpoint: `account-${feedSpec.feed}`,
+            requestParams: { address: job.address, from_block: feedFromBlock, to_block: sourceThroughBlock },
+            outcome: transient ? 'deferred' : 'failed',
+            httpStatus: wrapped.httpStatus, errorCode: wrapped.code,
+            errorDetail: publicErrorDetail(wrapped),
+          });
+          throw wrapped;
+        }
+        if (!Array.isArray(rows)) {
+          const error = new Error(`Blockscout ${feedSpec.feed} audit feed returned a non-array response`);
+          error.code = 'BLOCKSCOUT_FEED_FAILED';
+          throw error;
+        }
+        const pageSize = 500;
+        for (let offset = 0; offset < Math.max(rows.length, 1); offset += pageSize) {
+          assertLease(leaseState);
+          const pageRows = rows.slice(offset, offset + pageSize);
+          const observations = normalizer.explorerFeedObservations(
+            context, feedSpec.feed, pageRows
+          );
+          for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
+          await EvmAudit.commitPage(feedScope.id, pageRecord(
+            auditProvider, `account-${feedSpec.feed}`,
+            { address: job.address, from_block: feedFromBlock, to_block: sourceThroughBlock },
+            { body: { feed: feedSpec.feed, rows: pageRows } },
+            String(offset), offset + pageRows.length >= rows.length ? null : String(offset + pageRows.length),
+            pageRows.length
+          ), observations);
+          await EvmAudit.heartbeat(job.id, OWNER, {
+            progress: { current_feed: feedSpec.feed, transactions_seen: hashes.size },
+          });
+        }
+        await EvmAudit.completeScope(feedScope.id, {
+          status: 'complete', paginationExhausted: true,
+        });
+        await EvmAudit.acceptCoverage({
+          subjectId: job.subject_id, chainId, provider: auditProvider,
+          capability: feedSpec.capability, fromBlock: feedFromBlock,
+          throughBlock: sourceThroughBlock, throughHash: null,
+          paginationExhausted: true, status: 'complete', jobId: job.id,
+        });
+      }
+      const nativeCreditScope = await EvmAudit.upsertScope(job.id, {
+        chainId, provider: auditProvider, capability: 'native_credit', status: 'running',
+        fromBlock: 0, throughBlock: sourceThroughBlock, throughHash: null,
+      });
+      await EvmAudit.commitPage(nativeCreditScope.id, pageRecord(
+        auditProvider, 'native-credit-not-applicable', { chain_id: chainId },
+        { body: { chain_id: chainId, status: 'not_applicable' } }, null, null, 0
+      ), []);
+      await EvmAudit.completeScope(nativeCreditScope.id, {
         status: 'complete', paginationExhausted: true,
+        errorCode: 'NOT_APPLICABLE',
+        errorDetail: 'This chain has no configured account-independent native-credit feed; receipt logs remain canonical evidence.',
+      });
+      const foundBlocks = [...hashes].length
+        ? [...(await EvmAudit.observationsForJob(job.id, { chainId }))]
+          .filter((row) => row.provider === auditProvider && row.block_number != null)
+          .map((row) => Number(row.block_number)).filter(Number.isSafeInteger)
+        : [];
+      const discoveredChain = discovered.find((row) => row.chain_id === chainId);
+      if (discoveredChain) {
+        discoveredChain.active_hint = hashes.size > 0;
+        discoveredChain.active_hint_proven = false;
+        discoveredChain.bounded = true;
+        discoveredChain.status = 'bounded';
+        discoveredChain.source = auditProvider;
+        discoveredChain.first_block = foundBlocks.length ? Math.min(...foundBlocks) : null;
+        discoveredChain.last_block = foundBlocks.length ? Math.max(...foundBlocks) : null;
+      }
+      await EvmAudit.setDiscoveredChains(job.id, OWNER, discovered);
+      await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
+      await EvmAudit.acceptCoverage({
+        subjectId: job.subject_id, chainId, provider: auditProvider, capability: 'wallet_history',
+        fromBlock, throughBlock: sourceThroughBlock, throughHash: null,
+        paginationExhausted: true, status: 'complete', jobId: job.id,
       });
     }
     let legacyRows = await EvmAudit.storedTransferRows(job.user_id, job.subject_id, chainId, boundary.number);
@@ -537,36 +712,41 @@ class EvmAuditService {
     }
     for (const row of legacyRows) hashes.add(String(row.tx_hash).toLowerCase());
 
-    const moralisHashes = new Set((await EvmAudit.observationsForJob(job.id, { chainId, evidenceKind: 'transaction' }))
-      .filter((row) => row.provider === 'moralis').map((row) => row.tx_hash));
+    const providerTransactionHashes = new Set((await EvmAudit.observationsForJob(
+      job.id, { chainId }
+    ))
+      .filter((row) => row.provider === auditProvider && row.tx_hash)
+      .map((row) => row.tx_hash));
     // A restart may resume at a later provider cursor or overlap boundary.
     // Rehydrate every hash already linked to this durable job so previously
     // committed pages can never disappear from canonicalization.
-    for (const hash of moralisHashes) hashes.add(hash);
+    for (const hash of providerTransactionHashes) hashes.add(hash);
     let providerLookupGaps = 0;
-    for (const hash of hashes) {
-      if (moralisHashes.has(hash)) continue;
-      try {
-        const lookup = await moralis.transactionByHash(hash, providerConfig.moralis);
-        assertLease(leaseState);
-        const item = lookup.body;
-        const observations = normalizer.historyObservations(context, item);
-        await EvmAudit.commitPage(historyScope.id, pageRecord(
-          'moralis', 'transaction-lookup', { chain: providerConfig.moralis, transaction_hash: hash },
-          lookup, null, null, 1
-        ), observations);
-      } catch (error) {
-        providerLookupGaps += 1;
-        await EvmAudit.recordProviderAttempt({
-          jobId: job.id, scopeId: historyScope.id, provider: 'moralis',
-          endpoint: 'transaction-lookup',
-          requestParams: { chain: providerConfig.moralis, transaction_hash: hash },
-          outcome: ['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED'].includes(error.code)
-            ? 'deferred' : 'failed',
-          httpStatus: error.httpStatus || null, errorCode: error.code || 'MORALIS_LOOKUP_FAILED',
-          errorDetail: publicErrorDetail(error), requestId: error.requestId || null,
-        });
-        if (['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_AUTH_FAILED'].includes(error.code)) throw error;
+    if (providerConfig.moralis) {
+      for (const hash of hashes) {
+        if (providerTransactionHashes.has(hash)) continue;
+        try {
+          const lookup = await moralis.transactionByHash(hash, providerConfig.moralis);
+          assertLease(leaseState);
+          const item = lookup.body;
+          const observations = normalizer.historyObservations(context, item);
+          await EvmAudit.commitPage(historyScope.id, pageRecord(
+            'moralis', 'transaction-lookup', { chain: providerConfig.moralis, transaction_hash: hash },
+            lookup, null, null, 1
+          ), observations);
+        } catch (error) {
+          providerLookupGaps += 1;
+          await EvmAudit.recordProviderAttempt({
+            jobId: job.id, scopeId: historyScope.id, provider: 'moralis',
+            endpoint: 'transaction-lookup',
+            requestParams: { chain: providerConfig.moralis, transaction_hash: hash },
+            outcome: ['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED'].includes(error.code)
+              ? 'deferred' : 'failed',
+            httpStatus: error.httpStatus || null, errorCode: error.code || 'MORALIS_LOOKUP_FAILED',
+            errorDetail: publicErrorDetail(error), requestId: error.requestId || null,
+          });
+          if (['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_AUTH_FAILED'].includes(error.code)) throw error;
+        }
       }
     }
     // Transaction lookups use the same durable scope as the paginated history
@@ -793,3 +973,4 @@ class EvmAuditService {
 module.exports = EvmAuditService;
 module.exports._missingRanges = missingRanges;
 module.exports._unmatchedEffectCount = unmatchedEffectCount;
+module.exports._isBlockscoutTransient = isBlockscoutTransient;

--- a/backend/src/services/evmAudit/effectDecoder.js
+++ b/backend/src/services/evmAudit/effectDecoder.js
@@ -233,6 +233,7 @@ function effectsFromRpc(context, transaction, receipt, observationIds = new Map(
 function internalObservationFields(observation, wallet) {
   const payload = observation.payload_json || {};
   if (payload.is_error === true || payload.is_error === '1'
+      || payload.isError === true || payload.isError === '1'
       || payload.success === false || payload.error != null) return null;
   const from = normalizedAddress(payload.from_address ?? payload.from);
   const to = normalizedAddress(payload.to_address ?? payload.to);
@@ -243,10 +244,12 @@ function internalObservationFields(observation, wallet) {
 }
 
 // Receipts cannot prove internal calls. Promote trace-provider evidence without
-// pretending it is consensus evidence. When Moralis and the existing ledger
-// independently contain one unambiguous identical effect, retain both evidence
-// links and mark that effect verified; otherwise it remains provisional and
-// therefore blocks a gap-free audit.
+// pretending it is consensus evidence. When an independent trace provider and
+// the existing ledger contain one unambiguous identical effect, retain both
+// evidence links and mark that effect verified; otherwise it remains provisional
+// and therefore blocks a gap-free audit. Moralis takes precedence when both
+// independent providers are present; Blockscout is the fallback for chains
+// where Moralis does not enumerate history.
 function effectsFromInternalObservations(context, observations) {
   const wallet = context.address.toLowerCase();
   const byTransaction = new Map();
@@ -260,7 +263,10 @@ function effectsFromInternalObservations(context, observations) {
   const effects = [];
   for (const [hash, rows] of byTransaction) {
     const moralis = rows.filter((row) => row.provider === 'moralis');
-    const selected = moralis.length ? moralis : rows.filter((row) => row.provider === 'existing-ledger');
+    const explorer = rows.filter((row) => row.provider === 'blockscout');
+    const selectedProvider = moralis.length ? 'moralis'
+      : explorer.length ? 'blockscout' : 'existing-ledger';
+    const selected = rows.filter((row) => row.provider === selectedProvider);
     const legacyBySignature = new Map();
     for (const row of rows.filter((candidate) => candidate.provider === 'existing-ledger')) {
       const fields = internalObservationFields(row, wallet);
@@ -282,7 +288,8 @@ function effectsFromInternalObservations(context, observations) {
       const fields = internalObservationFields(row, wallet);
       if (!fields) continue;
       const signature = `${fields.from}:${fields.to}:${fields.value}`;
-      const legacyMatches = row.provider === 'moralis' ? (legacyBySignature.get(signature) || []) : [];
+      const legacyMatches = ['moralis', 'blockscout'].includes(row.provider)
+        ? (legacyBySignature.get(signature) || []) : [];
       const independentlyVerified = row.trace_address != null
         && legacyMatches.length === 1
         && legacyMatches[0].trace_address != null

--- a/backend/src/services/evmAudit/normalizer.js
+++ b/backend/src/services/evmAudit/normalizer.js
@@ -244,6 +244,35 @@ function legacyTransferObservations(context, rows) {
   }));
 }
 
+function explorerFeedObservations(context, feed, rows) {
+  const evidenceKind = feed === 'internal' ? 'internal_trace' : 'account_feed';
+  return rows.map((row) => {
+    const hash = txHash(row.hash || row.transactionHash);
+    if (!hash) throw new Error(`Explorer ${feed} feed returned an invalid transaction hash`);
+    const traceAddress = feed === 'internal'
+      ? (row.traceAddress ?? row.trace_address
+        ?? (/^\d+(?:_\d+)*$/.test(String(row.traceId || ''))
+          ? String(row.traceId).split('_').map(Number) : null))
+      : null;
+    const logIndex = feed === 'internal' ? null : safeInteger(row.logIndex);
+    const tokenId = row.tokenID ?? row.token_id ?? '';
+    const coordinate = feed === 'internal'
+      ? (traceAddress == null ? `provider:${sha256(row)}` : stableJson(traceAddress))
+      : (logIndex == null ? `provider:${sha256(row)}` : `${logIndex}:${tokenId}`);
+    return baseObservation(context, {
+      evidenceKind,
+      providerObjectKey: `account:${feed}:${hash}:${coordinate}`,
+      payload: row,
+      tx: hash,
+      blockNumber: row.blockNumber,
+      block: row.blockHash,
+      transactionIndex: row.transactionIndex,
+      logIndex,
+      traceAddress,
+    });
+  });
+}
+
 function transactionFromRpc(context, transaction, receipt, selectedObservationId) {
   const wallet = context.address.toLowerCase();
   const sender = address(transaction.from);
@@ -284,6 +313,7 @@ module.exports = {
   blockHash,
   canonicalize,
   decimalInteger,
+  explorerFeedObservations,
   historyObservations,
   legacyTransferObservations,
   rpcTransactionObservations,

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -59,13 +59,19 @@ test('unsupported audit chains become explicit amber scopes without a provider r
     return scope;
   };
   try {
-    assert.equal(await EvmAuditService.runUnsupportedChain({ job: { id: 7 }, chainId: 324 }), 1);
+    assert.equal(await EvmAuditService.runUnsupportedChain({ job: { id: 7 }, chainId: 32401 }), 1);
     assert.equal(scopes.length, 13);
     assert.ok(scopes.every((scope) => scope.status === 'unsupported'));
-    assert.ok(scopes.every((scope) => scope.errorCode === 'MORALIS_CHAIN_UNSUPPORTED'));
+    assert.ok(scopes.every((scope) => scope.errorCode === 'NON_EVM_CHAIN'));
   } finally {
     EvmAudit.upsertScope = originalUpsertScope;
   }
+});
+
+test('zkSync Era uses bounded Blockscout audit coverage instead of unsupported status', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
+  assert.match(source, /\[324, \{\s*auditProvider: 'blockscout'/);
+  assert.doesNotMatch(source, /\[324, \{\s*unsupported:/);
 });
 
 test('stable evidence hashes ignore object key order but not payload changes', () => {
@@ -118,6 +124,40 @@ test('Moralis history keeps receipt, log, internal and token evidence independen
     'an internal call without trace coordinates stays provider-scoped');
 });
 
+test('Blockscout account-feed evidence preserves internal trace identity and raw rows', () => {
+  const rows = normalizer.explorerFeedObservations({ ...context(324), provider: 'blockscout' }, 'internal', [{
+    hash: HASH, blockNumber: '12', blockHash: BLOCK_HASH, transactionIndex: '3',
+    traceId: '3_1', from: OTHER, to: WALLET, value: '7', isError: '0',
+  }]);
+  assert.equal(rows[0].provider, 'blockscout');
+  assert.equal(rows[0].evidenceKind, 'internal_trace');
+  assert.deepEqual(rows[0].traceAddress, [3, 1]);
+  assert.equal(rows[0].payload.value, '7');
+});
+
+test('Blockscout normal and token feeds use the additive account-feed evidence kind', () => {
+  const feeds = ['normal', 'erc20', 'erc721', 'erc1155'];
+  for (const feed of feeds) {
+    const [observation] = normalizer.explorerFeedObservations(
+      { ...context(324), provider: 'blockscout' },
+      feed,
+      [{ hash: HASH, blockNumber: '10', logIndex: '2', tokenID: '9' }]
+    );
+    assert.equal(observation.evidenceKind, 'account_feed');
+  }
+  const migration = fs.readFileSync(
+    path.join(__dirname, '../migrations/078_evm_account_feed_evidence.sql'), 'utf8'
+  );
+  assert.match(migration, /'account_feed'/);
+});
+
+test('Blockscout transient provider failures defer instead of becoming permanent gaps', () => {
+  assert.equal(EvmAuditService._isBlockscoutTransient({ response: { status: 408 } }), true);
+  assert.equal(EvmAuditService._isBlockscoutTransient({ response: { status: 503 } }), true);
+  assert.equal(EvmAuditService._isBlockscoutTransient({ code: 'EAI_AGAIN' }), true);
+  assert.equal(EvmAuditService._isBlockscoutTransient({ response: { status: 400 } }), false);
+});
+
 test('consensus canonicalization retains failed mined outgoing transactions and gas', () => {
   const transaction = {
     hash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH, transactionIndex: '0x2',
@@ -168,6 +208,30 @@ test('internal effects remain provisional unless Moralis and stored evidence mat
   }]);
   assert.equal(matched[0].resolutionStatus, 'provisional',
     'amount and counterparties cannot substitute for trace identity');
+});
+
+test('Blockscout internal evidence can corroborate the existing ledger when Moralis is unavailable', () => {
+  const payload = { from: OTHER, to: WALLET, value: '7', isError: '0' };
+  const blockscout = {
+    id: 11, provider: 'blockscout', provider_object_key: `account:internal:${HASH}:3`,
+    tx_hash: HASH, trace_address: [3, 1], payload_json: payload,
+  };
+  const ledger = {
+    id: 12, provider: 'existing-ledger', provider_object_key: `legacy:internal:${HASH}:0`,
+    tx_hash: HASH, trace_address: [3, 1],
+    payload_json: { from_address: OTHER, to_address: WALLET, value_wei: '7', is_error: false },
+  };
+  const effects = effectsFromInternalObservations(context(324), [blockscout, ledger]);
+  assert.equal(effects[0].resolutionStatus, 'verified');
+  assert.deepEqual(effects[0].evidenceObservationIds, [11, 12]);
+});
+
+test('failed Blockscout internal traces never become economic effects', () => {
+  const effects = effectsFromInternalObservations(context(324), [{
+    id: 13, provider: 'blockscout', tx_hash: HASH, trace_address: [3, 1],
+    payload_json: { from: OTHER, to: WALLET, value: '7', isError: '1' },
+  }]);
+  assert.deepEqual(effects, []);
 });
 
 test('OP Stack protocol deposits never consume the user nonce sequence', () => {
@@ -347,7 +411,9 @@ test('Moralis request deadlines cover body reads and abort before retrying', asy
 
 test('Moralis history scope is finalized after transaction lookup pages', () => {
   const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
-  const lookupPass = source.indexOf("for (const hash of hashes) {\n      if (moralisHashes.has(hash)) continue;");
+  assert.ok(source.includes("job.id, { chainId }"),
+    'restart rehydration must inspect all provider evidence kinds, including explorer feeds');
+  const lookupPass = source.indexOf("for (const hash of hashes) {\n        if (providerTransactionHashes.has(hash)) continue;");
   const canonicalization = source.indexOf("await EvmAudit.heartbeat(job.id, OWNER, { stage: 'canonicalizing' });", lookupPass);
   const finalization = source.indexOf(
     "await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });",


### PR DESCRIPTION
## Summary

- add zkSync Era (chain 324) as a bounded Blockscout audit source instead of reporting it as unsupported
- preserve raw normal, internal, ERC-20, ERC-721, and ERC-1155 account-feed evidence with stable provider identities
- canonicalize mined transactions and effects through consensus RPC, with Moralis taking precedence when both providers corroborate internal traces
- classify Blockscout transport/rate-limit failures as durable deferred status and keep finite coverage boundaries explicit
- fix restart/idempotency rehydration so committed evidence from either audit provider is reused

## Validation

- backend lint
- backend tests: 1,092 passed
- focused EVM audit tests: 31 passed
- ledger verification: all 92 checks passed
- safe public zkSync canary: indexed boundary and normal feed responded; the public internal-trace endpoint timed out and is therefore fail-closed/deferred

The production user's wallet address was not sent for a canary. A real audit still needs to run after deployment using the user's configured key, and the result must be reviewed against the finite provider coverage and reconciliation gates.