### PR TITLE
fix: make EVM audits fail closed across providers

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -83,6 +83,7 @@ class EvmAudit {
 
   static async createOrFindActiveJob(userId, wallet, {
     mode = 'incremental', requestedChains = [], credentialGeneration = null,
+    etherscanConfigured = false,
   } = {}) {
     const client = await pool.connect();
     try {
@@ -103,12 +104,18 @@ class EvmAudit {
       );
       if (active.rows[0]) {
         let activeJob = active.rows[0];
-        const moralisDeferred = String(activeJob.error_code || '').startsWith('MORALIS_');
-        const credentialChanged = moralisDeferred && (activeJob.credential_generation == null
+        const errorCode = String(activeJob.error_code || '');
+        const moralisDeferred = errorCode.startsWith('MORALIS_');
+        // Etherscan's credential is also user-scoped, but its deferred job may
+        // have no Moralis generation change to record. Re-open as soon as the
+        // Settings key exists so a missing-key deferral is not sticky for 24h.
+        const etherscanCredentialReady = errorCode === 'ETHERSCAN_NOT_CONFIGURED'
+          && etherscanConfigured;
+        const credentialChanged = etherscanCredentialReady || (moralisDeferred && (activeJob.credential_generation == null
           ? credentialGeneration != null
           : credentialGeneration == null
             || new Date(activeJob.credential_generation).getTime()
-              !== new Date(credentialGeneration).getTime());
+              !== new Date(credentialGeneration).getTime()));
         if (activeJob.status === 'deferred' && credentialChanged) {
           const refreshed = await client.query(
             `UPDATE evm_audit_jobs
@@ -883,7 +890,7 @@ class EvmAudit {
           SELECT 1 FROM evm_audit_scopes sc
            WHERE sc.job_id = $1 AND sc.chain_id = $2
              AND sc.capability = r.capability
-             AND sc.provider IN ('moralis', 'blockscout', 'existing-ledger')
+             AND sc.provider IN ('moralis', 'blockscout', 'etherscan', 'existing-ledger')
              AND sc.status = 'complete' AND sc.pagination_exhausted = TRUE
         )`,
       [jobId, chainId]

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -1715,14 +1715,28 @@ class EtherscanService {
 
     // The internal cursor fields (_block/_logIndex/_key) stay here; only the
     // account-feed-shaped columns leave, so normalizeFeeds sees an internal row.
-    const result = out.map((row) => ({
-      hash: row.hash,
-      blockNumber: row.blockNumber,
-      timeStamp: row.timeStamp,
-      from: row.from,
-      to: row.to,
-      value: row.value,
-    }));
+    const result = out.map((row) => {
+      const mapped = {
+        hash: row.hash,
+        blockNumber: row.blockNumber,
+        timeStamp: row.timeStamp,
+        from: row.from,
+        to: row.to,
+        value: row.value,
+      };
+      if (row.nativeCredit) {
+        Object.defineProperties(mapped, {
+          nativeCredit: { value: true },
+          logIndex: { value: row.logIndex },
+          blockHash: { value: row.blockHash },
+          transactionIndex: { value: row.transactionIndex },
+          address: { value: row.address },
+          topics: { value: row.topics },
+          data: { value: row.data },
+        });
+      }
+      return mapped;
+    });
     Object.defineProperty(result, 'scannedThroughBlock', {
       value: scannedThroughBlock,
       enumerable: false,
@@ -1768,7 +1782,7 @@ class EtherscanService {
     if (logIndex == null) fail('invalid logIndex');
     const transactionHash = String(log?.transactionHash || '').toLowerCase();
     if (!TX_HASH_RE.test(transactionHash)) fail('invalid transactionHash');
-    return {
+    const result = {
       hash: transactionHash,
       blockNumber: String(block),
       timeStamp: String(timeStamp),
@@ -1779,6 +1793,19 @@ class EtherscanService {
       _logIndex: logIndex,
       _key: `${transactionHash}:${logIndex}`,
     };
+    // Keep the ordinary sync-facing row shape stable while exposing the
+    // immutable log coordinates to the audit normalizer. The normalizer
+    // copies these non-enumerable fields into the durable raw observation.
+    Object.defineProperties(result, {
+      nativeCredit: { value: true },
+      logIndex: { value: String(logIndex) },
+      blockHash: { value: log?.blockHash || null },
+      transactionIndex: { value: log?.transactionIndex || null },
+      address: { value: String(log?.address || '').toLowerCase() },
+      topics: { value: Array.isArray(log?.topics) ? log.topics : [] },
+      data: { value: data },
+    });
+    return result;
   }
 }
 

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -19,17 +19,23 @@ const AUDIT_CAPABILITIES = [
   'token_balance', 'bridge', 'receipt_verification',
 ];
 const AUDIT_CHAINS = new Map([
-  [1, { moralis: 'eth', activeIds: new Set(['0x1', '1', 'eth', 'ethereum']) }],
-  [10, { moralis: 'optimism', activeIds: new Set(['0xa', '10', 'optimism']) }],
-  [100, { moralis: 'gnosis', activeIds: new Set(['0x64', '100', 'gnosis']) }],
-  [137, { moralis: 'polygon', activeIds: new Set(['0x89', '137', 'polygon']) }],
+  [1, { auditProvider: 'etherscan' }],
+  [10, { auditProvider: 'blockscout' }],
+  [100, {
+    moralis: 'gnosis', fallbackProvider: 'blockscout',
+    activeIds: new Set(['0x64', '100', 'gnosis']),
+  }],
+  [137, { auditProvider: 'etherscan' }],
   [324, {
     auditProvider: 'blockscout',
     errorDetail: 'Moralis does not enumerate zkSync Era; the configured Blockscout account feeds provide finite indexed coverage, while consensus RPC verifies mined transactions and effects.',
   }],
-  [8453, { moralis: 'base', activeIds: new Set(['0x2105', '8453', 'base']) }],
-  [42161, { moralis: 'arbitrum', activeIds: new Set(['0xa4b1', '42161', 'arbitrum']) }],
-  [59144, { moralis: 'linea', activeIds: new Set(['0xe708', '59144', 'linea']) }],
+  [8453, {
+    moralis: 'base', fallbackProvider: 'blockscout',
+    activeIds: new Set(['0x2105', '8453', 'base']),
+  }],
+  [42161, { auditProvider: 'etherscan' }],
+  [59144, { auditProvider: 'etherscan' }],
   [32401, {
     unsupported: true,
     errorCode: 'NON_EVM_CHAIN',
@@ -68,6 +74,24 @@ function activeRowMatches(row, config) {
     .filter((value) => value != null)
     .map((value) => String(value).toLowerCase());
   return candidates.some((value) => config.activeIds.has(value));
+}
+
+function configuredExplorerProvider(chainId) {
+  return String(chains.getChain(chainId)?.accountApi?.provider || 'Etherscan').toLowerCase();
+}
+
+function explorerRequiresKey(chainId) {
+  return chains.getChain(chainId)?.accountApi?.requiresApiKey !== false;
+}
+
+function moralisQuotaFallbackError(error) {
+  if (!error) return null;
+  if (!['MORALIS_NOT_CONFIGURED', 'MORALIS_QUOTA_EXHAUSTED'].includes(error.code)) return null;
+  return {
+    code: error.code,
+    detail: error.message,
+    retryAt: error.retryAt || new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
 }
 
 function missingRanges(nonces, nextNonce) {
@@ -116,7 +140,8 @@ function effectSignature(row, address, chain) {
     if (row.transfer_type === 'native'
         && chain?.opStackDeposits?.creditSource?.toLowerCase() === from) type = 'native_credit';
     if (row.transfer_type === 'internal') {
-      type = chain?.auditNativeCredits?.contract?.toLowerCase() === from ? 'native_credit' : 'internal';
+      const nativeCredit = chain?.auditNativeCredits || chain?.stateSyncDeposits;
+      type = nativeCredit?.contract?.toLowerCase() === from ? 'native_credit' : 'internal';
     }
   }
   if (!type) return null;
@@ -208,6 +233,14 @@ function isBlockscoutTransient(error) {
       .includes(error?.code);
 }
 
+function explorerFailurePrefix(provider) {
+  return provider === 'blockscout' ? 'BLOCKSCOUT' : 'ETHERSCAN';
+}
+
+function explorerDisplayName(provider) {
+  return provider === 'blockscout' ? 'Blockscout' : 'Etherscan';
+}
+
 function assertLease(leaseState) {
   if (!leaseState?.lost) return;
   const error = new Error('EVM audit lease ownership was lost; this worker stopped before further writes.');
@@ -231,10 +264,15 @@ class EvmAuditService {
     const selected = (requestedChains || this.configuredChainIds())
       .map(Number).filter((chainId) => AUDIT_CHAINS.has(chainId));
     const credentialGeneration = await EvmAudit.credentialGeneration(userId);
+    // Resolve without logging or returning the credential. This also detects
+    // an environment-backed Etherscan key, so a missing-key deferral can be
+    // reopened after the user configures either supported source.
+    const etherscanConfigured = Boolean(await SecretsService.getUserKey(userId, 'etherscan'));
     const result = await EvmAudit.createOrFindActiveJob(userId, wallet, {
       mode,
       requestedChains: [...new Set(selected)],
       credentialGeneration,
+      etherscanConfigured,
     });
     if (result.job.status !== 'deferred') this.enqueue(result.job.id);
     return result;
@@ -308,7 +346,6 @@ class EvmAuditService {
       const requested = (job.requested_chains || []).map(Number).filter((id) => AUDIT_CHAINS.has(id));
       const moralisRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).moralis);
       const explorerRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).auditProvider);
-      const providerRequested = [...new Set([...moralisRequested, ...explorerRequested])];
       const unsupportedRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).unsupported);
       if (!requested.length) {
         return EvmAudit.finish(jobId, OWNER, 'unsupported', {
@@ -317,21 +354,18 @@ class EvmAuditService {
       }
 
       let key = null;
+      let moralisUnavailable = null;
       if (moralisRequested.length) {
         key = await SecretsService.getUserKey(job.user_id, 'moralis');
         if (!key) {
-          return EvmAudit.finish(jobId, OWNER, 'deferred', {
-            errorCode: 'MORALIS_NOT_CONFIGURED',
-            errorDetail: 'Configure a Moralis API key in Settings to run this optional audit.',
-            // Do not wake this job every 30 seconds while configuration is
-            // absent. A user request still enqueues the active job immediately,
-            // so saving a key and pressing Audit resumes without waiting.
-            retryAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          moralisUnavailable = moralisQuotaFallbackError({
+            code: 'MORALIS_NOT_CONFIGURED',
+            message: 'Configure a Moralis API key in Settings to run the Base/Gnosis audit source.',
           });
         }
       }
       const credentialGeneration = await EvmAudit.credentialGeneration(job.user_id);
-      if (moralisRequested.length && job.credential_generation
+      if (key && moralisRequested.length && job.credential_generation
           && credentialGeneration
           && new Date(job.credential_generation).getTime() !== new Date(credentialGeneration).getTime()) {
         return EvmAudit.finish(jobId, OWNER, 'failed', {
@@ -347,17 +381,28 @@ class EvmAuditService {
           logger.warn({ err: error, auditJobId: jobId }, 'Failed to retain provider attempt evidence');
         }
       };
-      const moralis = moralisRequested.length ? new MoralisClient(key, { onFailedAttempt: retainAttempt }) : null;
+      let moralis = key && moralisRequested.length
+        ? new MoralisClient(key, { onFailedAttempt: retainAttempt }) : null;
 
       let activeResponse = { body: { active_chains: [] } };
       let activeRows = [];
-      if (moralisRequested.length) {
+      if (moralis) {
         await EvmAudit.heartbeat(jobId, OWNER, { stage: 'discovering' });
-        activeResponse = await moralis.activeChains(
-          job.address, moralisRequested.map((id) => AUDIT_CHAINS.get(id).moralis)
-        );
-        assertLease(leaseState);
-        activeRows = Array.isArray(activeResponse.body.active_chains) ? activeResponse.body.active_chains : [];
+        try {
+          activeResponse = await moralis.activeChains(
+            job.address, moralisRequested.map((id) => AUDIT_CHAINS.get(id).moralis)
+          );
+          assertLease(leaseState);
+          activeRows = Array.isArray(activeResponse.body.active_chains)
+            ? activeResponse.body.active_chains : [];
+        } catch (error) {
+          moralisUnavailable = moralisQuotaFallbackError(error);
+          if (!moralisUnavailable) throw error;
+          // A quota exhaustion is a provider limitation, not evidence that the
+          // wallet has no history. Preserve the failed discovery attempt and
+          // let chains with a configured explorer fallback proceed.
+          moralis = null;
+        }
       }
       const discovered = requested.map((chainId) => {
         const config = AUDIT_CHAINS.get(chainId);
@@ -367,10 +412,19 @@ class EvmAuditService {
             status: 'unsupported', error_code: config.errorCode, error_detail: config.errorDetail,
           };
         }
+        if (config.moralis && moralisUnavailable) {
+          return {
+            chain_id: chainId, active_hint: null, bounded: false,
+            status: 'deferred', source: 'moralis',
+            error_code: moralisUnavailable.code,
+            error_detail: moralisUnavailable.detail,
+            fallback_source: config.fallbackProvider || null,
+          };
+        }
         if (config.auditProvider) {
           return {
             chain_id: chainId, active_hint: null, bounded: false,
-            status: 'configured', source: config.auditProvider,
+            status: 'configured', source: configuredExplorerProvider(chainId),
             detail: config.errorDetail,
           };
         }
@@ -390,28 +444,71 @@ class EvmAuditService {
         assertLease(leaseState);
         gaps += await this.runUnsupportedChain({ job, chainId });
       }
-      for (const chainId of providerRequested) {
+      const explorerApiKey = explorerRequested.some((chainId) => explorerRequiresKey(chainId))
+        ? await SecretsService.getUserKey(job.user_id, 'etherscan') : null;
+      const runnable = [];
+      const unavailable = [];
+      for (const chainId of requested.filter((id) => !unsupportedRequested.includes(id))) {
+        const config = AUDIT_CHAINS.get(chainId);
+        if (config.moralis && moralis) {
+          runnable.push(chainId);
+          continue;
+        }
+        const fallback = config.moralis ? config.fallbackProvider : config.auditProvider;
+        if (!fallback) {
+          unavailable.push({ chainId, provider: 'moralis', error: moralisUnavailable });
+        } else if (explorerRequiresKey(chainId) && !explorerApiKey) {
+          unavailable.push({
+            chainId, provider: configuredExplorerProvider(chainId),
+            error: {
+              code: 'ETHERSCAN_NOT_CONFIGURED',
+              detail: 'Configure an Etherscan API key to audit this configured chain.',
+            },
+          });
+        } else {
+          runnable.push(chainId);
+        }
+      }
+      for (const item of unavailable) {
+        assertLease(leaseState);
+        gaps += await this.runUnavailableChain({ job, chainId: item.chainId,
+          provider: item.provider, error: item.error });
+      }
+      let providerDeferred = Boolean(moralisUnavailable || unavailable.length);
+      let deferredProviderError = moralisUnavailable;
+      for (const chainId of runnable) {
         assertLease(leaseState);
         const result = await this.runChain({
           job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt,
+          explorerApiKey, moralisUnavailable,
         });
         gaps += result.gaps;
+        if (result.deferred) {
+          providerDeferred = true;
+          deferredProviderError ||= result.deferredProviderError;
+        }
       }
-      return EvmAudit.finish(jobId, OWNER, gaps ? 'complete_with_gaps' : 'complete', {
-        progress: { chains_finished: requested.length, gaps },
+      const deferred = providerDeferred;
+      return EvmAudit.finish(jobId, OWNER, deferred ? 'deferred' : (gaps ? 'complete_with_gaps' : 'complete'), {
+        errorCode: deferredProviderError?.code || unavailable[0]?.error?.code || null,
+        errorDetail: deferredProviderError?.detail || unavailable[0]?.error?.detail || null,
+        retryAt: deferred ? (deferredProviderError?.retryAt || new Date(Date.now() + 24 * 60 * 60 * 1000)) : null,
+        progress: { chains_finished: runnable.length + unsupportedRequested.length, gaps },
       });
     } catch (error) {
       const deferred = [
         'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
         'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED',
-        'BLOCKSCOUT_TRANSPORT_ERROR',
+        'BLOCKSCOUT_TRANSPORT_ERROR', 'ETHERSCAN_RATE_LIMITED',
+        'ETHERSCAN_TRANSPORT_ERROR',
       ]
         .includes(error.code);
       const errorCode = String(error.code || '');
       const provider = errorCode.startsWith('MORALIS_') ? 'moralis'
-        : errorCode.startsWith('RPC_') ? 'consensus-rpc' : 'blockscout';
+        : errorCode.startsWith('RPC_') ? 'consensus-rpc'
+          : errorCode.startsWith('ETHERSCAN_') ? 'etherscan' : 'blockscout';
       if (errorCode.startsWith('MORALIS_') || errorCode.startsWith('RPC_')
-          || errorCode.startsWith('BLOCKSCOUT_')) {
+          || errorCode.startsWith('BLOCKSCOUT_') || errorCode.startsWith('ETHERSCAN_')) {
         try {
           await EvmAudit.recordProviderAttempt({
             jobId, provider,
@@ -446,10 +543,27 @@ class EvmAuditService {
     return 1;
   }
 
-  static async runChain({ job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt }) {
+  static async runUnavailableChain({ job, chainId, provider, error }) {
+    for (const capability of AUDIT_CAPABILITIES) {
+      await EvmAudit.upsertScope(job.id, {
+        chainId, provider, capability, status: 'deferred',
+        errorCode: error?.code || 'AUDIT_PROVIDER_UNAVAILABLE',
+        errorDetail: error?.detail || 'No configured audit provider is available for this chain.',
+      });
+    }
+    return 1;
+  }
+
+  static async runChain({
+    job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt,
+    explorerApiKey = null, moralisUnavailable = null,
+  }) {
     const chain = chains.getChain(chainId);
     const providerConfig = AUDIT_CHAINS.get(chainId);
-    const auditProvider = providerConfig.moralis ? 'moralis' : providerConfig.auditProvider;
+    const useMoralis = Boolean(providerConfig.moralis && moralis);
+    const auditProvider = useMoralis
+      ? 'moralis'
+      : (providerConfig.moralis ? providerConfig.fallbackProvider : providerConfig.auditProvider);
     const rpc = new RpcClient(chainId, { onFailedAttempt: retainAttempt });
     const boundary = await rpc.finalizedBoundary();
     const context = {
@@ -460,11 +574,17 @@ class EvmAuditService {
       stage: 'fetching', progress: { current_chain: chainId, boundary_block: boundary.number },
     });
 
+    if (providerConfig.moralis && !useMoralis && moralisUnavailable) {
+      await EvmAudit.upsertScope(job.id, {
+        chainId, provider: 'moralis', capability: 'active_chain', status: 'deferred',
+        errorCode: moralisUnavailable.code, errorDetail: moralisUnavailable.detail,
+      });
+    }
     const activeScope = await EvmAudit.upsertScope(job.id, {
       chainId, provider: auditProvider, capability: 'active_chain', status: 'running',
       fromBlock: 0, throughBlock: boundary.number, throughHash: boundary.hash,
     });
-    if (providerConfig.moralis) {
+    if (useMoralis) {
       const activeBody = {
         active_chains: (activeResponse.body.active_chains || [])
           .filter((row) => activeRowMatches(row, providerConfig)),
@@ -488,20 +608,24 @@ class EvmAuditService {
       await EvmAudit.completeScope(activeScope.id, {
         status: 'unverified', paginationExhausted: false,
         errorCode: 'ACTIVE_DISCOVERY_UNSUPPORTED',
-        errorDetail: 'This explorer exposes finite account-feed coverage but no active-chain discovery endpoint.',
+        errorDetail: moralisUnavailable
+          ? 'Moralis active-chain discovery was deferred; this fallback exposes finite account-feed coverage only.'
+          : 'This explorer exposes finite account-feed coverage but no active-chain discovery endpoint.',
       });
     }
 
     let indexedBoundary = null;
-    if (!providerConfig.moralis) {
+    if (!useMoralis) {
       try {
-        indexedBoundary = await EtherscanService.coverageBoundary(null, chainId);
+        indexedBoundary = await EtherscanService.coverageBoundary(explorerApiKey, chainId);
       } catch (error) {
         const transient = isBlockscoutTransient(error);
         const rateLimited = error.code === 'EXPLORER_RATE_LIMITED';
-        const wrapped = new Error(`Blockscout indexed boundary failed: ${publicErrorDetail(error)}`);
-        wrapped.code = rateLimited ? 'BLOCKSCOUT_RATE_LIMITED'
-          : transient ? 'BLOCKSCOUT_TRANSPORT_ERROR' : 'BLOCKSCOUT_BOUNDARY_FAILED';
+        const prefix = explorerFailurePrefix(auditProvider);
+        const name = explorerDisplayName(auditProvider);
+        const wrapped = new Error(`${name} indexed boundary failed: ${publicErrorDetail(error)}`);
+        wrapped.code = rateLimited ? `${prefix}_RATE_LIMITED`
+          : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_BOUNDARY_FAILED`;
         wrapped.httpStatus = error.response?.status || error.httpStatus || null;
         wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
         await EvmAudit.recordProviderAttempt({
@@ -513,7 +637,7 @@ class EvmAuditService {
         throw wrapped;
       }
     }
-    const sourceThroughBlock = providerConfig.moralis
+    const sourceThroughBlock = useMoralis
       ? boundary.number : Math.min(boundary.number, indexedBoundary.throughBlock);
     const prior = job.mode === 'incremental'
       ? await EvmAudit.latestCoverage(job.subject_id, chainId, auditProvider, 'wallet_history')
@@ -522,24 +646,58 @@ class EvmAuditService {
     const historyScope = await EvmAudit.upsertScope(job.id, {
       chainId, provider: auditProvider, capability: 'wallet_history', status: 'running',
       fromBlock, throughBlock: sourceThroughBlock,
-      throughHash: providerConfig.moralis ? boundary.hash : null,
+      throughHash: useMoralis ? boundary.hash : null,
     });
+    const fallbackAfterMoralis = async (error, scopeId) => {
+      const deferredError = moralisQuotaFallbackError(error);
+      if (!useMoralis || !deferredError || !providerConfig.fallbackProvider) throw error;
+      assertLease(leaseState);
+      await EvmAudit.completeScope(scopeId, {
+        status: 'deferred', paginationExhausted: false,
+        errorCode: deferredError.code, errorDetail: deferredError.detail,
+      });
+      const fallbackResult = await this.runChain({
+        job, chainId, moralis: null, activeResponse: { body: { active_chains: [] } },
+        discovered, leaseState, retainAttempt, explorerApiKey,
+        moralisUnavailable: deferredError,
+      });
+      return {
+        ...fallbackResult,
+        deferred: true,
+        deferredProviderError: deferredError,
+      };
+    };
     const hashes = new Set();
-    if (providerConfig.moralis) {
+    const moralisLookupHashes = new Set();
+    // Rehydrate every durable observation before either provider path runs.
+    // This is required when Moralis fails after committing pages and the
+    // explorer fallback starts with a fresh in-memory hash set.
+    const durableObservations = await EvmAudit.observationsForJob(job.id, { chainId });
+    for (const observation of durableObservations) {
+      if (observation.tx_hash) hashes.add(String(observation.tx_hash).toLowerCase());
+      if (observation.tx_hash && !['consensus-rpc', 'moralis'].includes(observation.provider)) {
+        moralisLookupHashes.add(String(observation.tx_hash).toLowerCase());
+      }
+    }
+    if (useMoralis) {
       let cursor = historyScope.provider_cursor || null;
-      for await (const page of moralis.walletHistoryPages(job.address, {
-        chain: providerConfig.moralis, fromBlock, throughBlock: boundary.number, cursor,
-      })) {
-        assertLease(leaseState);
-        const observations = page.items.flatMap((item) => normalizer.historyObservations(context, item));
-        for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
-        await EvmAudit.commitPage(historyScope.id, pageRecord(
-          'moralis', 'wallet-history', {
-            chain: providerConfig.moralis, from_block: fromBlock, to_block: boundary.number,
-          }, page, page.cursorIn, page.cursorOut, page.items.length
-        ), observations);
-        cursor = page.cursorOut;
-        await EvmAudit.heartbeat(job.id, OWNER, { progress: { current_cursor: cursor, transactions_seen: hashes.size } });
+      try {
+        for await (const page of moralis.walletHistoryPages(job.address, {
+          chain: providerConfig.moralis, fromBlock, throughBlock: boundary.number, cursor,
+        })) {
+          assertLease(leaseState);
+          const observations = page.items.flatMap((item) => normalizer.historyObservations(context, item));
+          for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
+          await EvmAudit.commitPage(historyScope.id, pageRecord(
+            'moralis', 'wallet-history', {
+              chain: providerConfig.moralis, from_block: fromBlock, to_block: boundary.number,
+            }, page, page.cursorIn, page.cursorOut, page.items.length
+          ), observations);
+          cursor = page.cursorOut;
+          await EvmAudit.heartbeat(job.id, OWNER, { progress: { current_cursor: cursor, transactions_seen: hashes.size } });
+        }
+      } catch (error) {
+        return fallbackAfterMoralis(error, historyScope.id);
       }
       await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
       await EvmAudit.acceptCoverage({
@@ -574,14 +732,16 @@ class EvmAuditService {
         let rows;
         try {
           rows = await EtherscanService[feedSpec.method](
-            job.address, feedFromBlock, null, chainId, sourceThroughBlock
+            job.address, feedFromBlock, explorerApiKey, chainId, sourceThroughBlock
           );
         } catch (error) {
           const transient = isBlockscoutTransient(error);
           const rateLimited = error.code === 'EXPLORER_RATE_LIMITED';
-          const wrapped = new Error(`Blockscout ${feedSpec.feed} audit feed failed: ${publicErrorDetail(error)}`);
-          wrapped.code = rateLimited ? 'BLOCKSCOUT_RATE_LIMITED'
-            : transient ? 'BLOCKSCOUT_TRANSPORT_ERROR' : 'BLOCKSCOUT_FEED_FAILED';
+          const prefix = explorerFailurePrefix(auditProvider);
+          const name = explorerDisplayName(auditProvider);
+          const wrapped = new Error(`${name} ${feedSpec.feed} audit feed failed: ${publicErrorDetail(error)}`);
+          wrapped.code = rateLimited ? `${prefix}_RATE_LIMITED`
+            : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_FEED_FAILED`;
           wrapped.httpStatus = error.response?.status || error.httpStatus || null;
           wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
           await EvmAudit.recordProviderAttempt({
@@ -595,8 +755,10 @@ class EvmAuditService {
           throw wrapped;
         }
         if (!Array.isArray(rows)) {
-          const error = new Error(`Blockscout ${feedSpec.feed} audit feed returned a non-array response`);
-          error.code = 'BLOCKSCOUT_FEED_FAILED';
+          const prefix = explorerFailurePrefix(auditProvider);
+          const name = explorerDisplayName(auditProvider);
+          const error = new Error(`${name} ${feedSpec.feed} audit feed returned a non-array response`);
+          error.code = `${prefix}_FEED_FAILED`;
           throw error;
         }
         const pageSize = 500;
@@ -632,15 +794,59 @@ class EvmAuditService {
         chainId, provider: auditProvider, capability: 'native_credit', status: 'running',
         fromBlock: 0, throughBlock: sourceThroughBlock, throughHash: null,
       });
-      await EvmAudit.commitPage(nativeCreditScope.id, pageRecord(
-        auditProvider, 'native-credit-not-applicable', { chain_id: chainId },
-        { body: { chain_id: chainId, status: 'not_applicable' } }, null, null, 0
-      ), []);
-      await EvmAudit.completeScope(nativeCreditScope.id, {
-        status: 'complete', paginationExhausted: true,
-        errorCode: 'NOT_APPLICABLE',
-        errorDetail: 'This chain has no configured account-independent native-credit feed; receipt logs remain canonical evidence.',
-      });
+      const nativeCreditConfig = chain?.stateSyncDeposits;
+      if (nativeCreditConfig) {
+        let nativeCreditRows;
+        try {
+          nativeCreditRows = await EtherscanService.fetchStateSyncDeposits(
+            job.address, 0, explorerApiKey, chainId, nativeCreditConfig, sourceThroughBlock
+          );
+        } catch (error) {
+          const transient = isBlockscoutTransient(error);
+          const rateLimited = error.code === 'EXPLORER_RATE_LIMITED';
+          const prefix = explorerFailurePrefix(auditProvider);
+          const wrapped = new Error(`Explorer native-credit audit feed failed: ${publicErrorDetail(error)}`);
+          wrapped.code = rateLimited ? `${prefix}_RATE_LIMITED`
+            : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_FEED_FAILED`;
+          wrapped.httpStatus = error.response?.status || error.httpStatus || null;
+          wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
+          await EvmAudit.recordProviderAttempt({
+            jobId: job.id, scopeId: nativeCreditScope.id, provider: auditProvider,
+            endpoint: 'native-credit', requestParams: {
+              address: job.address, from_block: 0, to_block: sourceThroughBlock,
+            }, outcome: transient ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
+            errorCode: wrapped.code, errorDetail: publicErrorDetail(wrapped),
+          });
+          throw wrapped;
+        }
+        const observations = normalizer.explorerFeedObservations(
+          { ...context, provider: auditProvider }, 'internal', nativeCreditRows
+        );
+        for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
+        await EvmAudit.commitPage(nativeCreditScope.id, pageRecord(
+          auditProvider, 'native-credit', {
+            address: job.address, from_block: 0, to_block: sourceThroughBlock,
+          }, { body: { rows: nativeCreditRows } }, null, null, nativeCreditRows.length
+        ), observations);
+        await EvmAudit.completeScope(nativeCreditScope.id, {
+          status: 'complete', paginationExhausted: true,
+        });
+        await EvmAudit.acceptCoverage({
+          subjectId: job.subject_id, chainId, provider: auditProvider,
+          capability: 'native_credit', fromBlock: 0, throughBlock: sourceThroughBlock,
+          throughHash: null, paginationExhausted: true, status: 'complete', jobId: job.id,
+        });
+      } else {
+        await EvmAudit.commitPage(nativeCreditScope.id, pageRecord(
+          auditProvider, 'native-credit-not-applicable', { chain_id: chainId },
+          { body: { chain_id: chainId, status: 'not_applicable' } }, null, null, 0
+        ), []);
+        await EvmAudit.completeScope(nativeCreditScope.id, {
+          status: 'complete', paginationExhausted: true,
+          errorCode: 'NOT_APPLICABLE',
+          errorDetail: 'This chain has no configured account-independent native-credit feed; receipt logs remain canonical evidence.',
+        });
+      }
       const foundBlocks = [...hashes].length
         ? [...(await EvmAudit.observationsForJob(job.id, { chainId }))]
           .filter((row) => row.provider === auditProvider && row.block_number != null)
@@ -653,6 +859,14 @@ class EvmAuditService {
         discoveredChain.bounded = true;
         discoveredChain.status = 'bounded';
         discoveredChain.source = auditProvider;
+        if (moralisUnavailable) {
+          discoveredChain.active_discovery = {
+            status: 'deferred', source: 'moralis',
+            error_code: moralisUnavailable.code,
+            error_detail: moralisUnavailable.detail,
+          };
+          discoveredChain.fallback_source = auditProvider;
+        }
         discoveredChain.first_block = foundBlocks.length ? Math.min(...foundBlocks) : null;
         discoveredChain.last_block = foundBlocks.length ? Math.max(...foundBlocks) : null;
       }
@@ -710,7 +924,11 @@ class EvmAuditService {
         errorDetail: coverageComplete ? null : (coverage?.error_message || `Stored ${feed} coverage is not proven complete.`),
       });
     }
-    for (const row of legacyRows) hashes.add(String(row.tx_hash).toLowerCase());
+    for (const row of legacyRows) {
+      const hash = String(row.tx_hash).toLowerCase();
+      hashes.add(hash);
+      moralisLookupHashes.add(hash);
+    }
 
     const providerTransactionHashes = new Set((await EvmAudit.observationsForJob(
       job.id, { chainId }
@@ -722,31 +940,35 @@ class EvmAuditService {
     // committed pages can never disappear from canonicalization.
     for (const hash of providerTransactionHashes) hashes.add(hash);
     let providerLookupGaps = 0;
-    if (providerConfig.moralis) {
-      for (const hash of hashes) {
-        if (providerTransactionHashes.has(hash)) continue;
-        try {
-          const lookup = await moralis.transactionByHash(hash, providerConfig.moralis);
-          assertLease(leaseState);
-          const item = lookup.body;
-          const observations = normalizer.historyObservations(context, item);
-          await EvmAudit.commitPage(historyScope.id, pageRecord(
-            'moralis', 'transaction-lookup', { chain: providerConfig.moralis, transaction_hash: hash },
-            lookup, null, null, 1
-          ), observations);
-        } catch (error) {
-          providerLookupGaps += 1;
-          await EvmAudit.recordProviderAttempt({
-            jobId: job.id, scopeId: historyScope.id, provider: 'moralis',
-            endpoint: 'transaction-lookup',
-            requestParams: { chain: providerConfig.moralis, transaction_hash: hash },
-            outcome: ['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED'].includes(error.code)
-              ? 'deferred' : 'failed',
-            httpStatus: error.httpStatus || null, errorCode: error.code || 'MORALIS_LOOKUP_FAILED',
-            errorDetail: publicErrorDetail(error), requestId: error.requestId || null,
-          });
-          if (['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_AUTH_FAILED'].includes(error.code)) throw error;
+    if (useMoralis) {
+      try {
+        for (const hash of moralisLookupHashes) {
+          if (providerTransactionHashes.has(hash)) continue;
+          try {
+            const lookup = await moralis.transactionByHash(hash, providerConfig.moralis);
+            assertLease(leaseState);
+            const item = lookup.body;
+            const observations = normalizer.historyObservations(context, item);
+            await EvmAudit.commitPage(historyScope.id, pageRecord(
+              'moralis', 'transaction-lookup', { chain: providerConfig.moralis, transaction_hash: hash },
+              lookup, null, null, 1
+            ), observations);
+          } catch (error) {
+            providerLookupGaps += 1;
+            await EvmAudit.recordProviderAttempt({
+              jobId: job.id, scopeId: historyScope.id, provider: 'moralis',
+              endpoint: 'transaction-lookup',
+              requestParams: { chain: providerConfig.moralis, transaction_hash: hash },
+              outcome: ['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED'].includes(error.code)
+                ? 'deferred' : 'failed',
+              httpStatus: error.httpStatus || null, errorCode: error.code || 'MORALIS_LOOKUP_FAILED',
+              errorDetail: publicErrorDetail(error), requestId: error.requestId || null,
+            });
+            if (['MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_AUTH_FAILED'].includes(error.code)) throw error;
+          }
         }
+      } catch (error) {
+        return fallbackAfterMoralis(error, historyScope.id);
       }
     }
     // Transaction lookups use the same durable scope as the paginated history
@@ -813,9 +1035,14 @@ class EvmAuditService {
       errorDetail: 'Consensus RPC verified known transaction receipts but did not enumerate account history.',
     });
 
-    const internalObservations = await EvmAudit.observationsForJob(job.id, {
-      chainId, evidenceKind: 'internal_trace',
-    });
+    const internalObservations = [
+      ...(await EvmAudit.observationsForJob(job.id, {
+        chainId, evidenceKind: 'internal_trace',
+      })),
+      ...(await EvmAudit.observationsForJob(job.id, {
+        chainId, evidenceKind: 'native_credit',
+      })),
+    ];
     for (const effect of effectsFromInternalObservations(context, internalObservations)) {
       const stored = await EvmAudit.upsertCanonicalEffect(effect);
       await EvmAudit.linkEffectEvidence(stored.id, effect.evidenceObservationIds);

--- a/backend/src/services/evmAudit/effectDecoder.js
+++ b/backend/src/services/evmAudit/effectDecoder.js
@@ -262,11 +262,15 @@ function effectsFromInternalObservations(context, observations) {
 
   const effects = [];
   for (const [hash, rows] of byTransaction) {
-    const moralis = rows.filter((row) => row.provider === 'moralis');
-    const explorer = rows.filter((row) => row.provider === 'blockscout');
+    const internalRows = rows.filter((row) => row.evidence_kind !== 'native_credit'
+      && row.payload_json?.native_credit !== true);
+    const moralis = internalRows.filter((row) => row.provider === 'moralis');
+    const explorer = internalRows.filter((row) => ['blockscout', 'etherscan'].includes(row.provider));
+    const explorerProvider = ['blockscout', 'etherscan']
+      .find((provider) => explorer.some((row) => row.provider === provider));
     const selectedProvider = moralis.length ? 'moralis'
-      : explorer.length ? 'blockscout' : 'existing-ledger';
-    const selected = rows.filter((row) => row.provider === selectedProvider);
+      : explorerProvider || 'existing-ledger';
+    const selected = internalRows.filter((row) => row.provider === selectedProvider);
     const legacyBySignature = new Map();
     for (const row of rows.filter((candidate) => candidate.provider === 'existing-ledger')) {
       const fields = internalObservationFields(row, wallet);
@@ -288,7 +292,7 @@ function effectsFromInternalObservations(context, observations) {
       const fields = internalObservationFields(row, wallet);
       if (!fields) continue;
       const signature = `${fields.from}:${fields.to}:${fields.value}`;
-      const legacyMatches = ['moralis', 'blockscout'].includes(row.provider)
+      const legacyMatches = ['moralis', 'blockscout', 'etherscan'].includes(row.provider)
         ? (legacyBySignature.get(signature) || []) : [];
       const independentlyVerified = row.trace_address != null
         && legacyMatches.length === 1
@@ -312,6 +316,22 @@ function effectsFromInternalObservations(context, observations) {
         evidenceObservationIds: [row.id, ...(independentlyVerified ? legacyMatches.map((match) => match.id) : [])],
       }));
     }
+  }
+  for (const row of observations.filter((candidate) => candidate.evidence_kind === 'native_credit'
+    || candidate.payload_json?.native_credit === true)) {
+    if (!row.tx_hash) continue;
+    const fields = internalObservationFields(row, wallet);
+    if (!fields) continue;
+    const logIndex = row.log_index ?? row.payload_json?.logIndex ?? null;
+    const coordinate = logIndex == null ? `native-credit:${row.tx_hash}:unproven`
+      : `native-credit:${row.tx_hash}:${Number(logIndex)}`;
+    effects.push(baseEffect(context, {
+      txHash: row.tx_hash, effectKey: coordinate, effectType: 'native_credit',
+      direction: fields.effectDirection, logIndex,
+      fromAddress: fields.from, toAddress: fields.to, valueUnits: fields.value,
+      resolutionStatus: 'provisional', selectedObservationId: row.id,
+      evidenceObservationIds: [row.id],
+    }));
   }
   return effects;
 }

--- a/backend/src/services/evmAudit/normalizer.js
+++ b/backend/src/services/evmAudit/normalizer.js
@@ -245,24 +245,38 @@ function legacyTransferObservations(context, rows) {
 }
 
 function explorerFeedObservations(context, feed, rows) {
-  const evidenceKind = feed === 'internal' ? 'internal_trace' : 'account_feed';
   return rows.map((row) => {
     const hash = txHash(row.hash || row.transactionHash);
     if (!hash) throw new Error(`Explorer ${feed} feed returned an invalid transaction hash`);
+    const nativeCredit = row.nativeCredit === true;
+    const evidenceKind = nativeCredit
+      ? 'native_credit' : feed === 'internal' ? 'internal_trace' : 'account_feed';
     const traceAddress = feed === 'internal'
       ? (row.traceAddress ?? row.trace_address
         ?? (/^\d+(?:_\d+)*$/.test(String(row.traceId || ''))
           ? String(row.traceId).split('_').map(Number) : null))
       : null;
-    const logIndex = feed === 'internal' ? null : safeInteger(row.logIndex);
+    const logIndex = nativeCredit || feed !== 'internal' ? safeInteger(row.logIndex) : null;
     const tokenId = row.tokenID ?? row.token_id ?? '';
-    const coordinate = feed === 'internal'
+    const coordinate = nativeCredit
+      ? (logIndex == null ? `provider:${sha256(row)}` : String(logIndex))
+      : feed === 'internal'
       ? (traceAddress == null ? `provider:${sha256(row)}` : stableJson(traceAddress))
       : (logIndex == null ? `provider:${sha256(row)}` : `${logIndex}:${tokenId}`);
+    const payload = nativeCredit ? {
+      ...row,
+      native_credit: true,
+      log_index: row.logIndex,
+      block_hash: row.blockHash,
+      transaction_index: row.transactionIndex,
+      address: row.address,
+      topics: row.topics,
+      data: row.data,
+    } : row;
     return baseObservation(context, {
       evidenceKind,
       providerObjectKey: `account:${feed}:${hash}:${coordinate}`,
-      payload: row,
+      payload,
       tx: hash,
       blockNumber: row.blockNumber,
       block: row.blockHash,

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -58,6 +58,7 @@ const EthDerivedPipeline = require('../src/services/EthDerivedPipeline');
 const EthReconciliationService = require('../src/services/EthReconciliationService');
 const MethodSignatureService = require('../src/services/MethodSignatureService');
 const EthActivityService = require('../src/services/EthActivityService');
+const normalizer = require('../src/services/evmAudit/normalizer');
 
 const { bridgeAsset, buildActivityRows } = EthActivityService;
 
@@ -268,6 +269,16 @@ test('the fetch sends address+topic0+topic2 and parses the log into an internal-
     to: WALLET,
     value: DEPOSIT_WEI,
   });
+  assert.equal(rows[0].nativeCredit, true);
+  assert.equal(rows[0].logIndex, '3');
+  const observations = normalizer.explorerFeedObservations({
+    jobId: 1, subjectId: 1, chainId: 137, provider: 'etherscan',
+  }, 'internal', rows);
+  assert.equal(observations[0].evidenceKind, 'native_credit');
+  assert.equal(observations[0].logIndex, 3);
+  assert.equal(observations[0].payload.native_credit, true);
+  assert.deepEqual(observations[0].payload.topics, depositLog().topics);
+  assert.equal(observations[0].payload.data, depositLog().data);
 });
 
 test('the amount is the FIRST 32 bytes of data; the trailing words are ignored', async (t) => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -9,6 +9,7 @@ const MoralisClient = require('../src/services/evmAudit/MoralisClient');
 const RpcClient = require('../src/services/evmAudit/RpcClient');
 const EvmAuditService = require('../src/services/EvmAuditService');
 const EvmAudit = require('../src/models/EvmAudit');
+const SecretsService = require('../src/services/SecretsService');
 const database = require('../src/config/database');
 const {
   TOPICS, effectsFromInternalObservations, effectsFromRpc,
@@ -49,6 +50,26 @@ test('history audit enumerates every configured chain', () => {
     if (original == null) delete process.env.ETH_CHAINS;
     else process.env.ETH_CHAINS = original;
   }
+});
+
+test('Moralis audit scope is limited to Base and Gnosis with explicit explorer fallbacks', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
+  assert.match(source, /\[100, \{\s*\n\s*moralis: 'gnosis', fallbackProvider: 'blockscout'/);
+  assert.match(source, /\[8453, \{\s*\n\s*moralis: 'base', fallbackProvider: 'blockscout'/);
+  assert.match(source, /\[1, \{ auditProvider: 'etherscan' \}\]/);
+  assert.match(source, /\[42161, \{ auditProvider: 'etherscan' \}\]/);
+  assert.match(source, /const useMoralis = Boolean\(providerConfig\.moralis && moralis\)/);
+  assert.match(source, /const nativeCredit = chain\?\.auditNativeCredits \|\| chain\?\.stateSyncDeposits/);
+  assert.match(source, /fetchStateSyncDeposits\(/);
+  assert.match(source, /evidenceKind: 'native_credit'/);
+});
+
+test('Moralis quota fallback remains visibly deferred and never marks discovery complete', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
+  assert.match(source, /status: 'deferred', source: 'moralis'/);
+  assert.match(source, /active_discovery = \{/);
+  assert.match(source, /key && moralisRequested\.length/);
+  assert.match(source, /let providerDeferred = Boolean\(moralisUnavailable \|\| unavailable\.length\)/);
 });
 
 test('unsupported audit chains become explicit amber scopes without a provider request', async () => {
@@ -226,6 +247,27 @@ test('Blockscout internal evidence can corroborate the existing ledger when Mora
   assert.deepEqual(effects[0].evidenceObservationIds, [11, 12]);
 });
 
+test('Etherscan internal evidence is selected and native-credit logs retain log identity', () => {
+  const etherscan = {
+    id: 14, provider: 'etherscan', provider_object_key: `account:internal:${HASH}:0`,
+    tx_hash: HASH, trace_address: [0],
+    payload_json: { from: OTHER, to: WALLET, value: '9', isError: '0' },
+  };
+  const effects = effectsFromInternalObservations(context(1), [etherscan]);
+  assert.equal(effects.length, 1);
+  assert.equal(effects[0].effectType, 'internal');
+
+  const nativeCredit = {
+    id: 15, provider: 'etherscan', evidence_kind: 'native_credit', tx_hash: HASH,
+    log_index: 7, payload_json: {
+      native_credit: true, from: OTHER, to: WALLET, value: '11', log_index: '7',
+    },
+  };
+  const nativeEffects = effectsFromInternalObservations(context(100), [nativeCredit]);
+  assert.equal(nativeEffects[0].effectType, 'native_credit');
+  assert.equal(nativeEffects[0].effectKey, `native-credit:${HASH}:7`);
+});
+
 test('failed Blockscout internal traces never become economic effects', () => {
   const effects = effectsFromInternalObservations(context(324), [{
     id: 13, provider: 'blockscout', tx_hash: HASH, trace_address: [3, 1],
@@ -362,6 +404,73 @@ test('Moralis plan quota exhaustion is deferred instead of reported as bad crede
   }
 });
 
+test('Moralis discovery quota exhaustion runs configured explorer fallbacks without certifying discovery', async () => {
+  const originalFetch = global.fetch;
+  const originals = {
+    acquireRunLock: EvmAudit.acquireRunLock,
+    releaseRunLock: EvmAudit.releaseRunLock,
+    claim: EvmAudit.claim,
+    findById: EvmAudit.findById,
+    heartbeat: EvmAudit.heartbeat,
+    credentialGeneration: EvmAudit.credentialGeneration,
+    setDiscoveredChains: EvmAudit.setDiscoveredChains,
+    recordProviderAttempt: EvmAudit.recordProviderAttempt,
+    finish: EvmAudit.finish,
+    getUserKey: SecretsService.getUserKey,
+    runChain: EvmAuditService.runChain,
+  };
+  const captured = [];
+  let finished;
+  global.fetch = async () => new Response(
+    JSON.stringify({ message: 'free-plan daily quota exhausted' }),
+    { status: 401, headers: { 'content-type': 'application/json' } }
+  );
+  EvmAudit.acquireRunLock = async () => ({ userId: 1 });
+  EvmAudit.releaseRunLock = async () => {};
+  EvmAudit.claim = async () => ({ id: 44 });
+  EvmAudit.findById = async () => ({
+    id: 44, user_id: 1, subject_id: 9, requested_wallet_id: 3,
+    address: WALLET, requested_chains: [100, 8453, 324], mode: 'full',
+    credential_generation: null,
+  });
+  EvmAudit.heartbeat = async () => ({ id: 44 });
+  EvmAudit.credentialGeneration = async () => null;
+  EvmAudit.setDiscoveredChains = async (_jobId, _owner, chainsFound) => chainsFound;
+  EvmAudit.recordProviderAttempt = async () => {};
+  EvmAudit.finish = async (_jobId, _owner, status, options) => {
+    finished = { status, options };
+    return finished;
+  };
+  SecretsService.getUserKey = async (_userId, service) => service === 'moralis' ? 'test-key' : null;
+  EvmAuditService.runChain = async (options) => {
+    captured.push({ chainId: options.chainId, moralis: Boolean(options.moralis) });
+    return { gaps: 0 };
+  };
+  try {
+    await EvmAuditService.run(44);
+    assert.deepEqual(captured, [
+      { chainId: 100, moralis: false },
+      { chainId: 8453, moralis: false },
+      { chainId: 324, moralis: false },
+    ]);
+    assert.equal(finished.status, 'deferred');
+    assert.equal(finished.options.errorCode, 'MORALIS_QUOTA_EXHAUSTED');
+  } finally {
+    global.fetch = originalFetch;
+    EvmAudit.acquireRunLock = originals.acquireRunLock;
+    EvmAudit.releaseRunLock = originals.releaseRunLock;
+    EvmAudit.claim = originals.claim;
+    EvmAudit.findById = originals.findById;
+    EvmAudit.heartbeat = originals.heartbeat;
+    EvmAudit.credentialGeneration = originals.credentialGeneration;
+    EvmAudit.setDiscoveredChains = originals.setDiscoveredChains;
+    EvmAudit.recordProviderAttempt = originals.recordProviderAttempt;
+    EvmAudit.finish = originals.finish;
+    SecretsService.getUserKey = originals.getUserKey;
+    EvmAuditService.runChain = originals.runChain;
+  }
+});
+
 test('Moralis requests have an explicit deadline even when fetch never settles', async () => {
   const originalFetch = global.fetch;
   const signals = [];
@@ -413,7 +522,7 @@ test('Moralis history scope is finalized after transaction lookup pages', () => 
   const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
   assert.ok(source.includes("job.id, { chainId }"),
     'restart rehydration must inspect all provider evidence kinds, including explorer feeds');
-  const lookupPass = source.indexOf("for (const hash of hashes) {\n        if (providerTransactionHashes.has(hash)) continue;");
+  const lookupPass = source.indexOf('for (const hash of moralisLookupHashes)');
   const canonicalization = source.indexOf("await EvmAudit.heartbeat(job.id, OWNER, { stage: 'canonicalizing' });", lookupPass);
   const finalization = source.indexOf(
     "await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });",
@@ -428,6 +537,9 @@ test('deferred audits can be reopened after a credential generation change', () 
   const source = fs.readFileSync(path.join(__dirname, '../src/models/EvmAudit.js'), 'utf8');
   assert.match(source, /activeJob\.status === 'deferred'/);
   assert.match(source, /startsWith\('MORALIS_'\)/);
+  assert.match(source, /errorCode === 'ETHERSCAN_NOT_CONFIGURED'/);
+  assert.match(source, /etherscanConfigured/);
+  assert.match(source, /etherscanCredentialReady/);
   assert.match(source, /SET status = 'queued'/);
   assert.match(source, /credential_generation = \$2/);
   assert.match(source, /credentialChanged/);


### PR DESCRIPTION
## Summary
- limit Moralis audit discovery to Base and Gnosis, with explicit Blockscout fallbacks
- preserve deferred/partial provider coverage and fall back safely on Moralis quota failures during discovery, history pagination, and transaction lookup
- retain state-sync native-credit log identity/raw payloads and receipt verification hashes
- include Etherscan internal evidence, durable observation rehydration, and credential-aware deferred-job recovery

## Validation
- backend `npm test`: 1,101 passed
- backend `npm run lint`: passed
- backend `npm run verify:ledger`: 92/92 passed
- frontend `npm test`: 210 passed
- frontend `npm run lint`: passed with existing warnings only
- frontend `npm run build`: passed
- independent architecture, data-integrity, and code reviews: approved