### PR TITLE
fix: widen deferred audits for full scans

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -132,7 +132,29 @@ class EvmAudit {
           );
           activeJob = refreshed.rows[0];
         }
-        const activeChains = new Set((activeJob.requested_chains || []).map(Number));
+        let activeChains = new Set((activeJob.requested_chains || []).map(Number));
+        // A deferred or not-yet-running incremental request is safe to widen
+        // when the user explicitly asks for the genesis audit. Keep the same
+        // durable job and its provider retry deadline: widening must never
+        // bypass a Moralis quota/cooldown or create overlapping evidence
+        // writers. A running job remains a real scope conflict.
+        if (mode === 'full' && activeJob.mode !== 'full' && activeJob.status !== 'running') {
+          const expandedChains = [...new Set([
+            ...activeChains,
+            ...requestedChains.map(Number),
+          ])];
+          const expanded = await client.query(
+            `UPDATE evm_audit_jobs
+                SET mode = 'full',
+                    requested_chains = $2::jsonb,
+                    updated_at = CURRENT_TIMESTAMP
+              WHERE id = $1 AND status <> 'running'
+            RETURNING *`,
+            [activeJob.id, JSON.stringify(expandedChains)]
+          );
+          activeJob = expanded.rows[0] || activeJob;
+          activeChains = new Set((activeJob.requested_chains || []).map(Number));
+        }
         const modeCovered = activeJob.mode === 'full' || mode === 'incremental';
         const chainsCovered = requestedChains.every((chainId) => activeChains.has(Number(chainId)));
         if (!modeCovered || !chainsCovered) {

--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -162,7 +162,7 @@ class EvmAudit {
           await client.query(
             `UPDATE evm_audit_scopes
                 SET status = 'queued',
-                    requested_from_block = 0,
+                    requested_from_block = CASE WHEN provider = 'consensus-rpc' THEN NULL ELSE 0 END,
                     requested_through_block = NULL,
                     requested_through_hash = NULL,
                     provider_cursor = NULL,

--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -154,6 +154,25 @@ class EvmAudit {
           );
           activeJob = expanded.rows[0] || activeJob;
           activeChains = new Set((activeJob.requested_chains || []).map(Number));
+          // The job may already contain partial incremental pages. Those raw
+          // observations remain valuable evidence, but their cursors and
+          // finite bounds are not valid for a genesis run. Reset only the
+          // provider scopes; the existing-ledger projection is a separate
+          // reconciliation input and must not be replayed here.
+          await client.query(
+            `UPDATE evm_audit_scopes
+                SET status = 'queued',
+                    requested_from_block = 0,
+                    requested_through_block = NULL,
+                    requested_through_hash = NULL,
+                    provider_cursor = NULL,
+                    pagination_exhausted = FALSE,
+                    error_code = NULL,
+                    error_detail = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+              WHERE job_id = $1 AND provider <> 'existing-ledger'`,
+            [activeJob.id]
+          );
         }
         const modeCovered = activeJob.mode === 'full' || mode === 'incremental';
         const chainsCovered = requestedChains.every((chainId) => activeChains.has(Number(chainId)));

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -560,11 +560,26 @@ test('a deferred narrow audit can be widened to full without bypassing cooldown'
     retry_after_at: new Date(Date.now() + 60_000),
   };
   const widened = { ...narrow, mode: 'full', requested_chains: [1, 8453] };
+  const partialScope = {
+    provider: 'moralis', provider_cursor: 'cursor-17',
+    requested_from_block: 123, requested_through_block: 456,
+    requested_through_hash: `0x${'ef'.repeat(32)}`,
+    pagination_exhausted: true,
+  };
   const client = {
     query: async (sql, params) => {
       calls.push({ sql, params });
       if (/FROM evm_audit_jobs/.test(sql) && /FOR UPDATE/.test(sql)) return { rows: [narrow] };
       if (/SET mode = 'full'/.test(sql)) return { rows: [widened] };
+      if (/UPDATE evm_audit_scopes/.test(sql)) {
+        Object.assign(partialScope, {
+          status: 'queued', provider_cursor: null,
+          requested_from_block: 0, requested_through_block: null,
+          requested_through_hash: null, pagination_exhausted: false,
+          error_code: null, error_detail: null,
+        });
+        return { rows: [partialScope] };
+      }
       return { rows: [] };
     },
     release: () => {},
@@ -587,6 +602,15 @@ test('a deferred narrow audit can be widened to full without bypassing cooldown'
   const update = calls.find(({ sql }) => /SET mode = 'full'/.test(sql));
   assert.ok(update);
   assert.match(update.sql, /status <> 'running'/);
+  const reset = calls.find(({ sql }) => /UPDATE evm_audit_scopes/.test(sql));
+  assert.ok(reset);
+  assert.match(reset.sql, /requested_from_block = 0/);
+  assert.match(reset.sql, /provider_cursor = NULL/);
+  assert.match(reset.sql, /pagination_exhausted = FALSE/);
+  assert.match(reset.sql, /provider <> 'existing-ledger'/);
+  assert.equal(partialScope.provider_cursor, null);
+  assert.equal(partialScope.requested_from_block, 0);
+  assert.equal(partialScope.pagination_exhausted, false);
   assert.equal(calls.at(-1).sql, 'COMMIT');
 });
 

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -604,7 +604,7 @@ test('a deferred narrow audit can be widened to full without bypassing cooldown'
   assert.match(update.sql, /status <> 'running'/);
   const reset = calls.find(({ sql }) => /UPDATE evm_audit_scopes/.test(sql));
   assert.ok(reset);
-  assert.match(reset.sql, /requested_from_block = 0/);
+  assert.match(reset.sql, /requested_from_block = CASE WHEN provider = 'consensus-rpc' THEN NULL ELSE 0 END/);
   assert.match(reset.sql, /provider_cursor = NULL/);
   assert.match(reset.sql, /pagination_exhausted = FALSE/);
   assert.match(reset.sql, /provider <> 'existing-ledger'/);

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -547,6 +547,49 @@ test('deferred audits can be reopened after a credential generation change', () 
   assert.match(source, /error_code = NULL/);
 });
 
+test('a deferred narrow audit can be widened to full without bypassing cooldown', async (t) => {
+  const originalConnect = database.connect;
+  const originalEnsureSubject = EvmAudit.ensureSubject;
+  const calls = [];
+  const narrow = {
+    id: 44,
+    status: 'deferred',
+    mode: 'incremental',
+    requested_chains: [1],
+    error_code: 'MORALIS_QUOTA_EXHAUSTED',
+    retry_after_at: new Date(Date.now() + 60_000),
+  };
+  const widened = { ...narrow, mode: 'full', requested_chains: [1, 8453] };
+  const client = {
+    query: async (sql, params) => {
+      calls.push({ sql, params });
+      if (/FROM evm_audit_jobs/.test(sql) && /FOR UPDATE/.test(sql)) return { rows: [narrow] };
+      if (/SET mode = 'full'/.test(sql)) return { rows: [widened] };
+      return { rows: [] };
+    },
+    release: () => {},
+  };
+  t.after(() => {
+    database.connect = originalConnect;
+    EvmAudit.ensureSubject = originalEnsureSubject;
+  });
+  database.connect = async () => client;
+  EvmAudit.ensureSubject = async () => ({ id: 8, address: WALLET });
+
+  const result = await EvmAudit.createOrFindActiveJob(7, { id: 3, address: WALLET }, {
+    mode: 'full', requestedChains: [1, 8453], credentialGeneration: null,
+  });
+
+  assert.equal(result.created, false);
+  assert.equal(result.job.mode, 'full');
+  assert.deepEqual(result.job.requested_chains, [1, 8453]);
+  assert.equal(result.job.status, 'deferred');
+  const update = calls.find(({ sql }) => /SET mode = 'full'/.test(sql));
+  assert.ok(update);
+  assert.match(update.sql, /status <> 'running'/);
+  assert.equal(calls.at(-1).sql, 'COMMIT');
+});
+
 test('same-credential deferred retries preserve provider cooldown', () => {
   const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
   assert.match(source, /if \(result\.job\.status !== 'deferred'\) this\.enqueue\(result\.job\.id\);/);


### PR DESCRIPTION
## What changed

A full history audit request can now widen an existing queued or deferred incremental audit into the same durable full-scan job.

## Why

The production UI had a deferred incremental audit marked active, so clicking the full Audit action returned a scope-conflict error even though no worker was running. The widened job preserves the existing provider retry deadline and never bypasses Moralis quota/cooldown handling or creates overlapping evidence writers.

## Validation

- Backend lint passed.
- Focused EVM audit and state-sync tests passed: 71/71.
- The repository-wide backend run reached 1,067 passing tests with no assertion failures before it was stopped while a live-provider test waited on an external provider; the remaining test process was cancelled, not failed by an assertion.
- `git diff --check` passed.