### PR TITLE
fix: retry deferred audits after key updates

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -102,7 +102,29 @@ class EvmAudit {
         [subject.id, ACTIVE_JOB_STATUSES]
       );
       if (active.rows[0]) {
-        const activeJob = active.rows[0];
+        let activeJob = active.rows[0];
+        const moralisDeferred = String(activeJob.error_code || '').startsWith('MORALIS_');
+        const credentialChanged = moralisDeferred && (activeJob.credential_generation == null
+          ? credentialGeneration != null
+          : credentialGeneration == null
+            || new Date(activeJob.credential_generation).getTime()
+              !== new Date(credentialGeneration).getTime());
+        if (activeJob.status === 'deferred' && credentialChanged) {
+          const refreshed = await client.query(
+            `UPDATE evm_audit_jobs
+                SET status = 'queued',
+                    stage = 'queued',
+                    credential_generation = $2,
+                    retry_after_at = NULL,
+                    error_code = NULL,
+                    error_detail = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+              WHERE id = $1
+            RETURNING *`,
+            [activeJob.id, credentialGeneration]
+          );
+          activeJob = refreshed.rows[0];
+        }
         const activeChains = new Set((activeJob.requested_chains || []).map(Number));
         const modeCovered = activeJob.mode === 'full' || mode === 'incremental';
         const chainsCovered = requestedChains.every((chainId) => activeChains.has(Number(chainId)));
@@ -239,6 +261,9 @@ class EvmAudit {
               updated_at = CURRENT_TIMESTAMP
         WHERE j.id = $1
           AND j.status IN ('queued', 'running', 'deferred')
+          AND (j.status <> 'deferred'
+            OR j.retry_after_at IS NULL
+            OR j.retry_after_at <= CURRENT_TIMESTAMP)
           AND (j.lease_expires_at IS NULL OR j.lease_expires_at < CURRENT_TIMESTAMP)
           AND NOT EXISTS (
             SELECT 1 FROM evm_audit_jobs sibling

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -236,7 +236,7 @@ class EvmAuditService {
       requestedChains: [...new Set(selected)],
       credentialGeneration,
     });
-    this.enqueue(result.job.id);
+    if (result.job.status !== 'deferred') this.enqueue(result.job.id);
     return result;
   }
 

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -424,6 +424,28 @@ test('Moralis history scope is finalized after transaction lookup pages', () => 
     'lookup evidence must be followed by a final complete status before canonicalization');
 });
 
+test('deferred audits can be reopened after a credential generation change', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/models/EvmAudit.js'), 'utf8');
+  assert.match(source, /activeJob\.status === 'deferred'/);
+  assert.match(source, /startsWith\('MORALIS_'\)/);
+  assert.match(source, /SET status = 'queued'/);
+  assert.match(source, /credential_generation = \$2/);
+  assert.match(source, /credentialChanged/);
+  assert.match(source, /retry_after_at = NULL/);
+  assert.match(source, /error_code = NULL/);
+});
+
+test('same-credential deferred retries preserve provider cooldown', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
+  assert.match(source, /if \(result\.job\.status !== 'deferred'\) this\.enqueue\(result\.job\.id\);/);
+});
+
+test('audit claims cannot bypass a deferred retry deadline', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/models/EvmAudit.js'), 'utf8');
+  assert.match(source, /j\.status <> 'deferred'/);
+  assert.match(source, /j\.retry_after_at <= CURRENT_TIMESTAMP/);
+});
+
 test('consensus RPC requires matching receipt identity and canonical block membership', async () => {
   const rpc = new RpcClient(8453, { spacingMs: 0 });
   rpc.request = async (method) => ({

--- a/frontend/src/components/crypto/WalletsPanel.jsx
+++ b/frontend/src/components/crypto/WalletsPanel.jsx
@@ -11,8 +11,10 @@ import DataTable from '../DataTable';
 import { useIsMobile } from '../../hooks/useMediaQuery';
 
 const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
-const auditIsPending = (audit) => ['queued', 'running', 'deferred'].includes(audit?.status)
-  && audit?.error_code !== 'MORALIS_NOT_CONFIGURED';
+// Deferred jobs are durable retry points, not active work. Keep their status
+// visible on the card while allowing an explicit Audit/Verify click to retry
+// after a provider cooldown or a newly entered credential.
+const auditIsPending = (audit) => ['queued', 'running'].includes(audit?.status);
 
 // Addresses render inside fallback chains and sentences composed here, so a
 // missing value must contribute nothing rather than 'unknown'.
@@ -536,9 +538,13 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = s
     try {
       const { job } = await ethAPI.startHistoryAudit(wallet.id, { mode });
       setAuditByWallet((current) => ({ ...current, [wallet.id]: job }));
-      showNotice(mode === 'full'
-        ? 'Full history audit queued. You can leave this page; progress and evidence are saved.'
-        : 'Incremental audit queued. It will resume from the last proven boundary and preserve prior evidence.');
+      if (job.status === 'deferred') {
+        showNotice('This audit is still deferred; its provider retry schedule remains in effect.');
+      } else {
+        showNotice(mode === 'full'
+          ? 'Full history audit queued. You can leave this page; progress and evidence are saved.'
+          : 'Incremental audit queued. It will resume from the last proven boundary and preserve prior evidence.');
+      }
     } catch (err) {
       onError(err.response?.data?.error || 'Failed to start history audit');
     } finally {


### PR DESCRIPTION
## Summary

- let deferred history audits be explicitly retried from the Wallets page
- when a deferred job sees a changed per-user Moralis credential generation, refresh the durable job to the new generation and clear the stale retry/error fields
- preserve the existing raw evidence and checkpointed audit job rather than creating a destructive reset
- keep queued/running jobs disabled while deferred jobs remain visible and retryable

## Validation

- backend focused EVM audit tests: 34 passed
- frontend tests, lint, and build passed
- full backend suite is running against this commit