### PR TITLE
fix: retry malformed chain RPC responses

### DIFF
--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -957,7 +957,13 @@ class EtherscanService {
     return result;
   }
 
-  static async _rpcRequest(chainId, method, params, rateLimitState = { attempt: 0 }) {
+  static async _rpcRequest(
+    chainId,
+    method,
+    params,
+    rateLimitState = { attempt: 0 },
+    malformedResponseAttempt = 0
+  ) {
     const rpcUrl = chains.getChain(chainId)?.rpcUrl;
     if (!rpcUrl) return null;
     const provider = rpcProvider(chainId, rpcUrl);
@@ -986,6 +992,30 @@ class EtherscanService {
           error: responseDetailError(detail, response),
           retry: () => this._rpcRequest(chainId, method, params, rateLimitState),
         });
+      }
+      // Public chain RPCs occasionally return an empty JSON-RPC envelope while
+      // the endpoint is healthy. Treat that as a bounded transient response,
+      // not as a missing transaction/balance, while still failing closed after
+      // the retry budget is exhausted.
+      if (!payload.error
+          && payload.result == null
+          && malformedResponseAttempt < EXPLORER_MALFORMED_RESPONSE_RETRIES) {
+        const delayMs = EXPLORER_TRANSIENT_RETRY_BASE_MS
+          * (2 ** malformedResponseAttempt);
+        logger.warn({
+          chainId,
+          method,
+          attempt: malformedResponseAttempt + 1,
+          delayMs,
+        }, 'Chain RPC returned a malformed JSON-RPC envelope; retrying');
+        await sleep(delayMs);
+        return this._rpcRequest(
+          chainId,
+          method,
+          params,
+          rateLimitState,
+          malformedResponseAttempt + 1
+        );
       }
       const error = new Error(`Chain RPC error: ${payload.error?.message || 'invalid response'}`);
       error.code = 'ETHERSCAN_API_ERROR';

--- a/backend/src/services/EtherscanService.js
+++ b/backend/src/services/EtherscanService.js
@@ -990,7 +990,13 @@ class EtherscanService {
           params: rpcParams,
           rateLimitState,
           error: responseDetailError(detail, response),
-          retry: () => this._rpcRequest(chainId, method, params, rateLimitState),
+          retry: () => this._rpcRequest(
+            chainId,
+            method,
+            params,
+            rateLimitState,
+            malformedResponseAttempt
+          ),
         });
       }
       // Public chain RPCs occasionally return an empty JSON-RPC envelope while

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -1752,6 +1752,42 @@ test('Polygon head remains fail-closed after repeated malformed JSON-RPC envelop
   assert.equal(requests, 3);
 });
 
+test('Gnosis JSON-RPC retries malformed envelopes before succeeding', async (t) => {
+  const axios = require('axios');
+  const originalPost = axios.post;
+  let requests = 0;
+  axios.post = async () => {
+    requests += 1;
+    if (requests <= 2) return { data: { jsonrpc: '2.0', id: 1 } };
+    return { data: { jsonrpc: '2.0', id: 1, result: '0x2d69a11' } };
+  };
+  t.after(() => { axios.post = originalPost; });
+
+  assert.equal(
+    await EtherscanService._rpcRequest(100, 'eth_blockNumber', []),
+    '0x2d69a11'
+  );
+  assert.equal(requests, 3);
+});
+
+test('Gnosis JSON-RPC remains fail-closed after malformed envelope retries', async (t) => {
+  const axios = require('axios');
+  const originalPost = axios.post;
+  let requests = 0;
+  axios.post = async () => {
+    requests += 1;
+    return { data: { jsonrpc: '2.0', id: 1 } };
+  };
+  t.after(() => { axios.post = originalPost; });
+
+  await assert.rejects(
+    () => EtherscanService._rpcRequest(100, 'eth_blockNumber', []),
+    (error) => error.code === 'ETHERSCAN_API_ERROR'
+      && /invalid response/.test(error.message)
+  );
+  assert.equal(requests, 3);
+});
+
 test('legacy Blockscout head falls back to the documented explorer endpoint', async (t) => {
   const axios = require('axios');
   const originalGet = axios.get;


### PR DESCRIPTION
## Summary
- retry bounded malformed JSON-RPC envelopes from public chain RPCs
- preserve fail-closed behavior after the retry budget
- add Gnosis-specific regression coverage

This addresses transient `invalid response` failures observed on Gnosis feed coverage. Focused tests and backend lint pass.

## Validation
- `node --test --test-name-pattern='Gnosis JSON-RPC' tests/ethMultiChain.test.js`
- `node --test tests/evmAudit.test.js tests/ethStateSyncFeed.test.js`
- `npm run lint`