### PR TITLE
fix: show deferred audit provider reason

### DIFF
--- a/frontend/src/components/crypto/WalletsPanel.jsx
+++ b/frontend/src/components/crypto/WalletsPanel.jsx
@@ -16,6 +16,15 @@ const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 // after a provider cooldown or a newly entered credential.
 const auditIsPending = (audit) => ['queued', 'running'].includes(audit?.status);
 
+const auditDeferredMessage = (job) => {
+  const detail = String(job?.error_detail || '').trim();
+  const retryAt = job?.retry_after_at ? new Date(job.retry_after_at) : null;
+  const retryText = retryAt && Number.isFinite(retryAt.getTime())
+    ? ` Retry after ${retryAt.toLocaleString()}.`
+    : '';
+  return `Audit deferred${detail ? `: ${detail}` : '; its provider retry schedule remains in effect.'}${retryText}`;
+};
+
 // Addresses render inside fallback chains and sentences composed here, so a
 // missing value must contribute nothing rather than 'unknown'.
 const shortEthAddress = (address) => shortEthAddressOrUnknown(address, '');
@@ -539,7 +548,7 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = s
       const { job } = await ethAPI.startHistoryAudit(wallet.id, { mode });
       setAuditByWallet((current) => ({ ...current, [wallet.id]: job }));
       if (job.status === 'deferred') {
-        showNotice('This audit is still deferred; its provider retry schedule remains in effect.');
+        showNotice(auditDeferredMessage(job));
       } else {
         showNotice(mode === 'full'
           ? 'Full history audit queued. You can leave this page; progress and evidence are saved.'

--- a/frontend/src/pages/CryptoWallets.test.jsx
+++ b/frontend/src/pages/CryptoWallets.test.jsx
@@ -431,6 +431,27 @@ describe('Crypto -> Wallets tab', () => {
     expect(await screen.findByText(/History audit: queued/i)).toBeInTheDocument();
   });
 
+  it('surfaces the persisted reason when an audit remains deferred', async () => {
+    apiMocks.eth.startHistoryAudit.mockResolvedValue({
+      created: false,
+      job: {
+        id: '43',
+        requested_wallet_id: 1,
+        status: 'deferred',
+        stage: 'discovering',
+        error_detail: 'Moralis daily plan quota is exhausted; audit deferred',
+        retry_after_at: '2026-08-09T11:00:00.000Z',
+        progress: {},
+      },
+    });
+    await openEthereumTab([wallet(report())]);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /audit mined history for main/i }))[0]);
+
+    expect(await screen.findByText(/Moralis daily plan quota is exhausted/i)).toBeInTheDocument();
+    expect(screen.getByText(/Retry after/)).toBeInTheDocument();
+  });
+
   it('offers an incremental verification run for idempotency checks', async () => {
     apiMocks.eth.startHistoryAudit.mockResolvedValue({
       created: true,


### PR DESCRIPTION
## Summary
- show the persisted provider error and retry time when a wallet history audit remains deferred
- keep deferred status amber and distinct from queued, running, and failed states
- add regression coverage for Moralis quota deferrals

## Validation
- frontend test suite: 211 passed
- frontend lint: 0 errors (12 existing warnings)
- frontend production build: passed
- two independent reviewers: approved

This does not bypass provider quotas or mark an audit complete.