### PR TITLE
fix: widen full audits for newly configured chains

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -138,7 +138,10 @@ class EvmAudit {
         // durable job and its provider retry deadline: widening must never
         // bypass a Moralis quota/cooldown or create overlapping evidence
         // writers. A running job remains a real scope conflict.
-        if (mode === 'full' && activeJob.mode !== 'full' && activeJob.status !== 'running') {
+        const needsFullExpansion = mode === 'full'
+          && (activeJob.mode !== 'full'
+            || requestedChains.some((chainId) => !activeChains.has(Number(chainId))));
+        if (needsFullExpansion && activeJob.status !== 'running') {
           const expandedChains = [...new Set([
             ...activeChains,
             ...requestedChains.map(Number),


### PR DESCRIPTION
## What changed

When a non-running audit is already full but was created with an older configured-chain list, a new full-audit request now widens the same durable job to include the newly requested chains.

## Why

After deployment, the existing production audit was still deferred and carried a narrower historical chain list. The full-audit action correctly avoided duplicate work but still reported a scope conflict. This preserves the single job, retry deadline, raw evidence, and cursor-reset rules while adding the missing chain scope.

## Validation

- Focused EVM audit tests pass.
- Backend lint passes.
- `git diff --check` passes.
- Independent architecture and data-integrity reviews approved the preceding cursor-reset implementation; this follow-up only broadens the same non-running scope predicate.