### PR TITLE
feat: replace Base Moralis history with Coinbase CDP

### DIFF
--- a/backend/migrations/076_moralis_user_key.sql
+++ b/backend/migrations/076_moralis_user_key.sql
@@ -4,6 +4,7 @@
 --
 -- Migrations re-run on every boot. Migration 027 creates the original narrower
 -- constraint on a fresh database, then this migration widens it exactly once.
+-- Migration 079 adds the separate CDP source without reusing the exchange key.
 DO $$
 BEGIN
   IF NOT EXISTS (

--- a/backend/migrations/079_cdp_base_sync.sql
+++ b/backend/migrations/079_cdp_base_sync.sql
@@ -1,0 +1,199 @@
+-- 079: separate, encrypted CDP credential and durable Base history checkpoints.
+--
+-- CDP is not the Coinbase exchange connector. It is a per-user Client API key
+-- for the Base address-history JSON-RPC API and must never share that secret's
+-- storage name or credential resolution path.
+
+-- Keep indexed-provider credential generations independent. A CDP key change
+-- must not reopen a deferred Gnosis/Moralis job, and a Moralis change must not
+-- invalidate a Base/CDP run.
+ALTER TABLE evm_audit_jobs
+  ADD COLUMN IF NOT EXISTS moralis_credential_generation TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS cdp_credential_generation TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'user_api_keys'::regclass
+       AND conname = 'user_api_keys_service_check'
+       AND pg_get_constraintdef(oid) LIKE '%cdp%'
+  ) THEN
+    ALTER TABLE user_api_keys
+      DROP CONSTRAINT IF EXISTS user_api_keys_service_check;
+    ALTER TABLE user_api_keys
+      ADD CONSTRAINT user_api_keys_service_check
+      CHECK (service IN (
+        'plaid_client_id', 'plaid_secret', 'etherscan', 'moralis', 'cdp'
+      ));
+  END IF;
+END $$;
+
+-- One opaque cursor is enough because CDP exposes one complete account stream;
+-- per-feed block cursors remain the derived ledger's public coverage boundary.
+ALTER TABLE eth_wallet_chains
+  ADD COLUMN IF NOT EXISTS provider_cursor TEXT,
+  ADD COLUMN IF NOT EXISTS provider_scan_id UUID,
+  ADD COLUMN IF NOT EXISTS provider_scan_head BIGINT,
+  ADD COLUMN IF NOT EXISTS provider_scan_head_hash VARCHAR(66),
+  ADD COLUMN IF NOT EXISTS provider_scan_order VARCHAR(20) NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS provider_scan_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS provider_scan_status VARCHAR(20) NOT NULL DEFAULT 'idle',
+  ADD COLUMN IF NOT EXISTS provider_scan_owner VARCHAR(160),
+  ADD COLUMN IF NOT EXISTS provider_scan_lease_expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS provider_last_page_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'eth_wallet_chains'::regclass
+       AND conname = 'eth_wallet_chains_provider_scan_running_check'
+  ) THEN
+    ALTER TABLE eth_wallet_chains
+      ADD CONSTRAINT eth_wallet_chains_provider_scan_running_check
+      CHECK (
+        provider_scan_status <> 'running'
+        OR (
+          provider_scan_id IS NOT NULL
+          AND provider_scan_owner IS NOT NULL
+          AND provider_scan_lease_expires_at IS NOT NULL
+        )
+      );
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'eth_wallet_chains'::regclass
+       AND conname = 'eth_wallet_chains_provider_scan_complete_check'
+  ) THEN
+    ALTER TABLE eth_wallet_chains
+      ADD CONSTRAINT eth_wallet_chains_provider_scan_complete_check
+      CHECK (
+        provider_scan_status <> 'complete'
+        OR (provider_scan_owner IS NULL AND provider_scan_lease_expires_at IS NULL)
+      );
+  END IF;
+END $$;
+
+-- A CDP cursor is restart state for one job; observed page order is the
+-- cross-run proof that lets an incremental walk stop at its reorg overlap
+-- instead of replaying genesis. Unknown is deliberately a valid value: a
+-- one-item page does not prove an ordering direction.
+ALTER TABLE evm_audit_scopes
+  ADD COLUMN IF NOT EXISTS provider_order VARCHAR(20) NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE evm_audit_scopes
+  ADD COLUMN IF NOT EXISTS coverage_basis TEXT;
+
+ALTER TABLE evm_source_coverage
+  ADD COLUMN IF NOT EXISTS provider_order VARCHAR(20) NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE evm_source_coverage
+  ADD COLUMN IF NOT EXISTS coverage_basis TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'eth_wallet_chains'::regclass
+       AND conname = 'eth_wallet_chains_provider_scan_status_check'
+  ) THEN
+    ALTER TABLE eth_wallet_chains
+      ADD CONSTRAINT eth_wallet_chains_provider_scan_status_check
+      CHECK (provider_scan_status IN ('idle', 'running', 'deferred', 'failed', 'complete'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'evm_audit_scopes'::regclass
+       AND conname = 'evm_audit_scopes_provider_order_check'
+  ) THEN
+    ALTER TABLE evm_audit_scopes
+      ADD CONSTRAINT evm_audit_scopes_provider_order_check
+      CHECK (provider_order IN ('unknown', 'newest_first', 'oldest_first'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'evm_source_coverage'::regclass
+       AND conname = 'evm_source_coverage_provider_order_check'
+  ) THEN
+    ALTER TABLE evm_source_coverage
+      ADD CONSTRAINT evm_source_coverage_provider_order_check
+      CHECK (provider_order IN ('unknown', 'newest_first', 'oldest_first'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'eth_wallet_chains'::regclass
+       AND conname = 'eth_wallet_chains_provider_scan_order_check'
+  ) THEN
+    ALTER TABLE eth_wallet_chains
+      ADD CONSTRAINT eth_wallet_chains_provider_scan_order_check
+      CHECK (provider_scan_order IN ('unknown', 'newest_first', 'oldest_first'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_eth_wallet_chains_provider_scan
+  ON eth_wallet_chains(wallet_id, chain_id, provider_scan_status, provider_scan_id);
+
+CREATE INDEX IF NOT EXISTS idx_eth_wallet_chains_provider_lease
+  ON eth_wallet_chains(wallet_id, chain_id, provider_scan_lease_expires_at);
+
+-- Raw CDP responses are append-only evidence. scan_id makes a retry within one
+-- run idempotent while allowing a later incremental run to preserve a fresh
+-- response even when the provider returns the same page token again.
+CREATE TABLE IF NOT EXISTS eth_provider_pages (
+  id BIGSERIAL PRIMARY KEY,
+  wallet_id INT NOT NULL REFERENCES eth_wallets(id) ON DELETE CASCADE,
+  chain_id INT NOT NULL,
+  provider VARCHAR(40) NOT NULL,
+  stream VARCHAR(40) NOT NULL,
+  scan_id UUID NOT NULL,
+  cursor_in TEXT,
+  cursor_out TEXT,
+  request_params JSONB NOT NULL,
+  response_sha256 VARCHAR(64) NOT NULL CHECK (response_sha256 ~ '^[0-9a-f]{64}$'),
+  response_raw TEXT,
+  response_json JSONB NOT NULL,
+  item_count INT NOT NULL CHECK (item_count >= 0),
+  observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (wallet_id, chain_id, provider, stream, scan_id, response_sha256)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eth_provider_pages_wallet_chain
+  ON eth_provider_pages(wallet_id, chain_id, observed_at DESC);
+
+-- A CDP page without the exact response body is not a recoverable evidence
+-- record. This table is new in 079; fail migration rather than silently
+-- accepting an already-corrupt page if a partial rollout inserted NULL raw.
+ALTER TABLE eth_provider_pages
+  ALTER COLUMN response_raw SET NOT NULL;
+
+-- Candidate expansion is auxiliary to tracked-wallet Sync. Do not let it
+-- silently fall back to Base's anonymous Blockscout account feeds now that
+-- CDP is the sole Base history provider; retain an explicit amber limitation
+-- instead of retrying an unsupported provider forever.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'eth_discovery_fetches'::regclass
+       AND conname = 'eth_discovery_fetches_status_check'
+  ) THEN
+    ALTER TABLE eth_discovery_fetches DROP CONSTRAINT eth_discovery_fetches_status_check;
+  END IF;
+  ALTER TABLE eth_discovery_fetches
+    ADD CONSTRAINT eth_discovery_fetches_status_check
+    CHECK (status IN ('complete', 'failed', 'truncated', 'contract', 'high_traffic', 'dust', 'unsupported'));
+END $$;

--- a/backend/src/config/chains.js
+++ b/backend/src/config/chains.js
@@ -26,13 +26,11 @@
 //     included. That matters more than it looks: internal traces are how ETH
 //     arriving from a contract is seen at all, so a chain without them silently
 //     drifts away from its own derived balance.
-//   * OP Mainnet (10) and Base (8453) remain paid-plan-only through Etherscan,
-//     so both use their public Blockscout instances instead. OP still uses the
-//     Etherscan-compatible facade. Base's anonymous legacy facade began
-//     returning a standing 429 in August 2026 while its documented v2 REST API
-//     remained healthy, so Base has an explicit v2 adapter. A per-chain
-//     ETHBridgeFinalized log feed records canonical native bridge credits
-//     independently.
+//   * OP Mainnet (10) remains on its public Blockscout instance. Base (8453)
+//     is CDP-only for ordinary history and full audits; its Blockscout adapter
+//     remains available only for a future keyed, transaction-scoped repair.
+//     A per-transaction receipt decoder records Base native bridge credits, so
+//     no chain-wide anonymous bridge-log walk is part of the critical path.
 //   * Polygon PoS (137) is served on the FREE key -- balance, txlist and
 //     txlistinternal all answered on a live probe, so it ships enabled. It is
 //     also the first chain here that is NOT ETH-native (see NATIVE_ASSETS).
@@ -249,6 +247,10 @@ const REGISTRY = [
     nativeAsset: 'ETH',
     coingeckoPlatform: 'base',
     enabledByDefault: true,
+    // Base history is served by the user's separately encrypted Coinbase CDP
+    // Client API key. Blockscout remains configured below only as a keyed,
+    // transaction-scoped repair source; it is not an ordinary sync provider.
+    historyProvider: 'coinbase-cdp',
     accountApi: {
       provider: 'Blockscout',
       baseUrl: 'https://base.blockscout.com/api',
@@ -262,7 +264,7 @@ const REGISTRY = [
       requestSpacingMs: 15000,
     },
     rpcUrl: 'https://mainnet.base.org',
-    ingestVersion: 1,
+    ingestVersion: 2,
     opStackDeposits: {
       creditSource: '0x4200000000000000000000000000000000000010',
     },

--- a/backend/src/models/EthDiscoveryCandidate.js
+++ b/backend/src/models/EthDiscoveryCandidate.js
@@ -39,7 +39,7 @@ class EthDiscoveryCandidate {
            AND r.address = f.address
            AND r.chain_id = f.chain_id
            AND r.depth = f.depth
-           AND r.status IN ('complete', 'contract', 'high_traffic', 'dust')
+           AND r.status IN ('complete', 'contract', 'high_traffic', 'dust', 'unsupported')
        )
        ORDER BY f.score DESC NULLS LAST, f.id ASC
        LIMIT $2`,

--- a/backend/src/models/EthFeedCoverage.js
+++ b/backend/src/models/EthFeedCoverage.js
@@ -10,7 +10,7 @@ const CURSOR_KINDS = new Set(['evm_block', 'archive_serial']);
 // makes the report change as one snapshot: readers cannot observe three feeds
 // from tonight and three from yesterday in the middle of a sync.
 class EthFeedCoverage {
-  static async recordAttempts(walletId, chainId, entries) {
+  static async recordAttempts(walletId, chainId, entries, { scanId = null, owner = null } = {}) {
     if (!Number.isInteger(walletId) || !Number.isInteger(chainId)) {
       throw new Error('EthFeedCoverage.recordAttempts requires integer wallet and chain ids');
     }
@@ -65,8 +65,28 @@ class EthFeedCoverage {
       )`);
     }
 
-    const result = await pool.query(
-      `INSERT INTO eth_feed_coverage (
+    const transactional = Boolean(scanId);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        const owned = await client.query(
+          `SELECT 1 FROM eth_wallet_chains
+            WHERE wallet_id = $1 AND chain_id = $2
+              AND provider_scan_id = $3::uuid AND provider_scan_owner = $4
+              AND provider_scan_status = 'running'
+              AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP
+            FOR UPDATE`,
+          [walletId, chainId, scanId, owner]
+        );
+        if (!owned.rows[0]) {
+          const error = new Error('Base CDP scan is no longer the active writer');
+          error.code = 'CDP_SCAN_STALE';
+          throw error;
+        }
+      }
+      const result = await client.query(
+        `INSERT INTO eth_feed_coverage (
          wallet_id, chain_id, feed, cursor_kind, provider, status,
          covered_from_block, covered_through_block,
          covered_from_at, covered_through_at, indexed_head,
@@ -122,9 +142,16 @@ class EthFeedCoverage {
          END,
          updated_at = CURRENT_TIMESTAMP
        RETURNING *`,
-      params
-    );
-    return result.rows;
+        params
+      );
+      if (transactional) await client.query('COMMIT');
+      return result.rows;
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
   static async findForUser(userId) {

--- a/backend/src/models/EthProviderPage.js
+++ b/backend/src/models/EthProviderPage.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const pool = require('../config/database');
+
+function stableJson(value) {
+  if (Array.isArray(value)) return value.map(stableJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableJson(value[key])]));
+  }
+  return value;
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex');
+}
+
+// Ordinary Base Sync has its own raw-page journal. The audit evidence plane is
+// intentionally not reused: a user-initiated sync and a full audit have
+// different lifetimes and different restart cursors, but both must retain what
+// the provider actually returned.
+class EthProviderPage {
+  static async record({
+    walletId, chainId, provider, stream, scanId, cursorIn = null, cursorOut = null,
+    requestParams = {}, responseSha256, responseRaw = null, responseJson = {}, itemCount = 0,
+    owner = null,
+  }) {
+    if (!responseRaw || sha256(responseRaw) !== String(responseSha256 || '').toLowerCase()) {
+      const error = new Error('Base CDP raw page is missing or its response hash does not match');
+      error.code = 'CDP_INVALID_RAW_PAGE';
+      throw error;
+    }
+    const transactional = Boolean(owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        const owned = await client.query(
+          `SELECT 1 FROM eth_wallet_chains
+            WHERE wallet_id = $1 AND chain_id = $2
+              AND provider_scan_id = $3::uuid AND provider_scan_owner = $4
+              AND provider_scan_status = 'running'
+              AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP
+            FOR UPDATE`,
+          [walletId, chainId, scanId, owner]
+        );
+        if (!owned.rows[0]) {
+          const error = new Error('Base CDP scan is no longer the active writer');
+          error.code = 'CDP_SCAN_STALE';
+          throw error;
+        }
+      }
+      const inserted = await client.query(
+        `INSERT INTO eth_provider_pages (
+         wallet_id, chain_id, provider, stream, scan_id, cursor_in, cursor_out,
+         request_params, response_sha256, response_raw, response_json, item_count
+       ) VALUES ($1,$2,$3,$4,$5::uuid,$6,$7,$8::jsonb,$9,$10,$11::jsonb,$12)
+       ON CONFLICT (wallet_id, chain_id, provider, stream, scan_id, response_sha256)
+       DO NOTHING
+       RETURNING *`,
+      [
+        walletId, chainId, provider, stream, scanId, cursorIn, cursorOut,
+        JSON.stringify(requestParams), responseSha256, responseRaw,
+        JSON.stringify(responseJson), itemCount,
+      ]
+      );
+      let row = inserted.rows[0];
+      if (!row) {
+        const existing = await client.query(
+          `SELECT * FROM eth_provider_pages
+            WHERE wallet_id = $1 AND chain_id = $2 AND provider = $3
+              AND stream = $4 AND scan_id = $5::uuid AND response_sha256 = $6`,
+          [walletId, chainId, provider, stream, scanId, responseSha256]
+        );
+        row = existing.rows[0];
+        if (!row || String(row.cursor_in || '') !== String(cursorIn || '')
+            || String(row.cursor_out || '') !== String(cursorOut || '')
+            || JSON.stringify(stableJson(row.request_params))
+              !== JSON.stringify(stableJson(requestParams))
+            || String(row.response_raw || '') !== String(responseRaw)) {
+          const error = new Error('Coinbase CDP returned conflicting data for an already journaled page');
+          error.code = 'CDP_CONFLICTING_PAGE';
+          throw error;
+        }
+      }
+      if (transactional) await client.query('COMMIT');
+      return row;
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
+  }
+
+  static async forScan(walletId, chainId, scanId) {
+    const result = await pool.query(
+      `SELECT * FROM eth_provider_pages
+        WHERE wallet_id = $1 AND chain_id = $2 AND scan_id = $3::uuid
+        ORDER BY id`,
+      [walletId, chainId, scanId]
+    );
+    return result.rows;
+  }
+
+  static async forWalletChain(walletId, chainId, provider = 'coinbase-cdp') {
+    const result = await pool.query(
+      `SELECT * FROM eth_provider_pages
+        WHERE wallet_id = $1 AND chain_id = $2 AND provider = $3
+        ORDER BY id`,
+      [walletId, chainId, provider]
+    );
+    return result.rows;
+  }
+}
+
+module.exports = EthProviderPage;

--- a/backend/src/models/EthTransfer.js
+++ b/backend/src/models/EthTransfer.js
@@ -181,7 +181,9 @@ class EthTransfer {
   //     own delete was skipped -- preserving the "a failed feed keeps its rows"
   //     invariant across the shared transfer_type.
   // Both are no-ops on every other feed and chain, which pass neither.
-  static async deleteFromBlock(walletId, chainId, transferTypes, block, { fromAddress = null, excludeFromAddress = null } = {}) {
+  static async deleteFromBlock(walletId, chainId, transferTypes, block, {
+    fromAddress = null, excludeFromAddress = null, client = pool,
+  } = {}) {
     const params = [walletId, chainId, transferTypes, block];
     let addressClause = '';
     if (fromAddress) {
@@ -191,7 +193,7 @@ class EthTransfer {
       params.push(excludeFromAddress.toLowerCase());
       addressClause = ` AND from_address <> $${params.length}`;
     }
-    await pool.query(
+    await client.query(
       `DELETE FROM eth_transfers
        WHERE wallet_id = $1 AND chain_id = $2 AND transfer_type = ANY($3)
          AND block_number >= $4 AND audit_effect_key IS NULL${addressClause}`,
@@ -199,7 +201,7 @@ class EthTransfer {
     );
   }
 
-  static async bulkInsert(rows) {
+  static async bulkInsert(rows, { client = pool } = {}) {
     if (!rows.length) return 0;
     const cols = [
       'wallet_id', 'chain_id', 'tx_hash', 'ordinal', 'transfer_type', 'block_number',
@@ -234,7 +236,7 @@ class EthTransfer {
         );
         return `(${cols.map((_, j) => `$${base + j + 1}`).join(', ')})`;
       });
-      const result = await pool.query(
+      const result = await client.query(
         `INSERT INTO eth_transfers (${cols.join(', ')})
          VALUES ${placeholders.join(', ')}
          ON CONFLICT (wallet_id, chain_id, transfer_type, tx_hash, ordinal) DO NOTHING`,
@@ -243,6 +245,48 @@ class EthTransfer {
       inserted += result.rowCount;
     }
     return inserted;
+  }
+
+  // Base CDP history is one provider stream projected into several ordinary
+  // feeds. Replace every successfully fetched overlap window in one database
+  // transaction so a deadlock/constraint error cannot leave old rows deleted
+  // while the durable cursors still claim the provider walk succeeded.
+  static async replaceFeeds(walletId, chainId, replacements, rows, { scanId = null, owner = null } = {}) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      if (scanId) {
+        const owned = await client.query(
+          `SELECT 1 FROM eth_wallet_chains
+            WHERE wallet_id = $1 AND chain_id = $2
+              AND provider_scan_id = $3::uuid
+              AND provider_scan_owner = $4
+              AND provider_scan_status = 'running'
+              AND (provider_scan_lease_expires_at IS NULL OR provider_scan_lease_expires_at > CURRENT_TIMESTAMP)
+            FOR UPDATE`,
+          [walletId, chainId, scanId, owner]
+        );
+        if (!owned.rows[0]) {
+          const error = new Error('Base CDP scan is no longer the active writer');
+          error.code = 'CDP_SCAN_STALE';
+          throw error;
+        }
+      }
+      for (const replacement of replacements) {
+        await this.deleteFromBlock(
+          walletId, chainId, replacement.types, replacement.block,
+          { ...(replacement.options || {}), client }
+        );
+      }
+      const inserted = await this.bulkInsert(rows, { client });
+      await client.query('COMMIT');
+      return inserted;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   // Selectors this wallet has stored but cannot yet name -- the decode pass's

--- a/backend/src/models/EthWalletChain.js
+++ b/backend/src/models/EthWalletChain.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const pool = require('../config/database');
 
 // Per-(wallet, chain) sync state: resume cursors, the error/degraded slot, and
@@ -46,6 +47,16 @@ class EthWalletChain {
            last_block_nft = 0,
            last_block_1155 = 0,
            last_block_statesync = 0,
+           provider_cursor = NULL,
+           provider_scan_id = NULL,
+           provider_scan_head = NULL,
+           provider_scan_head_hash = NULL,
+           provider_scan_order = 'unknown',
+           provider_scan_started_at = NULL,
+           provider_scan_status = 'idle',
+           provider_scan_owner = NULL,
+           provider_scan_lease_expires_at = NULL,
+           provider_last_page_at = NULL,
            ingest_version = $3,
            error_code = NULL,
            error_message = NULL,
@@ -83,6 +94,16 @@ class EthWalletChain {
            last_block_nft = 0,
            last_block_1155 = 0,
            last_block_statesync = 0,
+           provider_cursor = NULL,
+           provider_scan_id = NULL,
+           provider_scan_head = NULL,
+           provider_scan_head_hash = NULL,
+           provider_scan_order = 'unknown',
+           provider_scan_started_at = NULL,
+           provider_scan_status = 'idle',
+           provider_scan_owner = NULL,
+           provider_scan_lease_expires_at = NULL,
+           provider_last_page_at = NULL,
            error_code = NULL,
            error_message = NULL,
            unsupported_feeds = '{}',
@@ -121,7 +142,17 @@ class EthWalletChain {
   // native-credit feeds carry the common scanned explorer head even when empty,
   // so a completed historical rebuild resumes incrementally next time. A chain
   // that does not declare statesync passes NULL for that feed.
-  static async updateCursors(walletId, chainId, { normal, internal, token, nft, nft1155, statesync }) {
+  static async updateCursors(
+    walletId, chainId, { normal, internal, token, nft, nft1155, statesync },
+    { scanId = null, owner = null } = {}
+  ) {
+    const params = [walletId, chainId, normal ?? null, internal ?? null, token ?? null,
+      nft ?? null, nft1155 ?? null, statesync ?? null];
+    const fence = scanId
+      ? ' AND provider_scan_id = $9::uuid AND provider_scan_owner = $10'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP'
+      : '';
+    if (scanId) params.push(scanId, owner);
     const result = await pool.query(
       `UPDATE eth_wallet_chains
        SET last_block_normal = COALESCE($3, last_block_normal),
@@ -131,20 +162,184 @@ class EthWalletChain {
            last_block_1155 = COALESCE($7, last_block_1155),
            last_block_statesync = COALESCE($8, last_block_statesync),
            updated_at = CURRENT_TIMESTAMP
-       WHERE wallet_id = $1 AND chain_id = $2
+       WHERE wallet_id = $1 AND chain_id = $2${fence}
        RETURNING *`,
-      [walletId, chainId, normal ?? null, internal ?? null, token ?? null, nft ?? null, nft1155 ?? null, statesync ?? null]
+      params
     );
     return result.rows[0];
   }
 
-  static async updateSyncTime(walletId, chainId) {
+  static async updateSyncTime(
+    walletId, chainId, { scanId = null, owner = null, completed = false } = {}
+  ) {
+    const params = [walletId, chainId];
+    let fence = '';
+    if (scanId && completed) {
+      fence = ' AND provider_scan_id = $3::uuid AND provider_scan_status = \'complete\' AND provider_scan_owner IS NULL';
+      params.push(scanId);
+    } else if (scanId) {
+      fence = ' AND provider_scan_id = $3::uuid AND provider_scan_owner = $4'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP';
+      params.push(scanId, owner);
+    }
     const result = await pool.query(
       `UPDATE eth_wallet_chains
        SET last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
-       WHERE wallet_id = $1 AND chain_id = $2
+       WHERE wallet_id = $1 AND chain_id = $2${fence}
        RETURNING *`,
-      [walletId, chainId]
+      params
+    );
+    return result.rows[0];
+  }
+
+  // CDP's address-history stream is the single source cursor for Base. A
+  // completed scan starts a new run; a running/deferred/failed scan with the
+  // same finalized head resumes its last committed page token after a restart.
+  // The token is opaque and is never interpreted or exposed to the client.
+  static async startProviderScan(
+    walletId, chainId, throughBlock, throughHash = null, owner = null,
+    leaseMs = 2 * 60 * 1000
+  ) {
+    const current = await this.ensure(walletId, chainId);
+    const scanOwner = String(owner || `legacy:${process.pid}`);
+    const safeLeaseMs = Math.min(10 * 60 * 1000, Math.max(30 * 1000, Number(leaseMs) || 2 * 60 * 1000));
+    const leaseAt = new Date(Date.now() + safeLeaseMs);
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const locked = await client.query(
+        `SELECT * FROM eth_wallet_chains
+          WHERE wallet_id = $1 AND chain_id = $2
+          FOR UPDATE`,
+        [walletId, chainId]
+      );
+      const row = locked.rows[0] || current;
+      if (!row) throw new Error('Wallet chain sync state no longer exists');
+      const sameHead = Number(row.provider_scan_head) === Number(throughBlock)
+        && String(row.provider_scan_head_hash || '') === String(throughHash || '');
+      const leaseActive = row.provider_scan_lease_expires_at
+        && new Date(row.provider_scan_lease_expires_at).getTime() > Date.now();
+      if (row.provider_scan_status === 'running' && leaseActive
+          && row.provider_scan_owner && row.provider_scan_owner !== scanOwner) {
+        await client.query('COMMIT');
+        return null;
+      }
+      const resumable = row.provider_scan_id
+        && ['running', 'deferred', 'failed'].includes(row.provider_scan_status)
+        && sameHead;
+      const scanId = resumable ? row.provider_scan_id : crypto.randomUUID();
+      const result = await client.query(
+        `UPDATE eth_wallet_chains
+            SET provider_cursor = CASE WHEN $3 THEN provider_cursor ELSE NULL END,
+                provider_scan_id = $4::uuid,
+                provider_scan_head = $5,
+                provider_scan_head_hash = $6,
+                provider_scan_started_at = CASE WHEN $3 THEN provider_scan_started_at ELSE CURRENT_TIMESTAMP END,
+                provider_scan_status = 'running',
+                provider_scan_owner = $7,
+                provider_scan_lease_expires_at = $8,
+                provider_last_page_at = NULL,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE wallet_id = $1 AND chain_id = $2
+        RETURNING *`,
+        [walletId, chainId, Boolean(resumable), scanId, throughBlock, throughHash, scanOwner, leaseAt]
+      );
+      await client.query('COMMIT');
+      return result.rows[0];
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  static async checkpointProviderScan(walletId, chainId, scanId, cursor, owner = null) {
+    // The optional legacy shape is retained for callers/tests that predate
+    // provider fencing. Base CDP passes scanId + owner and therefore cannot
+    // checkpoint a scan that another worker has taken over.
+    if (arguments.length === 3) {
+      cursor = scanId;
+      scanId = null;
+    }
+    const params = [walletId, chainId, cursor || null];
+    const fence = scanId
+      ? ' AND provider_scan_id = $4::uuid AND provider_scan_owner = $5'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP'
+      : '';
+    if (scanId) params.push(scanId, owner);
+    const result = await pool.query(
+      `UPDATE eth_wallet_chains
+          SET provider_cursor = $3,
+              provider_scan_status = 'running',
+              provider_scan_lease_expires_at = CURRENT_TIMESTAMP + INTERVAL '2 minutes',
+              provider_last_page_at = CURRENT_TIMESTAMP,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE wallet_id = $1 AND chain_id = $2${fence}
+      RETURNING *`,
+      params
+    );
+    return result.rows[0];
+  }
+
+  static async finishProviderScan(walletId, chainId, scanId = null, owner = null) {
+    const params = [walletId, chainId];
+    const fence = scanId
+      ? ' AND provider_scan_id = $3::uuid AND provider_scan_owner = $4'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP'
+      : '';
+    if (scanId) params.push(scanId, owner);
+    const result = await pool.query(
+      `UPDATE eth_wallet_chains
+          SET provider_cursor = NULL,
+              provider_scan_status = 'complete',
+              provider_scan_owner = NULL,
+              provider_scan_lease_expires_at = NULL,
+              provider_last_page_at = CURRENT_TIMESTAMP,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE wallet_id = $1 AND chain_id = $2${fence}
+      RETURNING *`,
+      params
+    );
+    return result.rows[0];
+  }
+
+  static async failProviderScan(walletId, chainId, status = 'failed', scanId = null, owner = null) {
+    const params = [walletId, chainId, status];
+    const fence = scanId
+      ? ' AND provider_scan_id = $4::uuid AND provider_scan_owner = $5'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP'
+      : '';
+    if (scanId) params.push(scanId, owner);
+    const result = await pool.query(
+      `UPDATE eth_wallet_chains
+          SET provider_scan_status = $3,
+              provider_scan_owner = NULL,
+              provider_scan_lease_expires_at = NULL,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE wallet_id = $1 AND chain_id = $2${fence}
+      RETURNING *`,
+      params
+    );
+    return result.rows[0];
+  }
+
+  static async setProviderScanOrder(walletId, chainId, order, scanId = null, owner = null) {
+    const value = ['unknown', 'newest_first', 'oldest_first'].includes(order)
+      ? order : 'unknown';
+    const params = [walletId, chainId, value];
+    const fence = scanId
+      ? ' AND provider_scan_id = $4::uuid AND provider_scan_owner = $5'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP'
+      : '';
+    if (scanId) params.push(scanId, owner);
+    const result = await pool.query(
+      `UPDATE eth_wallet_chains
+          SET provider_scan_order = $3,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE wallet_id = $1 AND chain_id = $2${fence}
+      RETURNING *`,
+      params
     );
     return result.rows[0];
   }
@@ -152,35 +347,66 @@ class EthWalletChain {
   // Written on every sync of the chain, including with an empty array, so a
   // feed that starts working again (a plan upgrade, an Etherscan rollout)
   // clears its gap instead of warning about drift forever.
-  static async setUnsupportedFeeds(walletId, chainId, feeds) {
+  static async setUnsupportedFeeds(walletId, chainId, feeds, { scanId = null, owner = null } = {}) {
+    const params = [walletId, chainId, feeds];
+    const fence = scanId
+      ? ' AND provider_scan_id = $4::uuid AND provider_scan_owner = $5'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP'
+      : '';
+    if (scanId) params.push(scanId, owner);
     const result = await pool.query(
       `UPDATE eth_wallet_chains
        SET unsupported_feeds = $3, updated_at = CURRENT_TIMESTAMP
-       WHERE wallet_id = $1 AND chain_id = $2
+       WHERE wallet_id = $1 AND chain_id = $2${fence}
        RETURNING *`,
-      [walletId, chainId, feeds]
+      params
     );
     return result.rows[0];
   }
 
-  static async setError(walletId, chainId, errorCode, errorMessage) {
+  static async setError(
+    walletId, chainId, errorCode, errorMessage,
+    { scanId = null, owner = null, completed = false } = {}
+  ) {
+    const params = [walletId, chainId, errorCode, errorMessage];
+    let fence = '';
+    if (scanId && completed) {
+      fence = ' AND provider_scan_id = $5::uuid AND provider_scan_status = \'complete\' AND provider_scan_owner IS NULL';
+      params.push(scanId);
+    } else if (scanId) {
+      fence = ' AND provider_scan_id = $5::uuid AND provider_scan_owner = $6'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP';
+      params.push(scanId, owner);
+    }
     const result = await pool.query(
       `UPDATE eth_wallet_chains
        SET error_code = $3, error_message = $4, updated_at = CURRENT_TIMESTAMP
-       WHERE wallet_id = $1 AND chain_id = $2
+       WHERE wallet_id = $1 AND chain_id = $2${fence}
        RETURNING *`,
-      [walletId, chainId, errorCode, errorMessage]
+      params
     );
     return result.rows[0];
   }
 
-  static async clearError(walletId, chainId) {
+  static async clearError(
+    walletId, chainId, { scanId = null, owner = null, completed = false } = {}
+  ) {
+    const params = [walletId, chainId];
+    let fence = '';
+    if (scanId && completed) {
+      fence = ' AND provider_scan_id = $3::uuid AND provider_scan_status = \'complete\' AND provider_scan_owner IS NULL';
+      params.push(scanId);
+    } else if (scanId) {
+      fence = ' AND provider_scan_id = $3::uuid AND provider_scan_owner = $4'
+        + ' AND provider_scan_status = \'running\' AND provider_scan_lease_expires_at > CURRENT_TIMESTAMP';
+      params.push(scanId, owner);
+    }
     const result = await pool.query(
       `UPDATE eth_wallet_chains
        SET error_code = NULL, error_message = NULL, updated_at = CURRENT_TIMESTAMP
-       WHERE wallet_id = $1 AND chain_id = $2
+       WHERE wallet_id = $1 AND chain_id = $2${fence}
        RETURNING *`,
-      [walletId, chainId]
+      params
     );
     return result.rows[0];
   }

--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -2,9 +2,10 @@
 
 const crypto = require('node:crypto');
 const pool = require('../config/database');
+const { sha256 } = require('../services/evmAudit/normalizer');
 const {
   matchesLegacyTransfer,
-  matchesMoralisTransfer,
+  matchesIndexedTransfer,
   TRANSFER_TYPES,
 } = require('../services/evmAudit/corroboratedIdentity');
 
@@ -25,6 +26,46 @@ function chunks(items, size) {
     result.push(items.slice(index, index + size));
   }
   return result;
+}
+
+function validateProviderPage(page) {
+  if (['coinbase-cdp', 'consensus-rpc'].includes(page.provider)
+      && typeof page.responseRaw !== 'string') {
+    const error = new Error(`${page.provider} evidence must retain the raw response body`);
+    error.code = 'EVM_INVALID_RAW_PAGE';
+    throw error;
+  }
+  if (page.responseRaw != null && sha256(page.responseRaw) !== page.responseSha256) {
+    const error = new Error('EVM provider raw page hash does not match its response body');
+    error.code = 'EVM_INVALID_RAW_PAGE';
+    throw error;
+  }
+}
+
+function pageConflict(existing, page) {
+  return existing.provider !== page.provider
+    || existing.endpoint !== page.endpoint
+    || sha256(existing.request_params || {}) !== sha256(page.requestParams || {})
+    || existing.cursor_in !== (page.cursorIn || null)
+    || existing.cursor_out !== (page.cursorOut || null)
+    || existing.response_raw !== (page.responseRaw ?? null)
+    || sha256(existing.response_json || {}) !== sha256(page.responseJson || {})
+    || Number(existing.item_count) !== Number(page.itemCount);
+}
+
+async function assertActiveLease(client, jobId, owner) {
+  const { rows } = await client.query(
+    `SELECT 1 FROM evm_audit_jobs
+      WHERE id = $1 AND status = 'running' AND lease_owner = $2
+        AND lease_expires_at > CURRENT_TIMESTAMP
+      FOR UPDATE`,
+    [jobId, owner]
+  );
+  if (!rows[0]) {
+    const error = new Error('EVM audit lease is no longer active');
+    error.code = 'EVM_AUDIT_LEASE_LOST';
+    throw error;
+  }
 }
 
 class EvmAudit {
@@ -60,12 +101,25 @@ class EvmAudit {
     }
   }
 
-  static async credentialGeneration(userId) {
+  static async credentialGenerations(userId) {
     const { rows } = await pool.query(
-      `SELECT updated_at FROM user_api_keys WHERE user_id = $1 AND service = 'moralis'`,
+      `SELECT service, MAX(updated_at) AS updated_at
+         FROM user_api_keys
+        WHERE user_id = $1 AND service IN ('moralis', 'cdp')
+        GROUP BY service`,
       [userId]
     );
-    return rows[0]?.updated_at || null;
+    return rows.reduce((result, row) => {
+      result[row.service] = row.updated_at || null;
+      return result;
+    }, { moralis: null, cdp: null });
+  }
+
+  static async credentialGeneration(userId) {
+    const generations = await this.credentialGenerations(userId);
+    return [generations.moralis, generations.cdp]
+      .filter(Boolean)
+      .sort((left, right) => new Date(right).getTime() - new Date(left).getTime())[0] || null;
   }
 
   static async ensureSubject(userId, address, client = pool) {
@@ -83,8 +137,18 @@ class EvmAudit {
 
   static async createOrFindActiveJob(userId, wallet, {
     mode = 'incremental', requestedChains = [], credentialGeneration = null,
-    etherscanConfigured = false,
+    credentialGenerations = null,
+    etherscanConfigured = false, cdpConfigured = false,
   } = {}) {
+    const providerGenerations = credentialGenerations || {
+      moralis: credentialGeneration,
+      cdp: credentialGeneration,
+    };
+    const latestCredentialGeneration = credentialGeneration
+      || [providerGenerations.moralis, providerGenerations.cdp]
+        .filter(Boolean)
+        .sort((left, right) => new Date(right).getTime() - new Date(left).getTime())[0]
+      || null;
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
@@ -105,30 +169,53 @@ class EvmAudit {
       if (active.rows[0]) {
         let activeJob = active.rows[0];
         const errorCode = String(activeJob.error_code || '');
-        const moralisDeferred = errorCode.startsWith('MORALIS_');
+        const indexedProviderDeferred = errorCode.startsWith('MORALIS_')
+          || errorCode.startsWith('CDP_');
+        const deferredProvider = errorCode.startsWith('MORALIS_') ? 'moralis'
+          : errorCode.startsWith('CDP_') ? 'cdp' : null;
         // Etherscan's credential is also user-scoped, but its deferred job may
         // have no Moralis generation change to record. Re-open as soon as the
         // Settings key exists so a missing-key deferral is not sticky for 24h.
         const etherscanCredentialReady = errorCode === 'ETHERSCAN_NOT_CONFIGURED'
           && etherscanConfigured;
-        const credentialChanged = etherscanCredentialReady || (moralisDeferred && (activeJob.credential_generation == null
-          ? credentialGeneration != null
-          : credentialGeneration == null
-            || new Date(activeJob.credential_generation).getTime()
-              !== new Date(credentialGeneration).getTime()));
+        const cdpCredentialReady = errorCode === 'CDP_NOT_CONFIGURED' && cdpConfigured;
+        const deferredProviderGeneration = deferredProvider
+          ? providerGenerations[deferredProvider] : null;
+        const deferredProviderGenerationColumn = deferredProvider
+          ? `${deferredProvider}_credential_generation` : null;
+        const priorProviderGeneration = deferredProviderGenerationColumn
+          ? activeJob[deferredProviderGenerationColumn] || (
+            // Jobs created before provider-specific generations were added can
+            // fall back to the legacy value only when exactly one indexed
+            // provider was requested. A combined timestamp is ambiguous when
+            // both Moralis and CDP were in scope.
+            (activeJob.requested_chains || []).length === 1
+              ? activeJob.credential_generation : null
+          ) : null;
+        const deferredProviderGenerationChanged = indexedProviderDeferred && deferredProvider
+          && (priorProviderGeneration == null
+            ? deferredProviderGeneration != null
+            : deferredProviderGeneration == null
+              || new Date(priorProviderGeneration).getTime()
+                !== new Date(deferredProviderGeneration).getTime());
+        const credentialChanged = etherscanCredentialReady || cdpCredentialReady
+          || deferredProviderGenerationChanged;
         if (activeJob.status === 'deferred' && credentialChanged) {
           const refreshed = await client.query(
             `UPDATE evm_audit_jobs
                 SET status = 'queued',
                     stage = 'queued',
                     credential_generation = $2,
+                    moralis_credential_generation = $3,
+                    cdp_credential_generation = $4,
                     retry_after_at = NULL,
                     error_code = NULL,
                     error_detail = NULL,
                     updated_at = CURRENT_TIMESTAMP
               WHERE id = $1
             RETURNING *`,
-            [activeJob.id, credentialGeneration]
+            [activeJob.id, latestCredentialGeneration, providerGenerations.moralis,
+              providerGenerations.cdp]
           );
           activeJob = refreshed.rows[0];
         }
@@ -169,6 +256,7 @@ class EvmAudit {
                     requested_through_block = NULL,
                     requested_through_hash = NULL,
                     provider_cursor = NULL,
+                    provider_order = 'unknown',
                     pagination_exhausted = FALSE,
                     error_code = NULL,
                     error_detail = NULL,
@@ -191,12 +279,14 @@ class EvmAudit {
       const inserted = await client.query(
         `INSERT INTO evm_audit_jobs (
            user_id, subject_id, requested_wallet_id, mode, idempotency_key,
-           credential_generation, requested_chains
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+           credential_generation, moralis_credential_generation,
+           cdp_credential_generation, requested_chains
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
          RETURNING *`,
         [
           userId, subject.id, wallet.id, mode, idempotencyKey,
-          credentialGeneration, JSON.stringify(requestedChains),
+          latestCredentialGeneration, providerGenerations.moralis,
+          providerGenerations.cdp, JSON.stringify(requestedChains),
         ]
       );
       await client.query('COMMIT');
@@ -344,6 +434,7 @@ class EvmAudit {
               heartbeat_at = CURRENT_TIMESTAMP,
               updated_at = CURRENT_TIMESTAMP
         WHERE id = $1 AND lease_owner = $2 AND status = 'running'
+          AND lease_expires_at > CURRENT_TIMESTAMP
       RETURNING *`,
       [jobId, owner, stage, progress == null ? null : JSON.stringify(progress), leaseSeconds]
     );
@@ -367,7 +458,10 @@ class EvmAudit {
               lease_expires_at = NULL,
               heartbeat_at = CURRENT_TIMESTAMP,
               updated_at = CURRENT_TIMESTAMP
-        WHERE id = $1 AND ($2::text IS NULL OR lease_owner = $2)
+        WHERE id = $1 AND (
+          $2::text IS NULL
+          OR (lease_owner = $2 AND status = 'running' AND lease_expires_at > CURRENT_TIMESTAMP)
+        )
       RETURNING *`,
       [jobId, owner, status, progress == null ? null : JSON.stringify(progress), errorCode, errorDetail, retryAt]
     );
@@ -379,6 +473,7 @@ class EvmAudit {
       `UPDATE evm_audit_jobs
           SET discovered_chains = $3::jsonb, updated_at = CURRENT_TIMESTAMP
         WHERE id = $1 AND lease_owner = $2 AND status = 'running'
+          AND lease_expires_at > CURRENT_TIMESTAMP
       RETURNING *`,
       [jobId, owner, JSON.stringify(discoveredChains)]
     );
@@ -388,14 +483,26 @@ class EvmAudit {
   static async upsertScope(jobId, {
     chainId, provider, capability, status = 'queued', fromBlock = null,
     throughBlock = null, throughHash = null, cursor = null,
-    errorCode = null, errorDetail = null,
-  }) {
-    const { rows } = await pool.query(
+    providerOrder = null, coverageBasis = null, errorCode = null, errorDetail = null,
+  }, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        if (Number(fence.jobId) !== Number(jobId)) {
+          const error = new Error('EVM audit scope fence does not match its job');
+          error.code = 'EVM_AUDIT_LEASE_LOST';
+          throw error;
+        }
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_audit_scopes (
          job_id, chain_id, provider, capability, status,
          requested_from_block, requested_through_block, requested_through_hash,
-         provider_cursor, error_code, error_detail
-       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+         provider_cursor, provider_order, coverage_basis, error_code, error_detail
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
        ON CONFLICT (job_id, chain_id, provider, capability)
        DO UPDATE SET
          status = EXCLUDED.status,
@@ -403,16 +510,81 @@ class EvmAudit {
          requested_through_block = COALESCE(EXCLUDED.requested_through_block, evm_audit_scopes.requested_through_block),
          requested_through_hash = COALESCE(EXCLUDED.requested_through_hash, evm_audit_scopes.requested_through_hash),
          provider_cursor = COALESCE(EXCLUDED.provider_cursor, evm_audit_scopes.provider_cursor),
+         provider_order = COALESCE(EXCLUDED.provider_order, evm_audit_scopes.provider_order),
+         coverage_basis = COALESCE(EXCLUDED.coverage_basis, evm_audit_scopes.coverage_basis),
          error_code = EXCLUDED.error_code,
          error_detail = EXCLUDED.error_detail,
          updated_at = CURRENT_TIMESTAMP
        RETURNING *`,
-      [jobId, chainId, provider, capability, status, fromBlock, throughBlock, throughHash, cursor, errorCode, errorDetail]
-    );
-    return rows[0];
+        [jobId, chainId, provider, capability, status, fromBlock, throughBlock, throughHash,
+          cursor, providerOrder, coverageBasis, errorCode, errorDetail]
+      );
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
-  static async commitPage(scopeId, page, observations) {
+  // Persist the provider response before normalizing it. If a malformed or
+  // conflicting page makes the scan fail, the raw page remains inspectable
+  // while the scope cursor stays at the last normalized checkpoint.
+  static async recordRawPage(scopeId, page, fence = {}) {
+    validateProviderPage(page);
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const inserted = await client.query(
+      `INSERT INTO evm_provider_pages (
+         scope_id, job_id, provider, endpoint, request_params, cursor_in, cursor_out,
+         response_sha256, response_raw, response_json, request_id, item_count
+       )
+       SELECT sc.id, sc.job_id, $2, $3, $4::jsonb, $5, $6, $7, $8, $9::jsonb, $10, $11
+         FROM evm_audit_scopes sc
+        WHERE sc.id = $1
+       ON CONFLICT (scope_id, response_sha256)
+       DO NOTHING
+       RETURNING id`,
+      [
+        scopeId, page.provider, page.endpoint, JSON.stringify(page.requestParams),
+        page.cursorIn, page.cursorOut, page.responseSha256, page.responseRaw,
+        JSON.stringify(page.responseJson), page.requestId, page.itemCount,
+      ]
+      );
+      let row = inserted.rows[0];
+      const pageWasNew = Boolean(row);
+      if (!row) {
+        const existing = await client.query(
+          `SELECT * FROM evm_provider_pages WHERE scope_id = $1 AND response_sha256 = $2`,
+          [scopeId, page.responseSha256]
+        );
+        row = existing.rows[0];
+      }
+      if (!row) throw new Error('Audit scope no longer exists');
+      if (!pageWasNew && pageConflict(row, page)) {
+        const error = new Error('EVM provider page identity conflicts with retained evidence');
+        error.code = 'EVM_CONFLICTING_PAGE';
+        throw error;
+      }
+      if (transactional) await client.query('COMMIT');
+      return row.id;
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
+  }
+
+  static async commitPage(scopeId, page, observations, fence = {}) {
+    validateProviderPage(page);
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
@@ -425,6 +597,14 @@ class EvmAudit {
       );
       const scope = lockedScope.rows[0];
       if (!scope) throw new Error('Audit scope no longer exists');
+      if (fence.jobId && fence.owner) {
+        if (Number(scope.job_id) !== Number(fence.jobId)) {
+          const error = new Error('EVM audit page fence does not match its scope job');
+          error.code = 'EVM_AUDIT_LEASE_LOST';
+          throw error;
+        }
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
       const insertedPage = await client.query(
         `INSERT INTO evm_provider_pages (
            scope_id, job_id, provider, endpoint, request_params, cursor_in, cursor_out,
@@ -442,9 +622,15 @@ class EvmAudit {
       const pageWasNew = Boolean(pageId);
       if (!pageId) {
         const existing = await client.query(
-          `SELECT id FROM evm_provider_pages WHERE scope_id = $1 AND response_sha256 = $2`,
+          `SELECT * FROM evm_provider_pages WHERE scope_id = $1 AND response_sha256 = $2`,
           [scopeId, page.responseSha256]
         );
+        if (!existing.rows[0]) throw new Error('Audit provider page no longer exists');
+        if (pageConflict(existing.rows[0], page)) {
+          const error = new Error('EVM provider page identity conflicts with retained evidence');
+          error.code = 'EVM_CONFLICTING_PAGE';
+          throw error;
+        }
         pageId = existing.rows[0].id;
       }
 
@@ -523,12 +709,14 @@ class EvmAudit {
         `UPDATE evm_audit_scopes
             SET status = 'running',
                 provider_cursor = $2,
+                provider_order = COALESCE($5, provider_order),
                 pages_committed = pages_committed + $3,
                 items_committed = items_committed + $4,
                 last_checkpoint_at = CURRENT_TIMESTAMP,
                 updated_at = CURRENT_TIMESTAMP
           WHERE id = $1`,
-        [scopeId, page.cursorOut, pageWasNew ? 1 : 0, pageWasNew ? page.itemCount : 0]
+        [scopeId, page.cursorOut, pageWasNew ? 1 : 0, pageWasNew ? page.itemCount : 0,
+          page.providerOrder || null]
       );
       await client.query('COMMIT');
       return { pageId, pageWasNew, observationChanges, observationIds };
@@ -541,26 +729,58 @@ class EvmAudit {
   }
 
   static async completeScope(scopeId, {
-    status, paginationExhausted = false, errorCode = null, errorDetail = null,
-  }) {
-    const { rows } = await pool.query(
+    status, paginationExhausted = false, providerOrder = null,
+    coverageBasis = null, errorCode = null, errorDetail = null,
+  }, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        const scope = await client.query(
+          'SELECT job_id FROM evm_audit_scopes WHERE id = $1 FOR UPDATE', [scopeId]
+        );
+        if (!scope.rows[0] || Number(scope.rows[0].job_id) !== Number(fence.jobId)) {
+          const error = new Error('EVM audit scope fence does not match its job');
+          error.code = 'EVM_AUDIT_LEASE_LOST';
+          throw error;
+        }
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rows } = await client.query(
       `UPDATE evm_audit_scopes
           SET status = $2,
               pagination_exhausted = $3,
               provider_cursor = CASE WHEN $3 THEN NULL ELSE provider_cursor END,
+              provider_order = COALESCE($6, provider_order),
+              coverage_basis = COALESCE($7, coverage_basis),
               error_code = $4,
               error_detail = $5,
               last_checkpoint_at = CURRENT_TIMESTAMP,
               updated_at = CURRENT_TIMESTAMP
         WHERE id = $1
       RETURNING *`,
-      [scopeId, status, paginationExhausted, errorCode, errorDetail]
-    );
-    return rows[0];
+        [scopeId, status, paginationExhausted, errorCode, errorDetail, providerOrder, coverageBasis]
+      );
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
   static async recordProviderAttempt(row) {
-    const { rows } = await pool.query(
+    const transactional = Boolean(row.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, row.jobId, row.owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_provider_attempts (
          job_id, scope_id, provider, endpoint, method, attempt_no,
          request_params, cursor_in, outcome, http_status, error_code,
@@ -577,33 +797,58 @@ class EvmAudit {
         row.responseJson == null ? null : JSON.stringify(row.responseJson),
       ]
     );
-    return rows[0];
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
   static async acceptCoverage({
     subjectId, chainId, provider, capability, fromBlock, throughBlock,
-    throughHash = null, paginationExhausted, status, jobId,
+    throughHash = null, providerOrder = 'unknown', coverageBasis = null,
+    paginationExhausted, status, jobId,
+    owner = null,
   }) {
-    const { rows } = await pool.query(
+    const transactional = Boolean(owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, jobId, owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_source_coverage (
          subject_id, chain_id, provider, capability, from_block, through_block,
-         through_block_hash, pagination_exhausted, status, source_job_id
-       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         through_block_hash, provider_order, coverage_basis, pagination_exhausted, status, source_job_id
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
        ON CONFLICT (
          subject_id, chain_id, provider, capability,
          from_block, through_block, source_job_id
        ) DO UPDATE SET
          through_block_hash = EXCLUDED.through_block_hash,
+         provider_order = EXCLUDED.provider_order,
+         coverage_basis = EXCLUDED.coverage_basis,
          pagination_exhausted = EXCLUDED.pagination_exhausted,
          status = EXCLUDED.status,
          accepted_at = CURRENT_TIMESTAMP
        RETURNING *`,
-      [
-        subjectId, chainId, provider, capability, fromBlock, throughBlock,
-        throughHash, paginationExhausted, status, jobId,
-      ]
-    );
-    return rows[0];
+        [
+          subjectId, chainId, provider, capability, fromBlock, throughBlock,
+          throughHash, providerOrder, coverageBasis, paginationExhausted, status, jobId,
+        ]
+      );
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
   static async latestCoverage(subjectId, chainId, provider, capability) {
@@ -632,8 +877,29 @@ class EvmAudit {
     return rows;
   }
 
-  static async upsertMinedTransaction(transaction) {
+  static async transactionObservationsForSubject(
+    subjectId, chainId, provider, fromBlock = 0
+  ) {
     const { rows } = await pool.query(
+      `SELECT * FROM evm_provider_observations
+        WHERE subject_id = $1 AND chain_id = $2 AND provider = $3
+          AND evidence_kind = 'transaction'
+          AND (block_number IS NULL OR block_number >= $4)
+        ORDER BY block_number, transaction_index, id`,
+      [subjectId, chainId, provider, fromBlock]
+    );
+    return rows;
+  }
+
+  static async upsertMinedTransaction(transaction, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_mined_transactions (
          subject_id, chain_id, tx_hash, block_number, block_hash,
          transaction_index, from_address, to_address, nonce, value_wei, input,
@@ -717,12 +983,26 @@ class EvmAudit {
           ? null : JSON.stringify(transaction.conflictDetail),
       ]
     );
-    return rows[0];
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
-  static async linkTransactionEvidence(transactionId, evidence) {
-    for (const entry of evidence) {
-      await pool.query(
+  static async linkTransactionEvidence(transactionId, evidence, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      for (const entry of evidence) {
+        await client.query(
         `INSERT INTO evm_transaction_evidence (
            transaction_id, subject_id, chain_id, observation_id, evidence_role
          )
@@ -734,12 +1014,26 @@ class EvmAudit {
          ON CONFLICT (transaction_id, observation_id)
          DO UPDATE SET evidence_role = EXCLUDED.evidence_role`,
         [transactionId, entry.observationId, entry.role]
-      );
+        );
+      }
+      if (transactional) await client.query('COMMIT');
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
     }
   }
 
-  static async upsertCanonicalEffect(effect) {
-    const { rows } = await pool.query(
+  static async upsertCanonicalEffect(effect, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_canonical_effects (
          subject_id, chain_id, tx_hash, effect_key, effect_type, direction,
          log_index, trace_address, from_address, to_address, value_units,
@@ -822,13 +1116,27 @@ class EvmAudit {
         effect.selectedObservationId,
         effect.conflictDetail == null ? null : JSON.stringify(effect.conflictDetail),
       ]
-    );
-    return rows[0];
+      );
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
-  static async linkEffectEvidence(effectId, observationIds) {
-    for (const observationId of observationIds) {
-      await pool.query(
+  static async linkEffectEvidence(effectId, observationIds, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      for (const observationId of observationIds) {
+        await client.query(
         `INSERT INTO evm_effect_evidence (effect_id, subject_id, chain_id, observation_id)
          SELECT effect.id, effect.subject_id, effect.chain_id, obs.id
            FROM evm_canonical_effects effect
@@ -837,14 +1145,24 @@ class EvmAudit {
           WHERE effect.id = $1
          ON CONFLICT DO NOTHING`,
         [effectId, observationId]
-      );
+        );
+      }
+      if (transactional) await client.query('COMMIT');
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
     }
   }
 
-  static async invalidateMissingRpcEffects(subjectId, chainId, txHash, retainedKeys, receiptObservationId) {
+  static async invalidateMissingRpcEffects(
+    subjectId, chainId, txHash, retainedKeys, receiptObservationId, fence = {}
+  ) {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
+      if (fence.jobId && fence.owner) await assertActiveLease(client, fence.jobId, fence.owner);
       const { rows } = await client.query(
         `UPDATE evm_canonical_effects
             SET resolution_status = 'invalidated',
@@ -934,7 +1252,7 @@ class EvmAudit {
           SELECT 1 FROM evm_audit_scopes sc
            WHERE sc.job_id = $1 AND sc.chain_id = $2
              AND sc.capability = r.capability
-             AND sc.provider IN ('moralis', 'blockscout', 'etherscan', 'existing-ledger')
+             AND sc.provider IN ('moralis', 'coinbase-cdp', 'blockscout', 'etherscan', 'existing-ledger')
              AND sc.status = 'complete' AND sc.pagination_exhausted = TRUE
         )`,
       [jobId, chainId]
@@ -968,11 +1286,12 @@ class EvmAudit {
     return rows;
   }
 
-  static async backfillVerifiedEffects(userId, subjectId, chainId, effectIds) {
+  static async backfillVerifiedEffects(userId, subjectId, chainId, effectIds, fence = {}) {
     if (!effectIds.length) return 0;
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
+      if (fence.jobId && fence.owner) await assertActiveLease(client, fence.jobId, fence.owner);
       const wallet = await client.query(
         `SELECT w.id
            FROM evm_subjects s
@@ -1106,12 +1425,16 @@ class EvmAudit {
 
   // Legacy explorer rows normally have economics but no immutable log
   // coordinate. Upgrade them only when the same receipt effect is proven by
-  // consensus RPC and independently corroborated by Moralis at the exact
-  // transaction/log coordinate. Economic equality alone remains a gap.
-  static async repairCorroboratedTransferIdentities(jobId, userId, subjectId, chainId, throughBlock) {
+  // consensus RPC and independently corroborated by the configured indexed
+  // provider (Moralis for Gnosis or CDP for Base) at the exact transaction/log
+  // coordinate. Economic equality alone remains a gap.
+  static async repairCorroboratedTransferIdentities(
+    jobId, userId, subjectId, chainId, throughBlock, fence = {}
+  ) {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
+      if (fence.jobId && fence.owner) await assertActiveLease(client, fence.jobId, fence.owner);
       const walletResult = await client.query(
         `SELECT w.id, w.address
            FROM evm_subjects s
@@ -1125,16 +1448,17 @@ class EvmAudit {
 
       const effectsResult = await client.query(
         `SELECT e.*,
-                o.id AS moralis_observation_id,
-                o.provider AS moralis_provider,
-                o.evidence_kind AS moralis_evidence_kind,
-                o.tx_hash AS moralis_tx_hash,
-                o.log_index AS moralis_log_index,
-                o.payload_json AS moralis_payload_json
+                o.id AS indexed_observation_id,
+                o.provider AS indexed_provider,
+                o.evidence_kind AS indexed_evidence_kind,
+                o.tx_hash AS indexed_tx_hash,
+                o.log_index AS indexed_log_index,
+                o.payload_json AS indexed_payload_json
            FROM evm_canonical_effects e
            JOIN evm_provider_observations o
              ON o.subject_id = e.subject_id AND o.chain_id = e.chain_id
-            AND o.provider = 'moralis'
+            AND o.provider IN ('moralis', 'coinbase-cdp')
+            AND NOT (o.provider = 'moralis' AND o.chain_id = 8453)
             AND o.evidence_kind = e.effect_type || '_transfer'
             AND o.tx_hash = e.tx_hash AND o.log_index = e.log_index
           JOIN evm_job_observations jo
@@ -1174,17 +1498,17 @@ class EvmAudit {
       const repaired = [];
       for (const [effectId, observations] of byEffect) {
         const effect = observations[0];
-        const moralisMatches = observations.filter((observation) => matchesMoralisTransfer(
+        const indexedMatches = observations.filter((observation) => matchesIndexedTransfer(
           effect,
           {
-            provider: observation.moralis_provider,
-            evidence_kind: observation.moralis_evidence_kind,
-            tx_hash: observation.moralis_tx_hash,
-            log_index: observation.moralis_log_index,
-            payload_json: observation.moralis_payload_json,
+            provider: observation.indexed_provider,
+            evidence_kind: observation.indexed_evidence_kind,
+            tx_hash: observation.indexed_tx_hash,
+            log_index: observation.indexed_log_index,
+            payload_json: observation.indexed_payload_json,
           }
         ));
-        if (moralisMatches.length !== 1) continue;
+        if (indexedMatches.length !== 1) continue;
         const candidates = legacyRows.filter((row) => matchesLegacyTransfer(effect, row)
           && (row.source_log_index == null || Number(row.source_log_index) === Number(effect.log_index)));
         if (candidates.length !== 1) continue;
@@ -1215,7 +1539,7 @@ class EvmAudit {
           `INSERT INTO evm_effect_evidence (effect_id, subject_id, chain_id, observation_id)
            VALUES ($1, $2, $3, $4)
            ON CONFLICT DO NOTHING`,
-          [effectId, subjectId, chainId, moralisMatches[0].moralis_observation_id]
+          [effectId, subjectId, chainId, indexedMatches[0].indexed_observation_id]
         );
         repaired.push({ effectId: Number(effectId), transferId: legacy.id });
       }
@@ -1318,8 +1642,15 @@ class EvmAudit {
     };
   }
 
-  static async storeNonceAudit(row) {
-    const { rows } = await pool.query(
+  static async storeNonceAudit(row, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_nonce_audits (
          job_id, subject_id, chain_id, boundary_block, boundary_block_hash,
          next_mined_nonce, observed_outgoing_count, missing_nonces,
@@ -1347,11 +1678,25 @@ class EvmAudit {
         row.errorDetail || null,
       ]
     );
-    return rows[0];
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
-  static async storeBalanceAudit(row) {
-    const { rows } = await pool.query(
+  static async storeBalanceAudit(row, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rows } = await client.query(
       `INSERT INTO evm_balance_audits (
          job_id, subject_id, chain_id, asset_key, asset_type, boundary_block,
          derived_units, live_units, delta_units, status, detail
@@ -1372,7 +1717,14 @@ class EvmAudit {
         row.status, JSON.stringify(row.detail || {}),
       ]
     );
-    return rows[0];
+      if (transactional) await client.query('COMMIT');
+      return rows[0];
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
   }
 
   static async dueJobs(limit = 10) {

--- a/backend/src/services/EthDiscoveryService.js
+++ b/backend/src/services/EthDiscoveryService.js
@@ -54,6 +54,17 @@ class EthDiscoveryService {
         logger.info({ userId, address: candidate.address, chainId: candidate.chain_id }, 'Skipping discovery candidate with unknown chain');
         continue;
       }
+      if (chainId === 8453) {
+        // Base history is CDP-only. Candidate expansion is not a tracked-wallet
+        // audit and must not reintroduce the anonymous Blockscout account feeds
+        // that the Base provider pivot removed from critical paths.
+        await EthDiscoveryCandidate.recordFetch(userId, {
+          address: candidate.address, chainId, depth: Number(candidate.depth || 0),
+          status: 'unsupported', rowsFetched: 0,
+          errorMessage: 'Base candidate expansion is unsupported; CDP-backed tracked-wallet history is the canonical Base source.',
+        });
+        continue;
+      }
       const depth = Number.isInteger(candidate.depth)
         ? Math.max(0, candidate.depth)
         : Math.max(0, (candidate.evidence || []).reduce((max, item) => {

--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const pool = require('../config/database');
 const EtherscanService = require('./EtherscanService');
 const ZkSyncLiteService = require('./ZkSyncLiteService');
@@ -12,9 +13,13 @@ const EthWallet = require('../models/EthWallet');
 const EthWalletChain = require('../models/EthWalletChain');
 const EthFeedCoverage = require('../models/EthFeedCoverage');
 const EthTransfer = require('../models/EthTransfer');
+const EthProviderPage = require('../models/EthProviderPage');
 const chains = require('../config/chains');
 const logger = require('../config/logger');
 const { shortAddress } = require('../utils/ethAddress');
+const CdpClient = require('./evmAudit/CdpClient');
+const CdpHistoryProvider = require('./evmAudit/CdpHistoryProvider');
+const RpcClient = require('./evmAudit/RpcClient');
 
 const ADDRESS_RE = /^0x[0-9a-f]{40}$/i;
 
@@ -103,6 +108,7 @@ function sleep(milliseconds) {
 // restart the reset cursors remain durable and the next normal sync resumes the
 // unfinished recapture from genesis.
 const recaptureRuns = new Map();
+const PROVIDER_SCAN_OWNER = `${process.pid}:${crypto.randomUUID()}`;
 
 function toTimestamp(unixSeconds) {
   return new Date(Number(unixSeconds) * 1000);
@@ -124,7 +130,23 @@ function scannedThroughBlock(rows) {
   return rows.scannedThroughBlock ?? maxBlock(rows);
 }
 
+function cdpItemBlockNumber(item) {
+  const value = item?.blockHeight
+    ?? item?.content?.ethereum?.blockNumber
+    ?? item?.ethereum?.blockNumber;
+  try {
+    const parsed = BigInt(value);
+    if (parsed < 0n || parsed > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+    return Number(parsed);
+  } catch {
+    return null;
+  }
+}
+
 function providerName(chain) {
+  if (chain.historyProvider === 'coinbase-cdp') {
+    return 'Coinbase CDP address history (Base)';
+  }
   if (chain.historyProvider === 'zksync-lite') {
     return 'Matter Labs zkSync Lite archive';
   }
@@ -136,7 +158,12 @@ function providerName(chain) {
 }
 
 function coverageFailureStatus(error) {
-  if (isExplorerRateLimited(error)) return 'deferred';
+  if (isExplorerRateLimited(error) || String(error?.code || '').startsWith('CDP_')
+      && ['CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR', 'CDP_NOT_CONFIGURED',
+        'CDP_SCAN_BUSY'].includes(error.code)) {
+    return 'deferred';
+  }
+  if (['RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR'].includes(error?.code)) return 'deferred';
   return ['ETHERSCAN_CHAIN_UNAVAILABLE', 'ETHERSCAN_FEED_UNSUPPORTED'].includes(error?.code)
     ? 'unsupported' : 'failed';
 }
@@ -169,6 +196,380 @@ function retryAfterMsForResult(result) {
 }
 
 class EthWalletService {
+  static async _syncCdpWalletChain(wallet, chain) {
+    const nativeCreditConfig = chain.auditNativeCredits || chain.stateSyncDeposits || null;
+    const activeSpecs = [
+      ...FEED_SPECS.filter((spec) => !spec.chainFeed),
+      ...(nativeCreditConfig ? [STATE_SYNC_SPEC] : []),
+    ];
+    const provider = providerName(chain);
+    let state = await EthWalletChain.ensure(wallet.id, chain.id, Number(chain.ingestVersion || 0));
+    if (Number(state?.ingest_version || 0) < Number(chain.ingestVersion || 0)) {
+      state = await EthWalletChain.resetForIngestVersion(
+        wallet.id, chain.id, Number(chain.ingestVersion || 0)
+      );
+    }
+    const resumeFrom = (cursor) => Math.max(0, Number(cursor ?? 0) - REORG_OVERLAP_BLOCKS);
+    const resume = {
+      normal: resumeFrom(state?.last_block_normal),
+      internal: resumeFrom(state?.last_block_internal),
+      token: resumeFrom(state?.last_block_token),
+      nft: resumeFrom(state?.last_block_nft),
+      nft1155: resumeFrom(state?.last_block_1155),
+      statesync: resumeFrom(state?.last_block_statesync),
+    };
+    let scanId = null;
+    const retryError = async (error, { scanStarted = false, persist = true } = {}) => {
+      let canPersist = persist;
+      const status = coverageFailureStatus(error);
+      const retryAt = status === 'deferred' ? retryAfterAt(error) : null;
+      if (canPersist) {
+        const scanFence = scanStarted
+          ? { scanId, owner: PROVIDER_SCAN_OWNER }
+          : {};
+        try {
+          await EthFeedCoverage.recordAttempts(wallet.id, chain.id, [
+            ...activeSpecs.map((spec) => ({
+              feed: spec.key,
+              provider,
+              status,
+              attemptedFromBlock: resume[spec.key],
+              errorCode: error.code || 'CDP_SYNC_FAILED',
+              errorMessage: error.message,
+              retryAfterAt: retryAt,
+            })),
+          ], scanFence);
+          const supportedState = await EthWalletChain.setUnsupportedFeeds(
+            wallet.id, chain.id, [], scanFence
+          );
+          if (scanStarted && !supportedState) throw Object.assign(
+            new Error('Base CDP scan lease was lost before failure metadata was written.'),
+            { code: 'CDP_SCAN_STALE' }
+          );
+          const errorState = await EthWalletChain.setError(
+            wallet.id,
+            chain.id,
+            status === 'deferred' ? 'SYNC_DEFERRED' : 'FEED_SKIPPED',
+            `Base CDP history ${status}: ${error.message}`,
+            scanFence
+          );
+          if (scanStarted && !errorState) throw Object.assign(
+            new Error('Base CDP scan lease was lost before failure status was written.'),
+            { code: 'CDP_SCAN_STALE' }
+          );
+          const timeState = await EthWalletChain.updateSyncTime(wallet.id, chain.id, scanFence);
+          if (scanStarted && !timeState) throw Object.assign(
+            new Error('Base CDP scan lease was lost before failure timestamp was written.'),
+            { code: 'CDP_SCAN_STALE' }
+          );
+          if (scanStarted) {
+            const failedState = await EthWalletChain.failProviderScan(
+              wallet.id, chain.id, status === 'deferred' ? 'deferred' : 'failed',
+              scanId, PROVIDER_SCAN_OWNER
+            );
+            // A stale worker must not overwrite the current worker's durable
+            // status/error slot after the database lease has moved on.
+            canPersist = failedState != null;
+          }
+        } catch {
+          canPersist = false;
+        }
+      }
+      return {
+        chainId: chain.id,
+        chainName: chain.name,
+        inserted: 0,
+        skippedFeeds: activeSpecs.map((spec) => spec.key),
+        failedFeeds: status === 'failed' ? activeSpecs.map((spec) => spec.key) : [],
+        deferredFeeds: status === 'deferred' ? activeSpecs.map((spec) => spec.key) : [],
+        unsupportedFeeds: [],
+        unavailable: false,
+        rateLimited: [
+          'CDP_RATE_LIMITED', 'RPC_RATE_LIMITED', 'EXPLORER_RATE_LIMITED',
+        ].includes(error.code),
+        retryAfterMs: retryAt ? Math.max(1, retryAt.getTime() - Date.now()) : null,
+        retryAfterAt: retryAt?.toISOString() || null,
+        fetched: Object.fromEntries(FEED_SPECS.map((spec) => [spec.key, 0])),
+      };
+    };
+
+    const cdpKey = await SecretsService.getUserKey(wallet.user_id, 'cdp');
+    if (!cdpKey) {
+      return retryError(Object.assign(
+        new Error('Configure a separate Coinbase CDP Client API key in Settings -> API Keys to sync Base.'),
+        { code: 'CDP_NOT_CONFIGURED' }
+      ));
+    }
+
+    let boundary;
+    try {
+      // The indexer enumerates history; consensus RPC supplies the immutable
+      // finalized boundary used by cursors, reorg overlap and reconciliation.
+      boundary = await new RpcClient(chain.id).finalizedBoundary();
+    } catch (error) {
+      return retryError(error);
+    }
+
+    const previousOrder = state?.provider_scan_order || 'unknown';
+    const incrementalStop = state?.provider_scan_status === 'complete'
+      && previousOrder === 'newest_first'
+      && Math.min(...activeSpecs.map((spec) => resume[spec.key])) > 0;
+    state = await EthWalletChain.startProviderScan(
+      wallet.id, chain.id, boundary.number, boundary.hash, PROVIDER_SCAN_OWNER
+    );
+    if (!state) {
+      return retryError(Object.assign(
+        new Error('Another Base CDP sync currently owns this wallet-chain scan lease.'),
+        { code: 'CDP_SCAN_BUSY' }
+      ), { persist: false });
+    }
+    scanId = state.provider_scan_id;
+    const cdp = new CdpClient(cdpKey);
+    const feeds = { normal: [], internal: [], token: [], nft: [], nft1155: [], statesync: [] };
+    const seenCdpTransactions = new Map();
+    const historicalCdpTransactions = new Map();
+    try {
+      const journal = await EthProviderPage.forWalletChain(wallet.id, chain.id);
+      for (const page of journal) {
+        const body = typeof page.response_json === 'string'
+          ? JSON.parse(page.response_json) : page.response_json;
+        CdpHistoryProvider.assertNoConflicts(
+          body?.addressTransactions, historicalCdpTransactions
+        );
+      }
+    } catch (error) {
+      return retryError(error, { scanStarted: true });
+    }
+    let completePagination = false;
+    let order = previousOrder;
+    let previousBlock = null;
+    let orderDirection = null;
+    let stoppedAtOverlap = false;
+
+    const observeBlocks = (blocks) => {
+      for (const currentBlock of blocks) {
+        if (previousBlock != null && currentBlock !== previousBlock) {
+          const direction = currentBlock < previousBlock ? 'newest_first' : 'oldest_first';
+          if (orderDirection && orderDirection !== direction) orderDirection = 'unknown';
+          else if (!orderDirection) orderDirection = direction;
+        }
+        previousBlock = currentBlock;
+      }
+      if (orderDirection === 'unknown') order = 'unknown';
+      else if (order === 'unknown' && orderDirection) order = orderDirection;
+      else if (orderDirection && order !== orderDirection) order = 'unknown';
+    };
+
+    const addPage = (items) => {
+      const uniqueItems = CdpHistoryProvider.dedupeItems(items, seenCdpTransactions);
+      const normalized = CdpHistoryProvider.normalizePage(wallet.address, uniqueItems, {
+        nativeCredit: nativeCreditConfig,
+      });
+      for (const [feed, rows] of Object.entries(normalized.feeds)) {
+        feeds[feed].push(...rows.filter((row) => Number(row.blockNumber) <= boundary.number));
+      }
+      observeBlocks(uniqueItems.map(cdpItemBlockNumber)
+        .filter((block) => block != null && block <= boundary.number));
+    };
+
+    try {
+      // The raw page is durable before its cursor advances. Rehydrate every
+      // page through the last proven cursor before continuing a resumable
+      // scan; a process death or later provider error must not resume with an
+      // empty in-memory feed and delete the already-journaled prefix.
+      if (state.provider_cursor && scanId) {
+        const journal = await EthProviderPage.forScan(wallet.id, chain.id, scanId);
+        const checkpoint = journal.findIndex((page) => (
+          page.cursor_out != null && String(page.cursor_out) === String(state.provider_cursor)
+        ));
+        if (checkpoint < 0) {
+          const error = new Error('Coinbase CDP checkpoint has no matching raw page; Base sync is frozen safely.');
+          error.code = 'CDP_CHECKPOINT_MISSING';
+          throw error;
+        }
+        for (const page of journal.slice(0, checkpoint + 1)) {
+          const body = typeof page.response_json === 'string'
+            ? JSON.parse(page.response_json) : page.response_json;
+          if (!Array.isArray(body?.addressTransactions)) {
+            const error = new Error('Coinbase CDP journal page has an invalid address-history shape.');
+            error.code = 'CDP_INVALID_RESPONSE';
+            throw error;
+          }
+          addPage(body.addressTransactions);
+        }
+      }
+      for await (const page of cdp.addressTransactionPages(wallet.address, {
+        cursor: state.provider_cursor || null,
+        pageSize: 100,
+      })) {
+        const blocks = page.items.map(cdpItemBlockNumber)
+          .filter((block) => block != null && block <= boundary.number);
+        CdpHistoryProvider.assertNoConflicts(page.items, historicalCdpTransactions);
+        await EthProviderPage.record({
+          walletId: wallet.id, chainId: chain.id, provider: 'coinbase-cdp',
+          stream: 'address-history', scanId, cursorIn: page.cursorIn, cursorOut: page.cursorOut,
+          requestParams: { address: wallet.address.toLowerCase(), page_size: 100, page_token: page.cursorIn },
+          responseSha256: page.responseSha256, responseRaw: page.rawText,
+          responseJson: page.body, itemCount: page.items.length, owner: PROVIDER_SCAN_OWNER,
+        });
+        addPage(page.items);
+        const checkpointed = await EthWalletChain.checkpointProviderScan(
+          wallet.id, chain.id, scanId, page.cursorOut, PROVIDER_SCAN_OWNER
+        );
+        if (checkpointed == null) {
+          const error = new Error('Base CDP scan lease was lost before its cursor checkpoint.');
+          error.code = 'CDP_SCAN_STALE';
+          throw error;
+        }
+        state = { ...state, provider_cursor: page.cursorOut };
+        if (incrementalStop && orderDirection === 'newest_first'
+            && blocks.length && Math.min(...blocks) <= Math.min(...Object.values(resume))) {
+          stoppedAtOverlap = true;
+          break;
+        }
+      }
+      if (chain.opStackDeposits) {
+      const rpc = new RpcClient(chain.id);
+        for (const raw of feeds.normal.filter((row) => row.opStackType === '0x7e')) {
+          const { transaction } = await rpc.transactionAndReceipt(raw.hash);
+          if (String(transaction.type).toLowerCase() !== '0x7e'
+              || !/^0x[0-9a-f]{64}$/i.test(String(transaction.sourceHash || ''))
+              || !/^0x[0-9a-f]+$/i.test(String(transaction.mint || ''))
+              || !/^0x[0-9a-f]+$/i.test(String(transaction.value || ''))) {
+            const error = new Error(`OP Stack deposit ${raw.hash} is missing sourceHash, mint, or value`);
+            error.code = 'RPC_INVALID_RESPONSE';
+            throw error;
+          }
+          const rpcValue = BigInt(transaction.value).toString();
+          const rpcSourceHash = String(transaction.sourceHash).toLowerCase();
+          const rpcMint = BigInt(transaction.mint).toString();
+          const cdpFrom = String(raw.from || '').toLowerCase();
+          const cdpTo = String(raw.to || '').toLowerCase();
+          if (rpcValue !== String(raw.value)
+              || (raw.opStackSourceHash && rpcSourceHash !== String(raw.opStackSourceHash).toLowerCase())
+              || (raw.opStackMintWei != null && rpcMint !== String(raw.opStackMintWei))
+              || (cdpFrom && cdpFrom !== String(transaction.from || '').toLowerCase())
+              || (cdpTo && cdpTo !== String(transaction.to || '').toLowerCase())) {
+            const error = new Error(`OP Stack RPC value disagrees with CDP history for ${raw.hash}`);
+            error.code = 'RPC_IDENTITY_MISMATCH';
+            throw error;
+          }
+          raw.from = transaction.from;
+          raw.to = transaction.to;
+          raw.value = rpcValue;
+          raw.opStackSourceHash = rpcSourceHash;
+          raw.opStackMintWei = rpcMint;
+        }
+      }
+      completePagination = !stoppedAtOverlap;
+      if (orderDirection === 'unknown') order = 'unknown';
+      else if (order === 'unknown' && orderDirection) order = orderDirection;
+      else if (orderDirection && order !== orderDirection) order = 'unknown';
+    } catch (error) {
+      return retryError(error, { scanStarted: true });
+    }
+
+    // Re-derive the ordinary feeds only after the raw provider walk has
+    // completed or crossed a proven newest-first overlap. A failed page never
+    // reaches this delete phase, so omission cannot erase existing evidence.
+    let rows;
+    try {
+      rows = this.normalizeFeeds(wallet.address, feeds, {
+        preserveZeroValue: true,
+        stateSyncContract: nativeCreditConfig?.contract || null,
+        opStackDeposits: chain.opStackDeposits || null,
+      })
+        .map((row) => ({ ...row, wallet_id: wallet.id, chain_id: chain.id }))
+        .filter((row) => {
+          const feed = row.transfer_type === 'gas' || row.transfer_type === 'native'
+            ? 'normal' : row.transfer_type === 'internal' ? 'internal'
+              : row.transfer_type === 'token' ? 'token'
+                : row.transfer_type === 'nft' ? 'nft' : row.transfer_type === 'nft1155' ? 'nft1155' : null;
+          const effectiveFeed = feed === 'internal' && nativeCreditConfig
+            && row.from_address === nativeCreditConfig.contract.toLowerCase()
+            ? 'statesync' : feed;
+          return effectiveFeed && row.block_number >= resume[effectiveFeed];
+        });
+    } catch (error) {
+      return retryError(error, { scanStarted: true });
+    }
+    const replacements = activeSpecs.map((spec) => {
+      const deleteOpts = {};
+      if (spec.chainFeed) {
+        deleteOpts.fromAddress = nativeCreditConfig.contract;
+      } else if (spec.key === 'internal' && nativeCreditConfig) {
+        deleteOpts.excludeFromAddress = nativeCreditConfig.contract;
+      }
+      return { types: spec.types, block: resume[spec.key], options: deleteOpts };
+    });
+    const inserted = await EthTransfer.replaceFeeds(
+      wallet.id, chain.id, replacements, rows,
+      { scanId, owner: PROVIDER_SCAN_OWNER }
+    );
+    const throughBlock = boundary.number;
+    await EthFeedCoverage.recordAttempts(wallet.id, chain.id, activeSpecs.map((spec) => ({
+        feed: spec.key,
+        provider,
+        status: 'complete',
+        coveredFromBlock: 0,
+        coveredThroughBlock: throughBlock,
+        indexedHead: throughBlock,
+        attemptedFromBlock: resume[spec.key],
+      })), { scanId, owner: PROVIDER_SCAN_OWNER });
+    const cursorState = await EthWalletChain.updateCursors(wallet.id, chain.id, {
+      normal: throughBlock, internal: throughBlock, token: throughBlock,
+      nft: throughBlock, nft1155: throughBlock,
+      statesync: nativeCreditConfig ? throughBlock : null,
+    }, { scanId, owner: PROVIDER_SCAN_OWNER });
+    if (cursorState == null) {
+      const error = new Error('Base CDP scan lease was lost before cursor completion.');
+      error.code = 'CDP_SCAN_STALE';
+      throw error;
+    }
+    const supportedState = await EthWalletChain.setUnsupportedFeeds(
+      wallet.id, chain.id, [], { scanId, owner: PROVIDER_SCAN_OWNER }
+    );
+    if (supportedState == null) {
+      const error = new Error('Base CDP scan lease was lost before feed status completion.');
+      error.code = 'CDP_SCAN_STALE';
+      throw error;
+    }
+    const orderState = await EthWalletChain.setProviderScanOrder(
+      wallet.id, chain.id, order, scanId, PROVIDER_SCAN_OWNER
+    );
+    if (orderState == null) {
+      const error = new Error('Base CDP scan lease was lost before order completion.');
+      error.code = 'CDP_SCAN_STALE';
+      throw error;
+    }
+    const finished = await EthWalletChain.finishProviderScan(
+      wallet.id, chain.id, scanId, PROVIDER_SCAN_OWNER
+    );
+    if (finished == null) {
+      const error = new Error('Base CDP scan lease was lost before finalization.');
+      error.code = 'CDP_SCAN_STALE';
+      throw error;
+    }
+    const completedFence = { scanId, completed: true };
+    await EthWalletChain.clearError(wallet.id, chain.id, completedFence);
+    await EthWalletChain.updateSyncTime(wallet.id, chain.id, completedFence);
+    return {
+      chainId: chain.id,
+      chainName: chain.name,
+      inserted,
+      skippedFeeds: [],
+      failedFeeds: [],
+      deferredFeeds: [],
+      unsupportedFeeds: [],
+      unavailable: false,
+      rateLimited: false,
+      retryAfterMs: null,
+      retryAfterAt: null,
+      fetched: Object.fromEntries(FEED_SPECS.map((spec) => [spec.key, feeds[spec.key].length])),
+      cdp: { scanId, pagesComplete: completePagination, incremental: incrementalStop, order },
+    };
+  }
+
   static async _syncZkSyncLiteWalletChain(wallet, chain) {
     const ingestVersion = Number(chain.ingestVersion || 0);
     let state = await EthWalletChain.ensure(wallet.id, chain.id, ingestVersion);
@@ -375,7 +776,9 @@ class EthWalletService {
   // including failed txs, which still burn gas. Zero-value normal/internal
   // rows (contract calls, approvals) are dropped as noise; their economic
   // content is the gas row and/or the token row from the token feed.
-  static normalizeFeeds(walletAddress, { normal = [], internal = [], token = [], nft = [], nft1155 = [], statesync = [] } = {}, { stateSyncContract = null, classicDeposits = null, opStackDeposits = null } = {}) {
+  static normalizeFeeds(walletAddress, { normal = [], internal = [], token = [], nft = [], nft1155 = [], statesync = [] } = {}, {
+    stateSyncContract = null, classicDeposits = null, opStackDeposits = null, preserveZeroValue = false,
+  } = {}) {
     const wallet = walletAddress.toLowerCase();
     const rows = [];
     const ordinals = new Map();
@@ -437,7 +840,7 @@ class EthWalletService {
       // uint256, past Number precision -- keep it a string end to end. A
       // malformed id must not reach NUMERIC(78,0) and abort the chunk.
       token_id: raw.tokenID != null && /^\d+$/.test(String(raw.tokenID)) ? String(raw.tokenID) : null,
-      is_error: false,
+      is_error: raw.isError === '1',
     });
 
     for (const raw of normal) {
@@ -517,12 +920,12 @@ class EthWalletService {
       }
 
       const hasNativeLeg = raw.value !== '0';
-      if (hasNativeLeg) {
+      if (hasNativeLeg || preserveZeroValue) {
         rows.push({
           ...baseRow(raw, 'native'),
           value_wei: raw.value,
-          method_id: methodId,
-          method_name: methodName,
+          method_id: hasNativeLeg || (raw.from || '').toLowerCase() !== wallet ? methodId : null,
+          method_name: hasNativeLeg || (raw.from || '').toLowerCase() !== wallet ? methodName : null,
         });
       }
       if ((raw.from || '').toLowerCase() === wallet) {
@@ -559,7 +962,7 @@ class EthWalletService {
     }
 
     for (const raw of internal) {
-      if (raw.value === '0') continue;
+      if (raw.value === '0' && !preserveZeroValue) continue;
       // A trace FROM the precompile belongs to the STATE-SYNC feed. Today
       // txlistinternal does not serve such traces (that absence is the sixth
       // feed's whole premise), but the internal feed's delete already excludes
@@ -605,7 +1008,7 @@ class EthWalletService {
         token_decimals: raw.tokenDecimal != null ? Number(raw.tokenDecimal) : null,
         // tokentx is ERC-20 only; the NFT standards have their own feeds.
         token_standard: 'erc20',
-        is_error: false,
+        is_error: raw.isError === '1',
       });
     }
 
@@ -705,6 +1108,9 @@ class EthWalletService {
   static async _syncWalletChain(wallet, chain, apiKey) {
     if (chain.historyProvider === 'zksync-lite') {
       return this._syncZkSyncLiteWalletChain(wallet, chain);
+    }
+    if (chain.historyProvider === 'coinbase-cdp') {
+      return this._syncCdpWalletChain(wallet, chain);
     }
     const ingestVersion = Number(chain.ingestVersion || 0);
     let state = await EthWalletChain.ensure(wallet.id, chain.id, ingestVersion);

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -9,6 +9,8 @@ const EtherscanService = require('./EtherscanService');
 const chains = require('../config/chains');
 const logger = require('../config/logger');
 const MoralisClient = require('./evmAudit/MoralisClient');
+const CdpClient = require('./evmAudit/CdpClient');
+const CdpHistoryProvider = require('./evmAudit/CdpHistoryProvider');
 const RpcClient = require('./evmAudit/RpcClient');
 const normalizer = require('./evmAudit/normalizer');
 const { effectsFromInternalObservations, effectsFromRpc } = require('./evmAudit/effectDecoder');
@@ -31,7 +33,7 @@ const AUDIT_CHAINS = new Map([
     errorDetail: 'Moralis does not enumerate zkSync Era; the configured Blockscout account feeds provide finite indexed coverage, while consensus RPC verifies mined transactions and effects.',
   }],
   [8453, {
-    moralis: 'base', fallbackProvider: 'blockscout',
+    cdp: 'base',
     activeIds: new Set(['0x2105', '8453', 'base']),
   }],
   [42161, { auditProvider: 'etherscan' }],
@@ -43,6 +45,7 @@ const AUDIT_CHAINS = new Map([
   }],
 ]);
 const OVERLAP_BLOCKS = 64;
+const CDP_COVERAGE_BASIS = 'cdp_address_history_exhausted_to_finalized_boundary_v1';
 const EXPLORER_FEEDS = Object.freeze([
   { capability: 'normal', feed: 'normal', method: 'fetchNormalTxs' },
   { capability: 'internal', feed: 'internal', method: 'fetchInternalTxs' },
@@ -54,7 +57,8 @@ const OWNER = `${process.pid}:${crypto.randomUUID()}`;
 const queuedLocally = new Set();
 let resumeTimer = null;
 
-function pageRecord(provider, endpoint, requestParams, response, cursorIn = null, cursorOut = null, itemCount = 0) {
+function pageRecord(provider, endpoint, requestParams, response, cursorIn = null, cursorOut = null,
+  itemCount = 0, providerOrder = null) {
   return {
     provider,
     endpoint,
@@ -66,7 +70,65 @@ function pageRecord(provider, endpoint, requestParams, response, cursorIn = null
     responseJson: response.body,
     requestId: response.requestId || null,
     itemCount,
+    providerOrder,
   };
+}
+
+// Consensus RPC calls are authoritative point evidence, but a transaction
+// verification combines several JSON-RPC responses. Persist the exact raw
+// response text for every call inside one deterministic envelope so a later
+// audit can inspect the receipt, transaction, block, nonce, code, and balance
+// checks without relying on a provider replay.
+function rpcPageRecord(endpoint, requestParams, body, evidence = [], itemCount = 0) {
+  const rawText = JSON.stringify({
+    jsonrpc: '2.0',
+    requests: evidence.map((entry) => ({
+      method: entry.method,
+      params: entry.params,
+      response_raw: entry.rawText,
+    })),
+  });
+  const responseJson = {
+    ...body,
+    rpc_responses: evidence.map((entry) => ({
+      method: entry.method,
+      params: entry.params,
+      response: entry.responseJson,
+    })),
+  };
+  return pageRecord('consensus-rpc', endpoint, requestParams, {
+    body: responseJson,
+    rawText,
+    responseSha256: normalizer.sha256(rawText),
+    requestId: evidence.map((entry) => entry.requestId).filter(Boolean).join(',') || null,
+  }, null, null, itemCount);
+}
+
+function cdpItemBlockNumber(item) {
+  const value = item?.blockHeight
+    ?? item?.content?.ethereum?.blockNumber
+    ?? item?.ethereum?.blockNumber;
+  try {
+    const parsed = BigInt(value);
+    if (parsed < 0n || parsed > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+    return Number(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function cdpItemsThroughBoundary(items, throughBlock) {
+  const bounded = [];
+  for (const item of items) {
+    const block = cdpItemBlockNumber(item);
+    if (block == null) {
+      const error = new Error('Coinbase CDP returned a transaction without a safe block height');
+      error.code = 'CDP_INVALID_RESPONSE';
+      throw error;
+    }
+    if (block <= throughBlock) bounded.push(item);
+  }
+  return bounded;
 }
 
 function activeRowMatches(row, config) {
@@ -92,6 +154,23 @@ function moralisQuotaFallbackError(error) {
     detail: error.message,
     retryAt: error.retryAt || new Date(Date.now() + 24 * 60 * 60 * 1000),
   };
+}
+
+function cdpUnavailableError(error) {
+  if (!error) return null;
+  if (!['CDP_NOT_CONFIGURED', 'CDP_QUOTA_EXHAUSTED', 'CDP_RATE_LIMITED', 'CDP_TRANSPORT_ERROR']
+    .includes(error.code)) return null;
+  return {
+    code: error.code,
+    detail: error.message,
+    retryAt: error.retryAt || (error.code === 'CDP_QUOTA_EXHAUSTED'
+      ? nextCalendarMonth() : new Date(Date.now() + 60 * 60 * 1000)),
+  };
+}
+
+function nextCalendarMonth() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
 }
 
 function missingRanges(nonces, nextNonce) {
@@ -263,16 +342,22 @@ class EvmAuditService {
     if (!wallet) return null;
     const selected = (requestedChains || this.configuredChainIds())
       .map(Number).filter((chainId) => AUDIT_CHAINS.has(chainId));
-    const credentialGeneration = await EvmAudit.credentialGeneration(userId);
-    // Resolve without logging or returning the credential. This also detects
-    // an environment-backed Etherscan key, so a missing-key deferral can be
-    // reopened after the user configures either supported source.
+    const credentialGenerations = await EvmAudit.credentialGenerations(userId);
+    const credentialGeneration = [credentialGenerations.moralis, credentialGenerations.cdp]
+      .filter(Boolean)
+      .sort((left, right) => new Date(right).getTime() - new Date(left).getTime())[0] || null;
+    // Resolve without logging or returning credentials. This also detects a
+    // newly entered indexed-provider key so a missing-key deferral can be
+    // reopened without exposing either secret.
     const etherscanConfigured = Boolean(await SecretsService.getUserKey(userId, 'etherscan'));
+    const cdpConfigured = Boolean(await SecretsService.getUserKey(userId, 'cdp'));
     const result = await EvmAudit.createOrFindActiveJob(userId, wallet, {
       mode,
       requestedChains: [...new Set(selected)],
       credentialGeneration,
+      credentialGenerations,
       etherscanConfigured,
+      cdpConfigured,
     });
     if (result.job.status !== 'deferred') this.enqueue(result.job.id);
     return result;
@@ -345,6 +430,7 @@ class EvmAuditService {
     try {
       const requested = (job.requested_chains || []).map(Number).filter((id) => AUDIT_CHAINS.has(id));
       const moralisRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).moralis);
+      const cdpRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).cdp);
       const explorerRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).auditProvider);
       const unsupportedRequested = requested.filter((chainId) => AUDIT_CHAINS.get(chainId).unsupported);
       if (!requested.length) {
@@ -358,31 +444,50 @@ class EvmAuditService {
       if (moralisRequested.length) {
         key = await SecretsService.getUserKey(job.user_id, 'moralis');
         if (!key) {
-          moralisUnavailable = moralisQuotaFallbackError({
-            code: 'MORALIS_NOT_CONFIGURED',
-            message: 'Configure a Moralis API key in Settings to run the Base/Gnosis audit source.',
+        moralisUnavailable = moralisQuotaFallbackError({
+          code: 'MORALIS_NOT_CONFIGURED',
+          message: 'Configure a Moralis API key in Settings to audit Gnosis Chain.',
           });
         }
       }
-      const credentialGeneration = await EvmAudit.credentialGeneration(job.user_id);
-      if (key && moralisRequested.length && job.credential_generation
-          && credentialGeneration
-          && new Date(job.credential_generation).getTime() !== new Date(credentialGeneration).getTime()) {
+      const cdpKey = cdpRequested.length
+        ? await SecretsService.getUserKey(job.user_id, 'cdp') : null;
+      const cdpUnavailable = cdpRequested.length && !cdpKey
+        ? cdpUnavailableError({
+          code: 'CDP_NOT_CONFIGURED',
+          message: 'Configure a separate Coinbase CDP Client API key in Settings to audit Base.',
+        }) : null;
+      const credentialGenerations = await EvmAudit.credentialGenerations(job.user_id);
+      const providerCredentialChanged = [
+        { name: 'moralis', requested: moralisRequested.length > 0 },
+        { name: 'cdp', requested: cdpRequested.length > 0 },
+      ].some(({ name, requested }) => {
+        if (!requested) return false;
+        const current = credentialGenerations[name] || null;
+        const stored = job[`${name}_credential_generation`]
+          || (moralisRequested.length + cdpRequested.length === 1
+            ? job.credential_generation : null);
+        return stored == null ? current != null
+          : current == null || new Date(stored).getTime() !== new Date(current).getTime();
+      });
+      if (providerCredentialChanged) {
         return EvmAudit.finish(jobId, OWNER, 'failed', {
           errorCode: 'CREDENTIAL_GENERATION_CHANGED',
-          errorDetail: 'The Moralis credential changed after this audit was requested. Start a new audit.',
+          errorDetail: 'An indexed-provider credential changed after this audit was requested. Start a new audit.',
         });
       }
 
       const retainAttempt = async (attempt) => {
         try {
-          await EvmAudit.recordProviderAttempt({ jobId, ...attempt });
+          await EvmAudit.recordProviderAttempt({ jobId, ...attempt, owner: OWNER });
         } catch (error) {
           logger.warn({ err: error, auditJobId: jobId }, 'Failed to retain provider attempt evidence');
         }
       };
       let moralis = key && moralisRequested.length
         ? new MoralisClient(key, { onFailedAttempt: retainAttempt }) : null;
+      let cdp = cdpKey && cdpRequested.length
+        ? new CdpClient(cdpKey, { onFailedAttempt: retainAttempt }) : null;
 
       let activeResponse = { body: { active_chains: [] } };
       let activeRows = [];
@@ -421,6 +526,21 @@ class EvmAuditService {
             fallback_source: config.fallbackProvider || null,
           };
         }
+        if (config.cdp && cdpUnavailable) {
+          return {
+            chain_id: chainId, active_hint: null, bounded: false,
+            status: 'deferred', source: 'coinbase-cdp',
+            error_code: cdpUnavailable.code,
+            error_detail: cdpUnavailable.detail,
+          };
+        }
+        if (config.cdp) {
+          return {
+            chain_id: chainId, active_hint: null, bounded: false,
+            status: 'configured', source: 'coinbase-cdp',
+            detail: 'CDP address history is configured for Base; active-chain discovery is not universal.',
+          };
+        }
         if (config.auditProvider) {
           return {
             chain_id: chainId, active_hint: null, bounded: false,
@@ -440,9 +560,11 @@ class EvmAuditService {
       await EvmAudit.setDiscoveredChains(jobId, OWNER, discovered);
 
       let gaps = 0;
+      let failed = false;
+      let failedProviderError = null;
       for (const chainId of unsupportedRequested) {
         assertLease(leaseState);
-        gaps += await this.runUnsupportedChain({ job, chainId });
+        gaps += await this.runUnsupportedChain({ job, chainId, owner: OWNER });
       }
       const explorerApiKey = explorerRequested.some((chainId) => explorerRequiresKey(chainId))
         ? await SecretsService.getUserKey(job.user_id, 'etherscan') : null;
@@ -454,9 +576,17 @@ class EvmAuditService {
           runnable.push(chainId);
           continue;
         }
+        if (config.cdp && cdp) {
+          runnable.push(chainId);
+          continue;
+        }
         const fallback = config.moralis ? config.fallbackProvider : config.auditProvider;
         if (!fallback) {
-          unavailable.push({ chainId, provider: 'moralis', error: moralisUnavailable });
+          unavailable.push({
+            chainId,
+            provider: config.cdp ? 'coinbase-cdp' : 'moralis',
+            error: config.cdp ? cdpUnavailable : moralisUnavailable,
+          });
         } else if (explorerRequiresKey(chainId) && !explorerApiKey) {
           unavailable.push({
             chainId, provider: configuredExplorerProvider(chainId),
@@ -472,32 +602,40 @@ class EvmAuditService {
       for (const item of unavailable) {
         assertLease(leaseState);
         gaps += await this.runUnavailableChain({ job, chainId: item.chainId,
-          provider: item.provider, error: item.error });
+          provider: item.provider, error: item.error, owner: OWNER });
       }
-      let providerDeferred = Boolean(moralisUnavailable || unavailable.length);
-      let deferredProviderError = moralisUnavailable;
+      let providerDeferred = Boolean(moralisUnavailable || cdpUnavailable || unavailable.length);
+      let deferredProviderError = moralisUnavailable || cdpUnavailable;
       for (const chainId of runnable) {
         assertLease(leaseState);
         const result = await this.runChain({
           job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt,
-          explorerApiKey, moralisUnavailable,
+          explorerApiKey, moralisUnavailable, cdp, cdpUnavailable,
         });
         gaps += result.gaps;
         if (result.deferred) {
           providerDeferred = true;
           deferredProviderError ||= result.deferredProviderError;
         }
+        if (result.failed) {
+          failed = true;
+          failedProviderError ||= result.failedProviderError;
+        }
       }
       const deferred = providerDeferred;
-      return EvmAudit.finish(jobId, OWNER, deferred ? 'deferred' : (gaps ? 'complete_with_gaps' : 'complete'), {
-        errorCode: deferredProviderError?.code || unavailable[0]?.error?.code || null,
-        errorDetail: deferredProviderError?.detail || unavailable[0]?.error?.detail || null,
+      return EvmAudit.finish(jobId, OWNER,
+        deferred ? 'deferred' : failed ? 'failed' : (gaps ? 'complete_with_gaps' : 'complete'), {
+        errorCode: deferredProviderError?.code || failedProviderError?.code
+          || unavailable[0]?.error?.code || null,
+        errorDetail: deferredProviderError?.detail || failedProviderError?.detail
+          || unavailable[0]?.error?.detail || null,
         retryAt: deferred ? (deferredProviderError?.retryAt || new Date(Date.now() + 24 * 60 * 60 * 1000)) : null,
         progress: { chains_finished: runnable.length + unsupportedRequested.length, gaps },
       });
     } catch (error) {
       const deferred = [
         'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
+        'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR', 'CDP_NOT_CONFIGURED',
         'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED',
         'BLOCKSCOUT_TRANSPORT_ERROR', 'ETHERSCAN_RATE_LIMITED',
         'ETHERSCAN_TRANSPORT_ERROR',
@@ -505,9 +643,10 @@ class EvmAuditService {
         .includes(error.code);
       const errorCode = String(error.code || '');
       const provider = errorCode.startsWith('MORALIS_') ? 'moralis'
+        : errorCode.startsWith('CDP_') ? 'coinbase-cdp'
         : errorCode.startsWith('RPC_') ? 'consensus-rpc'
           : errorCode.startsWith('ETHERSCAN_') ? 'etherscan' : 'blockscout';
-      if (errorCode.startsWith('MORALIS_') || errorCode.startsWith('RPC_')
+      if (errorCode.startsWith('MORALIS_') || errorCode.startsWith('CDP_') || errorCode.startsWith('RPC_')
           || errorCode.startsWith('BLOCKSCOUT_') || errorCode.startsWith('ETHERSCAN_')) {
         try {
           await EvmAudit.recordProviderAttempt({
@@ -516,6 +655,7 @@ class EvmAuditService {
             outcome: deferred ? 'deferred' : 'failed', httpStatus: error.httpStatus || null,
             errorCode: error.code || 'EVM_AUDIT_FAILED', errorDetail: publicErrorDetail(error),
             requestId: error.requestId || null,
+            owner: OWNER,
           });
         } catch (attemptError) {
           logger.warn({ err: attemptError, auditJobId: jobId }, 'Failed to retain EVM provider attempt');
@@ -532,55 +672,82 @@ class EvmAuditService {
     }
   }
 
-  static async runUnsupportedChain({ job, chainId }) {
+  static async runUnsupportedChain({ job, chainId, owner = null }) {
     const config = AUDIT_CHAINS.get(chainId);
     for (const capability of AUDIT_CAPABILITIES) {
       await EvmAudit.upsertScope(job.id, {
         chainId, provider: 'moralis', capability, status: 'unsupported',
         errorCode: config.errorCode, errorDetail: config.errorDetail,
-      });
+      }, owner ? { jobId: job.id, owner } : {});
     }
     return 1;
   }
 
-  static async runUnavailableChain({ job, chainId, provider, error }) {
+  static async runUnavailableChain({ job, chainId, provider, error, owner = null }) {
     for (const capability of AUDIT_CAPABILITIES) {
       await EvmAudit.upsertScope(job.id, {
         chainId, provider, capability, status: 'deferred',
         errorCode: error?.code || 'AUDIT_PROVIDER_UNAVAILABLE',
         errorDetail: error?.detail || 'No configured audit provider is available for this chain.',
-      });
+      }, owner ? { jobId: job.id, owner } : {});
     }
     return 1;
   }
 
   static async runChain({
-    job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt,
-    explorerApiKey = null, moralisUnavailable = null,
+    job, chainId, moralis, cdp, activeResponse, discovered, leaseState, retainAttempt,
+    explorerApiKey = null, moralisUnavailable = null, cdpUnavailable = null,
   }) {
     const chain = chains.getChain(chainId);
     const providerConfig = AUDIT_CHAINS.get(chainId);
     const useMoralis = Boolean(providerConfig.moralis && moralis);
-    const auditProvider = useMoralis
-      ? 'moralis'
-      : (providerConfig.moralis ? providerConfig.fallbackProvider : providerConfig.auditProvider);
+    const useCdp = Boolean(providerConfig.cdp && cdp);
+    const auditProvider = useCdp ? 'coinbase-cdp'
+      : useMoralis ? 'moralis'
+        : (providerConfig.moralis ? providerConfig.fallbackProvider : providerConfig.auditProvider);
     const rpc = new RpcClient(chainId, { onFailedAttempt: retainAttempt });
     const boundary = await rpc.finalizedBoundary();
     const context = {
       jobId: job.id, subjectId: job.subject_id, chainId,
       address: job.address, provider: auditProvider, chain,
     };
+    const writeFence = { jobId: job.id, owner: OWNER };
+    const upsertScope = (scope) => EvmAudit.upsertScope(job.id, scope, writeFence);
+    const recordRawPage = (scopeId, page) => EvmAudit.recordRawPage(scopeId, page, writeFence);
+    const commitPage = (scopeId, page, observations) =>
+      EvmAudit.commitPage(scopeId, page, observations, writeFence);
+    const completeScope = (scopeId, options) =>
+      EvmAudit.completeScope(scopeId, options, writeFence);
+    const acceptCoverage = (options) => EvmAudit.acceptCoverage({ ...options, owner: OWNER });
+    const upsertMinedTransaction = (transaction) =>
+      EvmAudit.upsertMinedTransaction(transaction, writeFence);
+    const linkTransactionEvidence = (transactionId, evidence) =>
+      EvmAudit.linkTransactionEvidence(transactionId, evidence, writeFence);
+    const upsertCanonicalEffect = (effect) => EvmAudit.upsertCanonicalEffect(effect, writeFence);
+    const linkEffectEvidence = (effectId, observations) =>
+      EvmAudit.linkEffectEvidence(effectId, observations, writeFence);
+    const storeNonceAudit = (row) => EvmAudit.storeNonceAudit(row, writeFence);
+    const storeBalanceAudit = (row) => EvmAudit.storeBalanceAudit(row, writeFence);
+    const recordProviderAttempt = (row) => EvmAudit.recordProviderAttempt({
+      ...row, jobId: job.id, owner: OWNER,
+    });
     await EvmAudit.heartbeat(job.id, OWNER, {
       stage: 'fetching', progress: { current_chain: chainId, boundary_block: boundary.number },
     });
 
     if (providerConfig.moralis && !useMoralis && moralisUnavailable) {
-      await EvmAudit.upsertScope(job.id, {
+      await upsertScope({
         chainId, provider: 'moralis', capability: 'active_chain', status: 'deferred',
         errorCode: moralisUnavailable.code, errorDetail: moralisUnavailable.detail,
       });
     }
-    const activeScope = await EvmAudit.upsertScope(job.id, {
+    if (providerConfig.cdp && !useCdp && cdpUnavailable) {
+      await upsertScope({
+        chainId, provider: 'coinbase-cdp', capability: 'active_chain', status: 'deferred',
+        errorCode: cdpUnavailable.code, errorDetail: cdpUnavailable.detail,
+      });
+    }
+    const activeScope = await upsertScope({
       chainId, provider: auditProvider, capability: 'active_chain', status: 'running',
       fromBlock: 0, throughBlock: boundary.number, throughHash: boundary.hash,
     });
@@ -589,23 +756,32 @@ class EvmAuditService {
         active_chains: (activeResponse.body.active_chains || [])
           .filter((row) => activeRowMatches(row, providerConfig)),
       };
-      await EvmAudit.commitPage(activeScope.id, pageRecord(
+      await commitPage(activeScope.id, pageRecord(
         'moralis', 'active-chain-discovery', {
           chains: (job.requested_chains || []).map((id) => AUDIT_CHAINS.get(Number(id))?.moralis).filter(Boolean),
         },
         activeResponse, null, null, activeBody.active_chains.length
       ), normalizer.activeChainObservations(context, activeBody));
       // Active-chain discovery is a hint, not proof of historical absence.
-      await EvmAudit.completeScope(activeScope.id, { status: 'unverified', paginationExhausted: false });
+      await completeScope(activeScope.id, { status: 'unverified', paginationExhausted: false });
     } else {
-      await EvmAudit.commitPage(activeScope.id, pageRecord(
+      const activeBoundaryBody = {
+        chain_id: chainId, boundary_block: boundary.number, active_discovery: 'not_supported',
+      };
+      await commitPage(activeScope.id, pageRecord(
         auditProvider, 'indexed-account-feed-boundary', {
           chain_id: chainId, boundary_block: boundary.number,
         },
-        { body: { chain_id: chainId, boundary_block: boundary.number, active_discovery: 'not_supported' } },
+        auditProvider === 'coinbase-cdp'
+          ? {
+            body: activeBoundaryBody,
+            rawText: JSON.stringify(activeBoundaryBody),
+            responseSha256: normalizer.sha256(JSON.stringify(activeBoundaryBody)),
+          }
+          : { body: activeBoundaryBody },
         null, null, 0
       ), []);
-      await EvmAudit.completeScope(activeScope.id, {
+      await completeScope(activeScope.id, {
         status: 'unverified', paginationExhausted: false,
         errorCode: 'ACTIVE_DISCOVERY_UNSUPPORTED',
         errorDetail: moralisUnavailable
@@ -615,7 +791,7 @@ class EvmAuditService {
     }
 
     let indexedBoundary = null;
-    if (!useMoralis) {
+    if (!useMoralis && !useCdp) {
       try {
         indexedBoundary = await EtherscanService.coverageBoundary(explorerApiKey, chainId);
       } catch (error) {
@@ -628,7 +804,7 @@ class EvmAuditService {
           : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_BOUNDARY_FAILED`;
         wrapped.httpStatus = error.response?.status || error.httpStatus || null;
         wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
-        await EvmAudit.recordProviderAttempt({
+        await recordProviderAttempt({
           jobId: job.id, scopeId: activeScope.id, provider: auditProvider,
           endpoint: 'indexed-boundary', requestParams: { chain_id: chainId },
           outcome: transient ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
@@ -637,22 +813,26 @@ class EvmAuditService {
         throw wrapped;
       }
     }
-    const sourceThroughBlock = useMoralis
+    const sourceThroughBlock = useMoralis || useCdp
       ? boundary.number : Math.min(boundary.number, indexedBoundary.throughBlock);
     const prior = job.mode === 'incremental'
       ? await EvmAudit.latestCoverage(job.subject_id, chainId, auditProvider, 'wallet_history')
       : null;
     const fromBlock = prior ? Math.max(0, Number(prior.through_block) - OVERLAP_BLOCKS) : 0;
-    const historyScope = await EvmAudit.upsertScope(job.id, {
+    const priorProviderOrder = useCdp && job.mode === 'incremental'
+      ? prior?.provider_order || null : null;
+    const historyScope = await upsertScope({
       chainId, provider: auditProvider, capability: 'wallet_history', status: 'running',
       fromBlock, throughBlock: sourceThroughBlock,
-      throughHash: useMoralis ? boundary.hash : null,
+      throughHash: useMoralis || useCdp ? boundary.hash : null,
+      providerOrder: priorProviderOrder,
+      coverageBasis: useCdp ? CDP_COVERAGE_BASIS : null,
     });
     const fallbackAfterMoralis = async (error, scopeId) => {
       const deferredError = moralisQuotaFallbackError(error);
       if (!useMoralis || !deferredError || !providerConfig.fallbackProvider) throw error;
       assertLease(leaseState);
-      await EvmAudit.completeScope(scopeId, {
+      await completeScope(scopeId, {
         status: 'deferred', paginationExhausted: false,
         errorCode: deferredError.code, errorDetail: deferredError.detail,
       });
@@ -669,14 +849,33 @@ class EvmAuditService {
     };
     const hashes = new Set();
     const moralisLookupHashes = new Set();
+    const seenCdpTransactions = new Map();
+    const historicalCdpTransactions = new Map();
     // Rehydrate every durable observation before either provider path runs.
     // This is required when Moralis fails after committing pages and the
     // explorer fallback starts with a fresh in-memory hash set.
     const durableObservations = await EvmAudit.observationsForJob(job.id, { chainId });
     for (const observation of durableObservations) {
       if (observation.tx_hash) hashes.add(String(observation.tx_hash).toLowerCase());
-      if (observation.tx_hash && !['consensus-rpc', 'moralis'].includes(observation.provider)) {
+      if (observation.tx_hash && !['consensus-rpc', 'moralis', 'coinbase-cdp'].includes(observation.provider)) {
         moralisLookupHashes.add(String(observation.tx_hash).toLowerCase());
+      }
+    }
+    if (useCdp) {
+      const priorCdpObservations = await EvmAudit.transactionObservationsForSubject(
+        job.subject_id, chainId, 'coinbase-cdp', fromBlock
+      );
+      for (const observation of priorCdpObservations) {
+        const identity = CdpHistoryProvider.itemIdentity(observation.payload_json);
+        if (!identity.hash) continue;
+        const previous = historicalCdpTransactions.get(identity.hash);
+        if (previous && (previous.identity !== identity.identity
+            || previous.fingerprint !== identity.fingerprint)) {
+          const error = new Error(`Coinbase CDP retained conflicting data for ${identity.hash}`);
+          error.code = 'CDP_CONFLICTING_TRANSACTION';
+          throw error;
+        }
+        historicalCdpTransactions.set(identity.hash, identity);
       }
     }
     if (useMoralis) {
@@ -688,7 +887,7 @@ class EvmAuditService {
           assertLease(leaseState);
           const observations = page.items.flatMap((item) => normalizer.historyObservations(context, item));
           for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
-          await EvmAudit.commitPage(historyScope.id, pageRecord(
+          await commitPage(historyScope.id, pageRecord(
             'moralis', 'wallet-history', {
               chain: providerConfig.moralis, from_block: fromBlock, to_block: boundary.number,
             }, page, page.cursorIn, page.cursorOut, page.items.length
@@ -699,8 +898,8 @@ class EvmAuditService {
       } catch (error) {
         return fallbackAfterMoralis(error, historyScope.id);
       }
-      await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
-      await EvmAudit.acceptCoverage({
+      await completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
+      await acceptCoverage({
         subjectId: job.subject_id, chainId, provider: 'moralis', capability: 'wallet_history',
         fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
         paginationExhausted: true, status: 'complete', jobId: job.id,
@@ -709,13 +908,146 @@ class EvmAuditService {
       // capabilities. Keep their finite bounds explicit; RPC receipt lookups
       // remain a separate non-enumerating scope.
       for (const capability of ['normal', 'internal', 'erc20', 'erc721', 'erc1155', 'native_credit']) {
-        const capabilityScope = await EvmAudit.upsertScope(job.id, {
+        const capabilityScope = await upsertScope({
           chainId, provider: 'moralis', capability, status: 'running',
           fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
         });
-        await EvmAudit.completeScope(capabilityScope.id, {
+        await completeScope(capabilityScope.id, {
           status: 'complete', paginationExhausted: true,
         });
+      }
+    } else if (useCdp) {
+      let cursor = historyScope.provider_cursor || null;
+      let order = historyScope.provider_order && historyScope.provider_order !== 'unknown'
+        ? historyScope.provider_order : (priorProviderOrder || 'unknown');
+      let previousBlock = null;
+      let orderDirection = null;
+      const stopAtProvenOverlap = job.mode === 'incremental'
+        && prior && priorProviderOrder === 'newest_first' && fromBlock > 0;
+      try {
+        for await (const page of cdp.addressTransactionPages(job.address, {
+          cursor,
+          pageSize: 100,
+        })) {
+          assertLease(leaseState);
+          const blocks = page.items
+            .map((item) => Number(item.blockHeight ?? item.content?.ethereum?.blockNumber
+              ?? item.ethereum?.blockNumber))
+            .filter(Number.isSafeInteger);
+          for (const currentBlock of blocks) {
+            if (previousBlock != null && currentBlock !== previousBlock) {
+              const direction = currentBlock < previousBlock ? 'newest_first' : 'oldest_first';
+              if (orderDirection && orderDirection !== direction) orderDirection = 'unknown';
+              else if (!orderDirection) orderDirection = direction;
+            }
+            previousBlock = currentBlock;
+          }
+          if (orderDirection === 'unknown') order = 'unknown';
+          else if (order === 'unknown' && orderDirection) order = orderDirection;
+          else if (orderDirection && order !== orderDirection) order = 'unknown';
+          const pageEvidence = pageRecord(
+            'coinbase-cdp', 'address-history', {
+              address: job.address.toLowerCase(), page_size: 100, page_token: page.cursorIn,
+            }, page, page.cursorIn, page.cursorOut, page.items.length, order
+          );
+          await recordRawPage(historyScope.id, pageEvidence);
+          // Validate the complete returned page after raw persistence, then
+          // only canonicalize transactions at or below the RPC-finalized
+          // boundary. Future-indexed rows remain evidence, but can never enter
+          // the audit projection before consensus has finalized them.
+          CdpHistoryProvider.normalizePage(job.address, page.items, {
+            nativeCredit: chain?.auditNativeCredits || chain?.stateSyncDeposits || null,
+          });
+          CdpHistoryProvider.assertNoConflicts(page.items, historicalCdpTransactions);
+          const uniqueItems = CdpHistoryProvider.dedupeItems(page.items, seenCdpTransactions);
+          const boundedItems = cdpItemsThroughBoundary(uniqueItems, boundary.number);
+          const boundedBlocks = boundedItems.map(cdpItemBlockNumber);
+          const observations = boundedItems.flatMap((item) =>
+            normalizer.cdpHistoryObservations(context, item)
+          );
+          for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
+          await commitPage(historyScope.id, pageEvidence, observations);
+          cursor = page.cursorOut;
+          await EvmAudit.heartbeat(job.id, OWNER, {
+            progress: { current_cursor: cursor, transactions_seen: hashes.size },
+          });
+          if (stopAtProvenOverlap && orderDirection === 'newest_first'
+              && boundedBlocks.some((block) => block <= fromBlock)) break;
+        }
+      } catch (error) {
+        const deferredError = cdpUnavailableError(error);
+        const failedChain = discovered.find((row) => row.chain_id === chainId);
+        if (failedChain) {
+          failedChain.active_hint = null;
+          failedChain.bounded = false;
+          failedChain.status = deferredError ? 'deferred' : 'failed';
+          failedChain.source = 'coinbase-cdp';
+          failedChain.error_code = error.code || 'CDP_HISTORY_FAILED';
+          failedChain.error_detail = publicErrorDetail(error);
+          await EvmAudit.setDiscoveredChains(job.id, OWNER, discovered);
+        }
+        await completeScope(historyScope.id, {
+          status: deferredError ? 'deferred' : 'failed',
+          paginationExhausted: false,
+          providerOrder: order,
+          errorCode: error.code || 'CDP_HISTORY_FAILED',
+          errorDetail: publicErrorDetail(error),
+        });
+        return {
+          gaps: 1,
+          deferred: Boolean(deferredError),
+          deferredProviderError: deferredError,
+          failed: !deferredError,
+          failedProviderError: deferredError ? null : {
+            code: error.code || 'CDP_HISTORY_FAILED',
+            detail: publicErrorDetail(error),
+          },
+          boundary,
+          transactions: hashes.size,
+          discovered,
+        };
+      }
+      await completeScope(historyScope.id, {
+        status: 'complete', paginationExhausted: true, providerOrder: order,
+        coverageBasis: CDP_COVERAGE_BASIS,
+      });
+      await acceptCoverage({
+        subjectId: job.subject_id, chainId, provider: 'coinbase-cdp', capability: 'wallet_history',
+        fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
+        providerOrder: order, coverageBasis: CDP_COVERAGE_BASIS,
+        paginationExhausted: true, status: 'complete', jobId: job.id,
+      });
+      for (const capability of ['normal', 'internal', 'erc20', 'erc721', 'erc1155', 'native_credit']) {
+        const capabilityScope = await upsertScope({
+          chainId, provider: 'coinbase-cdp', capability, status: 'running',
+          fromBlock, throughBlock: boundary.number, throughHash: boundary.hash,
+          providerOrder: order,
+          coverageBasis: CDP_COVERAGE_BASIS,
+        });
+        await completeScope(capabilityScope.id, {
+          status: 'complete', paginationExhausted: true,
+          coverageBasis: CDP_COVERAGE_BASIS,
+        });
+      }
+      // CDP does not offer Moralis-style active-chain discovery. A completed
+      // address-history walk still proves a finite configured Base boundary,
+      // so expose that bounded fact without turning it into a universal
+      // absence claim across every EVM or every future provider.
+      const discoveredChain = discovered.find((row) => row.chain_id === chainId);
+      if (discoveredChain) {
+        const providerObservations = await EvmAudit.observationsForJob(job.id, { chainId });
+        const foundBlocks = providerObservations
+          .filter((row) => row.provider === 'coinbase-cdp' && row.block_number != null)
+          .map((row) => Number(row.block_number))
+          .filter(Number.isSafeInteger);
+        discoveredChain.active_hint = hashes.size > 0;
+        discoveredChain.active_hint_proven = false;
+        discoveredChain.bounded = true;
+        discoveredChain.status = 'bounded';
+        discoveredChain.source = 'coinbase-cdp';
+        discoveredChain.first_block = foundBlocks.length ? Math.min(...foundBlocks) : null;
+        discoveredChain.last_block = foundBlocks.length ? Math.max(...foundBlocks) : null;
+        await EvmAudit.setDiscoveredChains(job.id, OWNER, discovered);
       }
     } else {
       for (const feedSpec of EXPLORER_FEEDS) {
@@ -725,7 +1057,7 @@ class EvmAuditService {
           : null;
         const feedFromBlock = feedPrior
           ? Math.max(0, Number(feedPrior.through_block) - OVERLAP_BLOCKS) : 0;
-        const feedScope = await EvmAudit.upsertScope(job.id, {
+        const feedScope = await upsertScope({
           chainId, provider: auditProvider, capability: feedSpec.capability, status: 'running',
           fromBlock: feedFromBlock, throughBlock: sourceThroughBlock, throughHash: null,
         });
@@ -744,7 +1076,7 @@ class EvmAuditService {
             : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_FEED_FAILED`;
           wrapped.httpStatus = error.response?.status || error.httpStatus || null;
           wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
-          await EvmAudit.recordProviderAttempt({
+          await recordProviderAttempt({
             jobId: job.id, scopeId: feedScope.id, provider: auditProvider,
             endpoint: `account-${feedSpec.feed}`,
             requestParams: { address: job.address, from_block: feedFromBlock, to_block: sourceThroughBlock },
@@ -769,7 +1101,7 @@ class EvmAuditService {
             context, feedSpec.feed, pageRows
           );
           for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
-          await EvmAudit.commitPage(feedScope.id, pageRecord(
+          await commitPage(feedScope.id, pageRecord(
             auditProvider, `account-${feedSpec.feed}`,
             { address: job.address, from_block: feedFromBlock, to_block: sourceThroughBlock },
             { body: { feed: feedSpec.feed, rows: pageRows } },
@@ -780,17 +1112,17 @@ class EvmAuditService {
             progress: { current_feed: feedSpec.feed, transactions_seen: hashes.size },
           });
         }
-        await EvmAudit.completeScope(feedScope.id, {
+          await completeScope(feedScope.id, {
           status: 'complete', paginationExhausted: true,
         });
-        await EvmAudit.acceptCoverage({
+          await acceptCoverage({
           subjectId: job.subject_id, chainId, provider: auditProvider,
           capability: feedSpec.capability, fromBlock: feedFromBlock,
           throughBlock: sourceThroughBlock, throughHash: null,
           paginationExhausted: true, status: 'complete', jobId: job.id,
         });
       }
-      const nativeCreditScope = await EvmAudit.upsertScope(job.id, {
+      const nativeCreditScope = await upsertScope({
         chainId, provider: auditProvider, capability: 'native_credit', status: 'running',
         fromBlock: 0, throughBlock: sourceThroughBlock, throughHash: null,
       });
@@ -810,7 +1142,7 @@ class EvmAuditService {
             : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_FEED_FAILED`;
           wrapped.httpStatus = error.response?.status || error.httpStatus || null;
           wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
-          await EvmAudit.recordProviderAttempt({
+          await recordProviderAttempt({
             jobId: job.id, scopeId: nativeCreditScope.id, provider: auditProvider,
             endpoint: 'native-credit', requestParams: {
               address: job.address, from_block: 0, to_block: sourceThroughBlock,
@@ -823,25 +1155,25 @@ class EvmAuditService {
           { ...context, provider: auditProvider }, 'internal', nativeCreditRows
         );
         for (const observation of observations) if (observation.txHash) hashes.add(observation.txHash);
-        await EvmAudit.commitPage(nativeCreditScope.id, pageRecord(
+        await commitPage(nativeCreditScope.id, pageRecord(
           auditProvider, 'native-credit', {
             address: job.address, from_block: 0, to_block: sourceThroughBlock,
           }, { body: { rows: nativeCreditRows } }, null, null, nativeCreditRows.length
         ), observations);
-        await EvmAudit.completeScope(nativeCreditScope.id, {
+        await completeScope(nativeCreditScope.id, {
           status: 'complete', paginationExhausted: true,
         });
-        await EvmAudit.acceptCoverage({
+        await acceptCoverage({
           subjectId: job.subject_id, chainId, provider: auditProvider,
           capability: 'native_credit', fromBlock: 0, throughBlock: sourceThroughBlock,
           throughHash: null, paginationExhausted: true, status: 'complete', jobId: job.id,
         });
       } else {
-        await EvmAudit.commitPage(nativeCreditScope.id, pageRecord(
+        await commitPage(nativeCreditScope.id, pageRecord(
           auditProvider, 'native-credit-not-applicable', { chain_id: chainId },
           { body: { chain_id: chainId, status: 'not_applicable' } }, null, null, 0
         ), []);
-        await EvmAudit.completeScope(nativeCreditScope.id, {
+        await completeScope(nativeCreditScope.id, {
           status: 'complete', paginationExhausted: true,
           errorCode: 'NOT_APPLICABLE',
           errorDetail: 'This chain has no configured account-independent native-credit feed; receipt logs remain canonical evidence.',
@@ -871,12 +1203,51 @@ class EvmAuditService {
         discoveredChain.last_block = foundBlocks.length ? Math.max(...foundBlocks) : null;
       }
       await EvmAudit.setDiscoveredChains(job.id, OWNER, discovered);
-      await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
-      await EvmAudit.acceptCoverage({
+      await completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
+      await acceptCoverage({
         subjectId: job.subject_id, chainId, provider: auditProvider, capability: 'wallet_history',
         fromBlock, throughBlock: sourceThroughBlock, throughHash: null,
         paginationExhausted: true, status: 'complete', jobId: job.id,
       });
+    }
+    let cdpBalanceEvidenceFailed = false;
+    const cdpBalances = [];
+    if (useCdp) {
+      // CDP balances are retained as supplemental provider evidence. Consensus
+      // RPC remains authoritative for the native balance and the existing
+      // token-by-token RPC checks remain the completion gate.
+      const balanceScope = await upsertScope({
+        chainId, provider: 'coinbase-cdp', capability: 'token_balance', status: 'running',
+        fromBlock: null, throughBlock: boundary.number, throughHash: boundary.hash,
+        coverageBasis: 'cdp_list_balances_current_asset_index_v1',
+      });
+      try {
+        let cursor = balanceScope.provider_cursor || null;
+        for await (const page of cdp.balancePages(job.address, { cursor, pageSize: 100 })) {
+          assertLease(leaseState);
+          cdpBalances.push(...page.items);
+          const pageEvidence = pageRecord(
+            'coinbase-cdp', 'balance-history', {
+              address: job.address.toLowerCase(), page_size: 100, page_token: page.cursorIn,
+            }, page, page.cursorIn, page.cursorOut, page.items.length
+          );
+          await recordRawPage(balanceScope.id, pageEvidence);
+          const observations = normalizer.cdpBalanceObservations(context, page.items);
+          await commitPage(balanceScope.id, pageEvidence, observations);
+          cursor = page.cursorOut;
+        }
+        await completeScope(balanceScope.id, {
+          status: 'complete', paginationExhausted: true,
+          coverageBasis: 'cdp_list_balances_current_asset_index_v1',
+        });
+      } catch (error) {
+        cdpBalanceEvidenceFailed = true;
+        await completeScope(balanceScope.id, {
+          status: 'unverified', paginationExhausted: false,
+          errorCode: error.code || 'CDP_BALANCE_EVIDENCE_FAILED',
+          errorDetail: publicErrorDetail(error),
+        });
+      }
     }
     let legacyRows = await EvmAudit.storedTransferRows(job.user_id, job.subject_id, chainId, boundary.number);
     const coverageByFeed = new Map((await EvmAudit.storedFeedCoverage(
@@ -891,7 +1262,7 @@ class EvmAuditService {
       const coverage = coverageByFeed.get(feed);
       const coverageComplete = coverage?.status === 'complete'
         && coverage.covered_from_block != null && coverage.covered_through_block != null;
-      const scope = await EvmAudit.upsertScope(job.id, {
+      const scope = await upsertScope({
         chainId, provider: 'existing-ledger', capability, status: 'running',
         fromBlock: coverage?.covered_from_block ?? 0,
         throughBlock: coverage?.covered_through_block ?? boundary.number,
@@ -901,7 +1272,7 @@ class EvmAuditService {
       // restarted worker must not replay even an empty/unsupported feed page;
       // only restore the same finite coverage verdict and continue.
       if (scope.pages_committed > 0) {
-        await EvmAudit.completeScope(scope.id, {
+        await completeScope(scope.id, {
           status: coverageComplete ? 'complete' : 'unverified',
           paginationExhausted: coverageComplete,
           errorCode: coverageComplete ? null : (coverage?.error_code || 'LEDGER_COVERAGE_UNPROVEN'),
@@ -912,12 +1283,12 @@ class EvmAuditService {
       const observations = normalizer.legacyTransferObservations(
         { ...context, provider: 'existing-ledger' }, rows
       );
-      await EvmAudit.commitPage(scope.id, pageRecord(
+      await commitPage(scope.id, pageRecord(
         'existing-ledger', 'stored-transfer-evidence', {
           feed, through_block: coverage?.covered_through_block ?? null,
         }, { body: { rows } }, null, null, rows.length
       ), observations);
-      await EvmAudit.completeScope(scope.id, {
+      await completeScope(scope.id, {
         status: coverageComplete ? 'complete' : 'unverified',
         paginationExhausted: coverageComplete,
         errorCode: coverageComplete ? null : (coverage?.error_code || 'LEDGER_COVERAGE_UNPROVEN'),
@@ -949,13 +1320,13 @@ class EvmAuditService {
             assertLease(leaseState);
             const item = lookup.body;
             const observations = normalizer.historyObservations(context, item);
-            await EvmAudit.commitPage(historyScope.id, pageRecord(
+            await commitPage(historyScope.id, pageRecord(
               'moralis', 'transaction-lookup', { chain: providerConfig.moralis, transaction_hash: hash },
               lookup, null, null, 1
             ), observations);
           } catch (error) {
             providerLookupGaps += 1;
-            await EvmAudit.recordProviderAttempt({
+            await recordProviderAttempt({
               jobId: job.id, scopeId: historyScope.id, provider: 'moralis',
               endpoint: 'transaction-lookup',
               requestParams: { chain: providerConfig.moralis, transaction_hash: hash },
@@ -975,10 +1346,10 @@ class EvmAuditService {
     // stream. commitPage() correctly reopens a scope when it appends evidence,
     // so close it again after the lookup pass; otherwise a finite, exhausted
     // history can be reported as still running even though all pages committed.
-    await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
+    await completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });
 
     await EvmAudit.heartbeat(job.id, OWNER, { stage: 'canonicalizing' });
-    const rpcScope = await EvmAudit.upsertScope(job.id, {
+    const rpcScope = await upsertScope({
       chainId, provider: 'consensus-rpc', capability: 'receipt_verification', status: 'running',
       fromBlock: null, throughBlock: boundary.number, throughHash: boundary.hash,
     });
@@ -993,15 +1364,15 @@ class EvmAuditService {
       });
       if (!renewedBeforeLookup) leaseState.lost = true;
       assertLease(leaseState);
-      const { transaction, receipt } = await rpc.transactionAndReceipt(hash);
+      const { transaction, receipt, block, evidence } = await rpc.transactionAndReceipt(hash);
       assertLease(leaseState);
       if (Number(BigInt(transaction.blockNumber)) > boundary.number) continue;
       const observations = normalizer.rpcTransactionObservations(
         { ...context, provider: 'consensus-rpc' }, transaction, receipt
       );
-      const committed = await EvmAudit.commitPage(rpcScope.id, pageRecord(
-        'consensus-rpc', 'transaction-and-receipt', { transaction_hash: hash, boundary_block: boundary.number },
-        { body: { transaction, receipt } }, null, null, 1
+      const committed = await commitPage(rpcScope.id, rpcPageRecord(
+        'transaction-and-receipt', { transaction_hash: hash, boundary_block: boundary.number },
+        { transaction, receipt, block }, evidence || [], 1
       ), observations);
       const observationIds = new Map(observations.map((observation, index) => [
         observation.providerObjectKey, committed.observationIds[index],
@@ -1009,19 +1380,19 @@ class EvmAuditService {
       const tx = normalizer.transactionFromRpc(
         context, transaction, receipt, observationIds.get(`transaction:${hash}`)
       );
-      const canonical = await EvmAudit.upsertMinedTransaction(tx);
-      await EvmAudit.linkTransactionEvidence(canonical.id, [
+      const canonical = await upsertMinedTransaction(tx);
+      await linkTransactionEvidence(canonical.id, [
         { observationId: observationIds.get(`transaction:${hash}`), role: 'transaction' },
         { observationId: observationIds.get(`receipt:${hash}`), role: 'receipt' },
       ].filter((entry) => entry.observationId));
       const rpcEffects = effectsFromRpc(context, transaction, receipt, observationIds);
       for (const effect of rpcEffects) {
-        const stored = await EvmAudit.upsertCanonicalEffect(effect);
-        await EvmAudit.linkEffectEvidence(stored.id, effect.evidenceObservationIds);
+        const stored = await upsertCanonicalEffect(effect);
+        await linkEffectEvidence(stored.id, effect.evidenceObservationIds);
       }
       await EvmAudit.invalidateMissingRpcEffects(
         job.subject_id, chainId, hash, rpcEffects.map((effect) => effect.effectKey),
-        observationIds.get(`receipt:${hash}`) || null
+        observationIds.get(`receipt:${hash}`) || null, writeFence
       );
       const renewedAfterCommit = await EvmAudit.heartbeat(job.id, OWNER, {
         stage: 'canonicalizing',
@@ -1029,10 +1400,27 @@ class EvmAuditService {
       if (!renewedAfterCommit) leaseState.lost = true;
       assertLease(leaseState);
     }
-    await EvmAudit.completeScope(rpcScope.id, {
+    await completeScope(rpcScope.id, {
       status: 'unverified', paginationExhausted: false,
       errorCode: 'POINT_LOOKUPS_ONLY',
       errorDetail: 'Consensus RPC verified known transaction receipts but did not enumerate account history.',
+    });
+
+    const pointCheckBasis = 'consensus_rpc_point_checks_at_finalized_boundary_v1';
+    const nonceScope = await upsertScope({
+      chainId, provider: 'consensus-rpc', capability: 'nonce', status: 'running',
+      fromBlock: 0, throughBlock: boundary.number, throughHash: boundary.hash,
+      coverageBasis: pointCheckBasis,
+    });
+    const nativeBalanceScope = await upsertScope({
+      chainId, provider: 'consensus-rpc', capability: 'native_balance', status: 'running',
+      fromBlock: 0, throughBlock: boundary.number, throughHash: boundary.hash,
+      coverageBasis: pointCheckBasis,
+    });
+    const tokenBalanceScope = await upsertScope({
+      chainId, provider: 'consensus-rpc', capability: 'token_balance', status: 'running',
+      fromBlock: 0, throughBlock: boundary.number, throughHash: boundary.hash,
+      coverageBasis: pointCheckBasis,
     });
 
     const internalObservations = [
@@ -1044,15 +1432,15 @@ class EvmAuditService {
       })),
     ];
     for (const effect of effectsFromInternalObservations(context, internalObservations)) {
-      const stored = await EvmAudit.upsertCanonicalEffect(effect);
-      await EvmAudit.linkEffectEvidence(stored.id, effect.evidenceObservationIds);
+      const stored = await upsertCanonicalEffect(effect);
+      await linkEffectEvidence(stored.id, effect.evidenceObservationIds);
     }
 
     // Legacy rows may have the right economics but no immutable log index.
     // Upgrade only the independently corroborated receipt effects before the
     // strict reconciliation pass; unresolved economic matches remain gaps.
     const identityRepair = await EvmAudit.repairCorroboratedTransferIdentities(
-      job.id, job.user_id, job.subject_id, chainId, boundary.number
+      job.id, job.user_id, job.subject_id, chainId, boundary.number, writeFence
     );
     legacyRows = await EvmAudit.storedTransferRows(
       job.user_id, job.subject_id, chainId, boundary.number
@@ -1062,7 +1450,7 @@ class EvmAuditService {
     if (effectReconciliation.missing.length) {
       const inserted = await EvmAudit.backfillVerifiedEffects(
         job.user_id, job.subject_id, chainId,
-        effectReconciliation.missing.map((effect) => effect.id)
+        effectReconciliation.missing.map((effect) => effect.id), writeFence
       );
       if (inserted) {
         await EthDerivedPipeline.serializedForUser(job.user_id, async () => {
@@ -1080,23 +1468,35 @@ class EvmAuditService {
     const transactions = await EvmAudit.canonicalTransactions(job.subject_id, chainId);
     const transactionConflicts = await EvmAudit.transactionConflictCount(job.subject_id, chainId);
     await EvmAudit.heartbeat(job.id, OWNER, { stage: 'nonce_verification' });
-    const code = await rpc.code(job.address, boundary.numberHex);
+    const codeEvidence = await rpc.codeWithEvidence(job.address, boundary.numberHex);
+    await commitPage(nonceScope.id, rpcPageRecord(
+      'account-code', { address: job.address, block_tag: boundary.numberHex },
+      { address: job.address, block_tag: boundary.numberHex, code: codeEvidence.value },
+      [codeEvidence.evidence]
+    ), []);
+    const code = codeEvidence.value;
     let nonceGapCount = 0;
     if (code !== '0x') {
-      await EvmAudit.storeNonceAudit({
+      await storeNonceAudit({
         jobId: job.id, subjectId: job.subject_id, chainId,
         boundaryBlock: boundary.number, boundaryBlockHash: boundary.hash,
         nextMinedNonce: null, observedOutgoingCount: 0, status: 'unsupported',
         errorCode: 'SUBJECT_IS_CONTRACT', errorDetail: 'Nonce completeness applies only to EOAs.',
       });
     } else {
-      const nextNonce = await rpc.transactionCount(job.address, boundary.numberHex);
+      const nonceEvidence = await rpc.transactionCountWithEvidence(job.address, boundary.numberHex);
+      await commitPage(nonceScope.id, rpcPageRecord(
+        'account-nonce', { address: job.address, block_tag: boundary.numberHex },
+        { address: job.address, block_tag: boundary.numberHex, next_mined_nonce: nonceEvidence.value.toString() },
+        [nonceEvidence.evidence]
+      ), []);
+      const nextNonce = nonceEvidence.value;
       const outgoing = transactions.filter((row) => row.signedness === 'user_signed' && BigInt(row.nonce) < nextNonce);
       const missing = missingRanges(outgoing.map((row) => row.nonce), nextNonce);
       const conflicts = conflictNonces(outgoing);
       const unknown = transactions.filter((row) => row.signedness === 'unknown').length;
       nonceGapCount = missing.length + conflicts.length + unknown;
-      await EvmAudit.storeNonceAudit({
+      await storeNonceAudit({
         jobId: job.id, subjectId: job.subject_id, chainId,
         boundaryBlock: boundary.number, boundaryBlockHash: boundary.hash,
         nextMinedNonce: nextNonce.toString(), observedOutgoingCount: outgoing.length,
@@ -1104,31 +1504,73 @@ class EvmAuditService {
         status: nonceGapCount ? 'unverified' : 'complete',
       });
     }
+    await completeScope(nonceScope.id, {
+      status: 'complete', paginationExhausted: true, coverageBasis: pointCheckBasis,
+    });
 
     await EvmAudit.heartbeat(job.id, OWNER, { stage: 'balance_reconciliation' });
-    const [liveBalance, derivedBalance] = await Promise.all([
-      rpc.balance(job.address, boundary.numberHex),
+    const [liveBalanceEvidence, derivedBalance] = await Promise.all([
+      rpc.balanceWithEvidence(job.address, boundary.numberHex),
       EvmAudit.nativeDerivedAt(job.user_id, job.subject_id, chainId, boundary.number),
     ]);
+    await commitPage(nativeBalanceScope.id, rpcPageRecord(
+      'native-balance', { address: job.address, block_tag: boundary.numberHex },
+      { address: job.address, block_tag: boundary.numberHex,
+        balance_wei: liveBalanceEvidence.value.toString() },
+      [liveBalanceEvidence.evidence]
+    ), []);
+    const liveBalance = liveBalanceEvidence.value;
     const delta = liveBalance - BigInt(derivedBalance);
-    await EvmAudit.storeBalanceAudit({
+    await storeBalanceAudit({
       jobId: job.id, subjectId: job.subject_id, chainId,
       assetKey: 'native', assetType: 'native', boundaryBlock: boundary.number,
       derivedUnits: derivedBalance, liveUnits: liveBalance.toString(), deltaUnits: delta.toString(),
       status: delta === 0n ? 'match' : 'mismatch',
       detail: { boundary_hash: boundary.hash },
     });
+    await completeScope(nativeBalanceScope.id, {
+      status: 'complete', paginationExhausted: true, coverageBasis: pointCheckBasis,
+    });
 
     let tokenMismatches = 0;
+    let tokenEvidenceFailures = 0;
     const tokenBalances = await EvmAudit.tokenDerivedAt(
       job.user_id, job.subject_id, chainId, boundary.number
     );
-    for (const token of tokenBalances) {
+    const tokensByContract = new Map(tokenBalances.map((token) => [
+      String(token.token_contract).toLowerCase(), token,
+    ]));
+    // CDP's balance index is used to discover ERC-20 contracts that the
+    // derived ledger does not contain. Consensus RPC, not CDP's delayed
+    // balance value, is authoritative for the actual comparison.
+    for (const balance of cdpBalances) {
+      if (String(balance?.asset?.type || '').toLowerCase() !== 'erc20') continue;
+      const contract = String(balance.asset.groupId || '').toLowerCase();
+      if (!tokensByContract.has(contract)) {
+        tokensByContract.set(contract, {
+          token_contract: contract, token_decimals: balance.decimals, balance_units: '0',
+        });
+      }
+    }
+    for (const token of tokensByContract.values()) {
       try {
-        const live = await rpc.erc20Balance(token.token_contract, job.address, boundary.numberHex);
+        const liveEvidence = await rpc.erc20BalanceWithEvidence(
+          token.token_contract, job.address, boundary.numberHex
+        );
+        await commitPage(tokenBalanceScope.id, rpcPageRecord(
+          'erc20-balance', {
+            contract: token.token_contract, address: job.address, block_tag: boundary.numberHex,
+          },
+          {
+            contract: token.token_contract, address: job.address,
+            block_tag: boundary.numberHex, balance_units: liveEvidence.value.toString(),
+          },
+          [liveEvidence.evidence]
+        ), []);
+        const live = liveEvidence.value;
         const tokenDelta = live - BigInt(token.balance_units);
         if (tokenDelta !== 0n) tokenMismatches += 1;
-        await EvmAudit.storeBalanceAudit({
+        await storeBalanceAudit({
           jobId: job.id, subjectId: job.subject_id, chainId,
           assetKey: token.token_contract, assetType: 'erc20', boundaryBlock: boundary.number,
           derivedUnits: token.balance_units, liveUnits: live.toString(), deltaUnits: tokenDelta.toString(),
@@ -1136,7 +1578,8 @@ class EvmAuditService {
           detail: { boundary_hash: boundary.hash, token_decimals: Number(token.token_decimals) },
         });
       } catch (error) {
-        await EvmAudit.storeBalanceAudit({
+        tokenEvidenceFailures += 1;
+        await storeBalanceAudit({
           jobId: job.id, subjectId: job.subject_id, chainId,
           assetKey: token.token_contract, assetType: 'erc20', boundaryBlock: boundary.number,
           derivedUnits: token.balance_units, liveUnits: null, deltaUnits: null,
@@ -1146,6 +1589,14 @@ class EvmAuditService {
         tokenMismatches += 1;
       }
     }
+    await completeScope(tokenBalanceScope.id, {
+      status: tokenEvidenceFailures ? 'failed' : 'complete',
+      paginationExhausted: !tokenEvidenceFailures,
+      coverageBasis: pointCheckBasis,
+      errorCode: tokenEvidenceFailures ? 'TOKEN_BALANCE_EVIDENCE_FAILED' : null,
+      errorDetail: tokenEvidenceFailures
+        ? `${tokenEvidenceFailures} consensus token balance point check(s) failed.` : null,
+    });
 
     let activityHashes = await EvmAudit.activityTxHashes(job.user_id, job.subject_id, chainId, boundary.number);
     let missingActivity = transactions.filter((row) => !activityHashes.has(row.tx_hash)).length;
@@ -1170,7 +1621,8 @@ class EvmAuditService {
     const provisionalEffects = await EvmAudit.provisionalEffectCount(job.subject_id, chainId);
     const unmatchedEffects = effectReconciliation.gaps;
     const capabilityGaps = await EvmAudit.requiredScopeGapCount(job.id, chainId);
-    const gaps = providerLookupGaps + nonceGapCount + transactionConflicts + capabilityGaps + (delta === 0n ? 0 : 1)
+    const gaps = providerLookupGaps + nonceGapCount + transactionConflicts + capabilityGaps
+      + (cdpBalanceEvidenceFailed ? 1 : 0) + (delta === 0n ? 0 : 1)
       + tokenMismatches + missingActivity + unresolvedBridges + provisionalEffects
       + unmatchedEffects;
     await EvmAudit.heartbeat(job.id, OWNER, {
@@ -1184,6 +1636,7 @@ class EvmAuditService {
           nonce_gaps: nonceGapCount,
           native_balance_match: delta === 0n,
           token_balance_gaps: tokenMismatches,
+          balance_evidence_gap: cdpBalanceEvidenceFailed,
           corroborated_identity_repairs: identityRepair.repaired,
           missing_activity: missingActivity,
           unresolved_bridges: bridgeAudit.unresolved,

--- a/backend/src/services/SecretsService.js
+++ b/backend/src/services/SecretsService.js
@@ -6,12 +6,14 @@ const secretCrypto = require('../utils/secretCrypto');
 
 // Resolution order: decrypted DB value -> configured env fallback -> null.
 // Only services listed in ENV_FALLBACKS can use an environment value; Moralis
-// is deliberately per-user and resolves to null when no stored key is usable.
+// and CDP are deliberately per-user and resolve to null when no stored key is
+// usable. CDP is the Coinbase Developer Platform address-history credential,
+// not the Coinbase exchange connector's credential.
 // If SECRETS_ENCRYPTION_KEY is unset, reads skip the DB entirely and writes
 // throw SECRETS_NOT_CONFIGURED. A DB value that fails to decrypt logs a warning
 // and uses its configured environment fallback, if any, rather than breaking.
 
-const USER_SERVICES = ['plaid_client_id', 'plaid_secret', 'etherscan', 'moralis'];
+const USER_SERVICES = ['plaid_client_id', 'plaid_secret', 'etherscan', 'moralis', 'cdp'];
 const APP_KEYS = ['cg_api_key', 'cmc_api_key'];
 
 const ENV_FALLBACKS = {

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -1,0 +1,314 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const JSONbig = require('json-bigint')({ useNativeBigInt: true });
+const { sha256 } = require('./normalizer');
+
+// CDP's address-history JSON-RPC endpoint is network-scoped. The client API
+// key is deliberately kept only in this instance; it is never part of a
+// persisted request parameter object or an error message.
+const ROOT = 'https://api.developer.coinbase.com/rpc/v1/base';
+const DEFAULT_SPACING_MS = 25;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const MAX_INLINE_RETRY_MS = 30_000;
+const MAX_ATTEMPTS = 3;
+const MAX_PAGES = 100_000;
+const MAX_PAGE_SIZE = 100;
+const queues = new Map();
+
+function providerError(message, code, extra = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, extra);
+  return error;
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseRetryAfter(value) {
+  if (!value) return null;
+  if (/^\d+(?:\.\d+)?$/.test(value)) return Math.ceil(Number(value) * 1000);
+  const at = Date.parse(value);
+  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : null;
+}
+
+function normalizeJsonNumbers(value) {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(normalizeJsonNumbers);
+  if (!value || typeof value !== 'object') return value;
+  const normalized = {};
+  const numericFields = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (typeof child === 'bigint') {
+      normalized[key] = child.toString();
+      numericFields.push(key);
+    } else {
+      normalized[key] = normalizeJsonNumbers(child);
+    }
+  }
+  if (numericFields.length) normalized.__evm_json_numeric_fields = numericFields;
+  return normalized;
+}
+
+function isQuotaError(detail) {
+  return /(?:quota|credit|billing|usage).*(?:exhaust|limit|exceed)|(?:exhaust|limit|exceed).*(?:quota|credit|billing|usage)/i.test(detail);
+}
+
+function nextCalendarMonth() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
+}
+
+function responseError(response, body, method) {
+  const detail = String(body?.error?.message || body?.message || '').slice(0, 500);
+  if (response.status === 429) {
+    const retryAfterMs = parseRetryAfter(response.headers.get('retry-after')) ?? 5_000;
+    return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
+      httpStatus: response.status,
+      retryAfterMs,
+      retryAt: new Date(Date.now() + retryAfterMs),
+    });
+  }
+  if ([401, 403].includes(response.status)) {
+    if (isQuotaError(detail)) {
+      return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
+        httpStatus: response.status,
+        // CDP Node's free billing-unit allowance is documented as a calendar-
+        // month allowance. A portal/account-specific quota may differ, so the
+        // UI still displays this as a provider retry boundary, not a promise
+        // that all credits reset after 24 hours.
+        retryAt: nextCalendarMonth(),
+      });
+    }
+    return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
+      httpStatus: response.status,
+    });
+  }
+  if (body?.error) {
+    const code = String(body.error.code || '').toLowerCase();
+    return providerError(
+      `Coinbase CDP ${method} returned an error${detail ? `: ${detail}` : ''}`,
+      isQuotaError(detail) || /quota|credit|billing/.test(code) ? 'CDP_QUOTA_EXHAUSTED' : 'CDP_API_ERROR',
+      { httpStatus: response.status }
+    );
+  }
+  return providerError(
+    `Coinbase CDP ${method} returned HTTP ${response.status}${detail ? `: ${detail}` : ''}`,
+    'CDP_API_ERROR',
+    { httpStatus: response.status }
+  );
+}
+
+function pageCursor(value, method) {
+  if (value == null || value === '') return null;
+  if (typeof value !== 'string') {
+    throw providerError(
+      `Coinbase CDP ${method} returned an invalid page cursor`,
+      'CDP_INVALID_RESPONSE'
+    );
+  }
+  return value;
+}
+
+class CdpClient {
+  constructor(apiKey, {
+    spacingMs = DEFAULT_SPACING_MS,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    requestTimeoutGraceMs = 1000,
+    maxAttempts = MAX_ATTEMPTS,
+    baseUrl = ROOT,
+    onFailedAttempt = null,
+  } = {}) {
+    if (!apiKey) throw providerError('Coinbase CDP Client API key is not configured', 'CDP_NOT_CONFIGURED');
+    this.apiKey = apiKey;
+    this.spacingMs = spacingMs;
+    this.requestTimeoutMs = requestTimeoutMs;
+    this.requestTimeoutGraceMs = requestTimeoutGraceMs;
+    this.maxAttempts = maxAttempts;
+    this.baseUrl = String(baseUrl).replace(/\/$/, '');
+    this.onFailedAttempt = onFailedAttempt;
+    this.queueKey = crypto.createHash('sha256').update(apiKey).digest('hex');
+  }
+
+  async _scheduled(task) {
+    const previous = queues.get(this.queueKey) || Promise.resolve();
+    const run = previous.catch(() => {}).then(async () => {
+      await wait(this.spacingMs);
+      return task();
+    });
+    const queued = run.catch(() => {}).finally(() => {
+      if (queues.get(this.queueKey) === queued) queues.delete(this.queueKey);
+    });
+    queues.set(this.queueKey, queued);
+    return run;
+  }
+
+  async _request(method, params, endpoint = method) {
+    return this._scheduled(async () => {
+      const url = `${this.baseUrl}/${encodeURIComponent(this.apiKey)}`;
+      for (let attempt = 1; attempt <= this.maxAttempts; attempt += 1) {
+        let response;
+        let text;
+        let timedOut = false;
+        try {
+          const controller = new AbortController();
+          let timeout;
+          const request = (async () => {
+            const result = await fetch(url, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json', accept: 'application/json' },
+              body: JSON.stringify({
+                jsonrpc: '2.0', id: 1, method,
+                params: [{ ...params, pageSize: Math.min(MAX_PAGE_SIZE, Number(params.pageSize || MAX_PAGE_SIZE)) }],
+              }),
+              signal: controller.signal,
+            });
+            return { response: result, text: await result.text() };
+          })();
+          request.catch(() => {});
+          try {
+            ({ response, text } = await Promise.race([
+              request,
+              new Promise((_, reject) => {
+                timeout = setTimeout(() => {
+                  timedOut = true;
+                  controller.abort();
+                  reject(providerError(`Coinbase CDP ${endpoint} request exceeded its deadline`, 'CDP_TRANSPORT_ERROR'));
+                }, this.requestTimeoutMs + this.requestTimeoutGraceMs);
+              }),
+            ]));
+          } finally {
+            clearTimeout(timeout);
+          }
+        } catch {
+          await this.onFailedAttempt?.({
+            provider: 'coinbase-cdp', endpoint, method: 'POST', attemptNo: attempt,
+            requestParams: params, outcome: attempt < this.maxAttempts && !timedOut ? 'deferred' : 'failed',
+            errorCode: 'CDP_TRANSPORT_ERROR', errorDetail: 'Network request failed before a response.',
+          });
+          if (attempt < this.maxAttempts && !timedOut) {
+            await wait(500 * (2 ** (attempt - 1)));
+            continue;
+          }
+          // Do not attach the fetch error as `cause`: some HTTP clients include
+          // the request URL in a transport error, and this URL contains the
+          // Client API key. The retained provider-attempt detail is deliberately
+          // generic for the same reason.
+          throw providerError(`Coinbase CDP ${endpoint} request failed`, 'CDP_TRANSPORT_ERROR');
+        }
+
+        let body;
+        try { body = normalizeJsonNumbers(JSONbig.parse(text)); } catch {
+          body = null;
+        }
+        const hasResult = body && typeof body === 'object' && !Array.isArray(body)
+          && body.result != null;
+        // Do not accept a malformed JSON-RPC envelope that contains both an
+        // error and a result. A partial result paired with an error is not a
+        // proven page and must not advance a durable cursor.
+        if (response.ok && hasResult && !body.error) {
+          return {
+            body: body.result,
+            rawText: text,
+            responseSha256: sha256(text),
+            requestId: response.headers.get('x-request-id') || null,
+          };
+        }
+
+        const error = responseError(response, body, method);
+        const retryable = error.code === 'CDP_RATE_LIMITED' && attempt < this.maxAttempts;
+        await this.onFailedAttempt?.({
+          provider: 'coinbase-cdp', endpoint, method: 'POST', attemptNo: attempt,
+          requestParams: params, outcome: retryable || error.code === 'CDP_QUOTA_EXHAUSTED' ? 'deferred' : 'failed',
+          httpStatus: error.httpStatus || response.status,
+          errorCode: error.code, errorDetail: error.message,
+          requestId: response.headers.get('x-request-id') || null,
+          responseSha256: sha256(text), responseRaw: text, responseJson: body,
+        });
+        if (retryable && error.retryAfterMs <= MAX_INLINE_RETRY_MS) {
+          await wait(error.retryAfterMs);
+          continue;
+        }
+        throw error;
+      }
+      throw providerError(`Coinbase CDP ${endpoint} retry budget exhausted`, 'CDP_TRANSPORT_ERROR');
+    });
+  }
+
+  async *addressTransactionPages(address, { cursor = null, pageSize = MAX_PAGE_SIZE } = {}) {
+    const normalizedAddress = String(address || '').toLowerCase();
+    let next = pageCursor(cursor, 'address history');
+    const seenCursors = new Set();
+    let pages = 0;
+    do {
+      if (next != null) {
+        if (seenCursors.has(next)) {
+          throw providerError('Coinbase CDP address history returned a repeated page token', 'CDP_PAGINATION_STALLED');
+        }
+        seenCursors.add(next);
+      }
+      const params = {
+        address: normalizedAddress,
+        pageSize: Math.min(MAX_PAGE_SIZE, Math.max(1, Number(pageSize) || MAX_PAGE_SIZE)),
+        pageToken: next || '',
+      };
+      const response = await this._request('cdp_listAddressTransactions', params, 'address-history');
+      const items = response.body?.addressTransactions;
+      if (!Array.isArray(items)) {
+        throw providerError('Coinbase CDP address history returned an invalid result shape', 'CDP_INVALID_RESPONSE');
+      }
+      pages += 1;
+      if (pages > MAX_PAGES) {
+        throw providerError('Coinbase CDP address history exceeded the pagination safety bound', 'CDP_PAGINATION_STALLED');
+      }
+      const cursorOut = pageCursor(response.body?.nextPageToken, 'address history');
+      if (cursorOut && seenCursors.has(cursorOut)) {
+        throw providerError('Coinbase CDP address history returned a repeated page token', 'CDP_PAGINATION_STALLED');
+      }
+      yield { ...response, items, cursorIn: next, cursorOut };
+      next = cursorOut;
+    } while (next);
+  }
+
+  async *balancePages(address, { cursor = null, pageSize = MAX_PAGE_SIZE } = {}) {
+    const normalizedAddress = String(address || '').toLowerCase();
+    let next = pageCursor(cursor, 'balances');
+    const seenCursors = new Set();
+    let pages = 0;
+    do {
+      if (next != null) {
+        if (seenCursors.has(next)) {
+          throw providerError('Coinbase CDP balances returned a repeated page token', 'CDP_PAGINATION_STALLED');
+        }
+        seenCursors.add(next);
+      }
+      const params = {
+        address: normalizedAddress,
+        pageSize: Math.min(MAX_PAGE_SIZE, Math.max(1, Number(pageSize) || MAX_PAGE_SIZE)),
+        pageToken: next || '',
+      };
+      const response = await this._request('cdp_listBalances', params, 'balance-history');
+      const items = response.body?.balances;
+      if (!Array.isArray(items)) {
+        throw providerError('Coinbase CDP balance history returned an invalid result shape', 'CDP_INVALID_RESPONSE');
+      }
+      pages += 1;
+      if (pages > MAX_PAGES) {
+        throw providerError('Coinbase CDP balances exceeded the pagination safety bound', 'CDP_PAGINATION_STALLED');
+      }
+      const cursorOut = pageCursor(response.body?.nextPageToken, 'balances');
+      if (cursorOut && seenCursors.has(cursorOut)) {
+        throw providerError('Coinbase CDP balances returned a repeated page token', 'CDP_PAGINATION_STALLED');
+      }
+      yield { ...response, items, cursorIn: next, cursorOut };
+      next = cursorOut;
+    } while (next);
+  }
+}
+
+module.exports = CdpClient;
+module.exports.parseRetryAfter = parseRetryAfter;
+module.exports.normalizeJsonNumbers = normalizeJsonNumbers;
+module.exports.providerError = providerError;

--- a/backend/src/services/evmAudit/CdpHistoryProvider.js
+++ b/backend/src/services/evmAudit/CdpHistoryProvider.js
@@ -1,0 +1,369 @@
+'use strict';
+
+const { txHash, address, stableJson, sha256 } = require('./normalizer');
+
+const ZERO = '0x0000000000000000000000000000000000000000';
+
+function quantity(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  try {
+    const result = BigInt(value);
+    return result >= 0n ? result.toString() : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function invalidResponse(message) {
+  const error = new Error(message);
+  error.code = 'CDP_INVALID_RESPONSE';
+  return error;
+}
+
+function requiredQuantity(value, field) {
+  const parsed = quantity(value);
+  if (parsed == null) throw invalidResponse(`Coinbase CDP returned an invalid ${field}`);
+  return parsed;
+}
+
+function blockNumber(item, ethereum) {
+  const value = item.blockHeight ?? ethereum.blockNumber;
+  const parsed = quantity(value);
+  if (parsed == null || BigInt(parsed) > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  return Number(parsed);
+}
+
+function timestampSeconds(ethereum) {
+  const value = ethereum.blockTimestamp ?? ethereum.timestamp;
+  if (value == null) return null;
+  const parsed = Date.parse(String(value));
+  if (Number.isFinite(parsed)) return String(Math.floor(parsed / 1000));
+  return quantity(value);
+}
+
+function statusIsError(item, ethereum, nestedStatus = null) {
+  const receiptStatus = ethereum.receipt?.status ?? ethereum.status;
+  const classify = (value, field) => {
+    if (value == null) return null;
+    const text = String(value ?? '').toLowerCase();
+    if (['0', '0x0', 'failed', 'reverted', 'error', 'false'].includes(text)) return true;
+    if (['1', '0x1', 'confirmed', 'success', 'succeeded', 'true'].includes(text)) return false;
+    throw invalidResponse(`Coinbase CDP returned an unknown ${field} status`);
+  };
+  const statuses = [
+    classify(receiptStatus, 'receipt'),
+    classify(item.status, 'transaction'),
+    classify(nestedStatus, 'trace'),
+  ].filter((value) => value != null);
+  if (!statuses.length) throw invalidResponse('Coinbase CDP returned a mined transaction without a status');
+  if (statuses.some(Boolean)) return '1';
+  return '0';
+}
+
+function traceAddressOf(trace) {
+  if (Array.isArray(trace.traceAddress)) return trace.traceAddress.map((value) => Number(value));
+  if (Array.isArray(trace.trace_address)) return trace.trace_address.map((value) => Number(value));
+  const traceId = String(trace.traceId || '');
+  const suffix = traceId.includes('_') ? traceId.slice(traceId.lastIndexOf('_') + 1) : '';
+  if (/^\d+(?:_\d+)*$/.test(suffix)) return suffix.split('_').map(Number);
+  return null;
+}
+
+function opStackType(value) {
+  if (value == null) return null;
+  try {
+    return BigInt(value) === 126n ? '0x7e' : String(value).toLowerCase();
+  } catch {
+    return String(value).toLowerCase();
+  }
+}
+
+function nativeCreditRows(item, ethereum, wallet, config) {
+  if (!config) return [];
+  const contract = address(config.contract);
+  const topic0 = String(config.topic0 || '').toLowerCase();
+  if (!contract || !/^0x[0-9a-f]{64}$/.test(topic0)
+      || statusIsError(item, ethereum) === '1') return [];
+  const rows = [];
+  for (const log of (ethereum.receipt?.logs || [])) {
+    const topics = Array.isArray(log.topics)
+      ? log.topics.map((topic) => String(topic).toLowerCase()) : [];
+    if (address(log.address) !== contract || topics[0] !== topic0) continue;
+    const receiverIndex = Number(config.userTopicIndex ?? 2);
+    const receiverTopic = topics[receiverIndex] || '';
+    const receiver = /^0x[0-9a-f]{64}$/.test(receiverTopic)
+      ? address(`0x${receiverTopic.slice(-40)}`) : null;
+    const data = String(log.data || '').toLowerCase();
+    const amountWord = /^0x[0-9a-f]{64}/.test(data) ? data.slice(2, 66) : null;
+    const amount = amountWord && /^[0-9a-f]{64}$/.test(amountWord)
+      ? quantity(`0x${amountWord}`) : null;
+    if (receiver == null || amount == null) {
+      throw invalidResponse('Coinbase CDP returned a malformed configured native-credit log');
+    }
+    if (receiver !== wallet) continue;
+    rows.push(transferBase(item, ethereum, {
+      from: contract,
+      to: wallet,
+      value: amount,
+      logIndex: log.logIndex ?? log.log_index ?? null,
+      isError: '0',
+      nativeCredit: true,
+    }));
+  }
+  return rows;
+}
+
+function transferBase(item, ethereum, fields) {
+  const hash = txHash(item.hash || ethereum.hash);
+  const block = blockNumber(item, ethereum);
+  const timeStamp = timestampSeconds(ethereum);
+  if (!hash || block == null || timeStamp == null) {
+    const error = new Error('Coinbase CDP returned an incomplete mined transaction coordinate');
+    error.code = 'CDP_INVALID_RESPONSE';
+    throw error;
+  }
+  const logIndex = fields.logIndex == null ? null : quantity(fields.logIndex);
+  return {
+    hash,
+    blockNumber: String(block),
+    blockHash: item.blockHash || ethereum.blockHash || null,
+    timeStamp,
+    isError: statusIsError(item, ethereum, fields.status),
+    ...fields,
+    transactionIndex: quantity(
+      ethereum.index ?? ethereum.transactionIndex
+        ?? ethereum.receipt?.transactionIndex ?? ethereum.receipt?.transaction_index
+    ),
+    ...(fields.logIndex == null ? {} : { logIndex }),
+  };
+}
+
+function transactionRows(item, walletAddress, { nativeCredit = null } = {}) {
+  const ethereum = item.content?.ethereum || item.ethereum || item.content || {};
+  const hash = txHash(item.hash || ethereum.hash);
+  if (!hash) throw new Error('Coinbase CDP returned an invalid transaction hash');
+  if (!ethereum.receipt || typeof ethereum.receipt !== 'object'
+      || !Array.isArray(ethereum.receipt.logs)) {
+    throw invalidResponse('Coinbase CDP returned no complete receipt log collection');
+  }
+  if (!Array.isArray(ethereum.flattenedTraces)) {
+    throw invalidResponse('Coinbase CDP returned no complete flattened trace collection');
+  }
+  if (!Array.isArray(ethereum.tokenTransfers)) {
+    throw invalidResponse('Coinbase CDP returned no complete token transfer collection');
+  }
+  const failed = statusIsError(item, ethereum);
+  const gasUsed = requiredQuantity(
+    ethereum.receipt?.gasUsed ?? ethereum.gasUsed, 'receipt gas used'
+  );
+  const effectiveGasPrice = requiredQuantity(
+    ethereum.receipt?.effectiveGasPrice ?? ethereum.effectiveGasPrice ?? ethereum.gasPrice,
+    'receipt effective gas price'
+  );
+  const gasPrice = quantity(ethereum.gasPrice, effectiveGasPrice);
+  const feeWei = (BigInt(gasUsed) * BigInt(effectiveGasPrice)).toString();
+  const input = ethereum.input || '0x';
+  const sender = address(ethereum.from);
+  if (!sender) {
+    const error = new Error('Coinbase CDP returned a mined transaction without a valid sender');
+    error.code = 'CDP_INVALID_RESPONSE';
+    throw error;
+  }
+  const value = requiredQuantity(ethereum.value, 'transaction value');
+  const gas = requiredQuantity(ethereum.gas, 'transaction gas');
+  const common = {
+    from: sender,
+    to: address(ethereum.to) || null,
+    value,
+    gas,
+    gasUsed,
+    gasPrice,
+    feeWei,
+    isError: failed,
+    input,
+    methodId: /^0x[0-9a-f]{8}/i.test(input) ? input.slice(0, 10).toLowerCase() : null,
+    functionName: null,
+    opStackType: opStackType(ethereum.type),
+    opStackSourceHash: ethereum.sourceHash || null,
+    opStackMintWei: quantity(ethereum.mint),
+  };
+  const wallet = walletAddress.toLowerCase();
+  const recipient = address(ethereum.to);
+  const normal = sender === wallet || recipient === wallet
+    ? [transferBase(item, ethereum, common)] : [];
+  const internal = [];
+  if (ethereum.flattenedTraces != null && !Array.isArray(ethereum.flattenedTraces)) {
+    throw invalidResponse('Coinbase CDP returned a non-array flattened trace collection');
+  }
+  for (const trace of (ethereum.flattenedTraces || [])) {
+    const traceFrom = address(trace.from);
+    const traceTo = address(trace.to);
+    if (!traceFrom || !traceTo || (traceFrom !== wallet && traceTo !== wallet)) continue;
+    internal.push(transferBase(item, ethereum, {
+      from: traceFrom,
+      to: traceTo,
+      value: requiredQuantity(trace.value, 'internal trace value'),
+      isError: statusIsError(item, ethereum, trace.status ?? (trace.error ? '1' : null)),
+      traceAddress: traceAddressOf(trace),
+      traceId: trace.traceId || null,
+    }));
+  }
+
+  const token = [];
+  const nft = [];
+  const nft1155 = [];
+  if (ethereum.tokenTransfers != null && !Array.isArray(ethereum.tokenTransfers)) {
+    throw invalidResponse('Coinbase CDP returned a non-array token transfer collection');
+  }
+  for (const transfer of (ethereum.tokenTransfers || [])) {
+    const from = address(transfer.fromAddress || transfer.from_address || transfer.from);
+    const to = address(transfer.toAddress || transfer.to_address || transfer.to);
+    const contract = address(transfer.tokenAddress || transfer.token_address || transfer.address);
+    if (!from || !to || !contract || (from !== wallet && to !== wallet)) continue;
+    const base = transferBase(item, ethereum, {
+      from, to, contractAddress: contract,
+      logIndex: transfer.logIndex ?? transfer.log_index ?? null,
+      tokenSymbol: transfer.tokenSymbol || transfer.token_symbol || null,
+      tokenDecimal: transfer.decimals ?? transfer.tokenDecimal ?? transfer.token_decimals ?? null,
+      tokenID: transfer.tokenId ?? transfer.tokenID ?? null,
+      tokenValue: transfer.value ?? transfer.amount ?? null,
+      isError: failed,
+    });
+    const erc20 = transfer.erc20;
+    const erc721 = transfer.erc721;
+    const erc1155 = transfer.erc1155;
+    if (erc1155) {
+      const ids = Array.isArray(erc1155.tokenIds)
+        ? erc1155.tokenIds : [erc1155.tokenId ?? base.tokenID];
+      const values = Array.isArray(erc1155.values)
+        ? erc1155.values : [erc1155.value ?? base.tokenValue];
+      if (!ids.length || ids.length !== values.length) {
+        throw invalidResponse('Coinbase CDP returned mismatched ERC-1155 ids and values');
+      }
+      ids.forEach((id, index) => {
+        nft1155.push({
+          ...base,
+          tokenID: requiredQuantity(id, 'ERC-1155 token id'),
+          tokenValue: requiredQuantity(values[index], 'ERC-1155 token value'),
+        });
+      });
+    } else if (erc721 || base.tokenID != null) {
+      nft.push({
+        ...base,
+        tokenID: requiredQuantity(erc721?.tokenId ?? base.tokenID, 'ERC-721 token id'),
+        tokenValue: '1',
+      });
+    } else if (erc20 || base.tokenValue != null) {
+      token.push({
+        ...base,
+        value: requiredQuantity(erc20?.value ?? base.tokenValue, 'ERC-20 token value'),
+      });
+    }
+  }
+
+  // Keep the top-level transaction even when it is a zero-value contract call.
+  // normalizeFeeds intentionally makes its canonical ledger representation the
+  // gas leg; the raw CDP page and audit evidence retain the zero-value call.
+  return {
+    normal,
+    internal,
+    token,
+    nft,
+    nft1155,
+    statesync: nativeCreditRows(item, ethereum, wallet, nativeCredit),
+  };
+}
+
+function normalizePage(walletAddress, items, { nativeCredit = null } = {}) {
+  const feeds = { normal: [], internal: [], token: [], nft: [], nft1155: [], statesync: [] };
+  const uniqueItems = dedupeItems(items);
+  let maxBlock = null;
+  for (const item of uniqueItems) {
+    const hash = txHash(item.hash || item.content?.ethereum?.hash || item.ethereum?.hash);
+    if (!hash) throw new Error('Coinbase CDP page contained a transaction without a valid hash');
+    const ethereum = item.content?.ethereum || item.ethereum || item.content || {};
+    if (blockNumber(item, ethereum) == null || timestampSeconds(ethereum) == null) {
+      throw invalidResponse('Coinbase CDP page contained a transaction without a safe mined coordinate');
+    }
+    const rows = transactionRows(item, walletAddress, { nativeCredit });
+    for (const [feed, entries] of Object.entries(rows)) feeds[feed].push(...entries);
+    const current = blockNumber(item, ethereum);
+    if (Number.isSafeInteger(current)) maxBlock = maxBlock == null ? current : Math.max(maxBlock, current);
+  }
+  for (const rows of Object.values(feeds)) rows.scannedThroughBlock = maxBlock;
+  return {
+    feeds,
+    transactions: uniqueItems.map((item) => txHash(
+      item.hash || item.content?.ethereum?.hash || item.ethereum?.hash
+    )),
+    maxBlock,
+    itemCount: items.length,
+  };
+}
+
+// Keep one identity/fingerprint map across pages and restarts. A repeated
+// transaction at the same coordinate is harmless; the same hash with changed
+// coordinates or economics is an integrity conflict and freezes the cursor.
+function itemIdentity(item) {
+  const hash = txHash(item?.hash || item?.content?.ethereum?.hash || item?.ethereum?.hash);
+  const ethereum = item?.content?.ethereum || item?.ethereum || item?.content || {};
+  return {
+    hash,
+    identity: stableJson({
+      hash,
+      blockHash: item?.blockHash || ethereum.blockHash || null,
+      blockHeight: item?.blockHeight ?? ethereum.blockNumber ?? null,
+    }),
+    fingerprint: stableJson(item),
+  };
+}
+
+function assertNoConflicts(items, seen = new Map()) {
+  if (!Array.isArray(items)) throw invalidResponse('Coinbase CDP transaction page is not an array');
+  for (const item of items) {
+    const current = itemIdentity(item);
+    if (!current.hash) throw invalidResponse('Coinbase CDP page contained a transaction without a valid hash');
+    const previous = seen.get(current.hash);
+    if (previous && (previous.identity !== current.identity || previous.fingerprint !== current.fingerprint)) {
+      const error = new Error(`Coinbase CDP returned conflicting data for ${current.hash}`);
+      error.code = 'CDP_CONFLICTING_TRANSACTION';
+      throw error;
+    }
+    if (!previous) seen.set(current.hash, current);
+  }
+}
+
+function dedupeItems(items, seen = new Map()) {
+  if (!Array.isArray(items)) throw invalidResponse('Coinbase CDP transaction page is not an array');
+  const unique = [];
+  for (const item of items) {
+    const current = itemIdentity(item);
+    const hash = current.hash;
+    if (!hash) throw invalidResponse('Coinbase CDP page contained a transaction without a valid hash');
+    const previous = seen.get(hash);
+    if (previous) {
+      if (previous.identity !== current.identity || previous.fingerprint !== current.fingerprint) {
+        const error = new Error(`Coinbase CDP returned conflicting data for ${hash}`);
+        error.code = 'CDP_CONFLICTING_TRANSACTION';
+        throw error;
+      }
+      continue;
+    }
+    seen.set(hash, current);
+    unique.push(item);
+  }
+  return unique;
+}
+
+module.exports = {
+  ZERO,
+  normalizePage,
+  quantity,
+  statusIsError,
+  transactionRows,
+  nativeCreditRows,
+  dedupeItems,
+  assertNoConflicts,
+  itemIdentity,
+  sha256,
+};

--- a/backend/src/services/evmAudit/RpcClient.js
+++ b/backend/src/services/evmAudit/RpcClient.js
@@ -47,7 +47,7 @@ class RpcClient {
     return run;
   }
 
-  async request(method, params) {
+  async requestWithEvidence(method, params) {
     return this._scheduled(async () => {
       let response;
       try {
@@ -84,8 +84,21 @@ class RpcClient {
           { httpStatus: response.status }
         );
       }
-      return body.result;
+      return {
+        result: body.result,
+        rawText: text,
+        responseJson: body,
+        responseSha256: sha256(text),
+        requestId: response.headers.get('x-request-id') || null,
+        httpStatus: response.status,
+        method,
+        params,
+      };
     });
+  }
+
+  async request(method, params) {
+    return (await this.requestWithEvidence(method, params)).result;
   }
 
   async finalizedBoundary() {
@@ -108,8 +121,26 @@ class RpcClient {
     );
   }
 
+  async transactionCountWithEvidence(address, blockTag) {
+    const response = await this.requestWithEvidence(
+      'eth_getTransactionCount', [address, blockTag]
+    );
+    return {
+      value: quantity(response.result, 'transaction count'),
+      evidence: response,
+    };
+  }
+
   async balance(address, blockTag) {
     return quantity(await this.request('eth_getBalance', [address, blockTag]), 'native balance');
+  }
+
+  async balanceWithEvidence(address, blockTag) {
+    const response = await this.requestWithEvidence('eth_getBalance', [address, blockTag]);
+    return {
+      value: quantity(response.result, 'native balance'),
+      evidence: response,
+    };
   }
 
   async code(address, blockTag) {
@@ -120,6 +151,17 @@ class RpcClient {
     return value.toLowerCase();
   }
 
+  async codeWithEvidence(address, blockTag) {
+    const response = await this.requestWithEvidence('eth_getCode', [address, blockTag]);
+    if (typeof response.result !== 'string' || !/^0x[0-9a-f]*$/i.test(response.result)) {
+      throw rpcError('Consensus RPC returned invalid account code', 'RPC_INVALID_RESPONSE');
+    }
+    return {
+      value: response.result.toLowerCase(),
+      evidence: response,
+    };
+  }
+
   async erc20Balance(contract, address, blockTag) {
     const data = `0x70a08231${address.toLowerCase().slice(2).padStart(64, '0')}`;
     return quantity(
@@ -128,9 +170,26 @@ class RpcClient {
     );
   }
 
+  async erc20BalanceWithEvidence(contract, address, blockTag) {
+    const data = `0x70a08231${address.toLowerCase().slice(2).padStart(64, '0')}`;
+    const response = await this.requestWithEvidence(
+      'eth_call', [{ to: contract, data }, blockTag]
+    );
+    return {
+      value: quantity(response.result, 'ERC-20 balance'),
+      evidence: response,
+    };
+  }
+
   async transactionAndReceipt(hash) {
-    const transaction = await this.request('eth_getTransactionByHash', [hash]);
-    const receipt = await this.request('eth_getTransactionReceipt', [hash]);
+    const transactionResponse = await this.requestWithEvidence(
+      'eth_getTransactionByHash', [hash]
+    );
+    const receiptResponse = await this.requestWithEvidence(
+      'eth_getTransactionReceipt', [hash]
+    );
+    const transaction = transactionResponse.result;
+    const receipt = receiptResponse.result;
     if (!transaction || !receipt) {
       throw rpcError('Consensus RPC could not find a mined transaction and receipt', 'RPC_TRANSACTION_NOT_FOUND');
     }
@@ -143,12 +202,20 @@ class RpcClient {
         || String(transaction.blockHash || '').toLowerCase() !== String(receipt.blockHash || '').toLowerCase()) {
       throw rpcError('Consensus RPC returned conflicting transaction/receipt coordinates', 'RPC_IDENTITY_MISMATCH');
     }
-    const block = await this.request('eth_getBlockByNumber', [transaction.blockNumber, false]);
+    const blockResponse = await this.requestWithEvidence(
+      'eth_getBlockByNumber', [transaction.blockNumber, false]
+    );
+    const block = blockResponse.result;
     if (String(block?.hash || '').toLowerCase() !== String(transaction.blockHash || '').toLowerCase()
         || BigInt(block?.number || '-1') !== BigInt(transaction.blockNumber)) {
       throw rpcError('Consensus RPC transaction is not in the canonical block at its height', 'RPC_CANONICALITY_MISMATCH');
     }
-    return { transaction, receipt, block };
+    return {
+      transaction,
+      receipt,
+      block,
+      evidence: [transactionResponse, receiptResponse, blockResponse],
+    };
   }
 }
 

--- a/backend/src/services/evmAudit/corroboratedIdentity.js
+++ b/backend/src/services/evmAudit/corroboratedIdentity.js
@@ -27,41 +27,68 @@ function decimal(value, options) {
   return parsed == null ? null : parsed.toString();
 }
 
-function moralisTransferFields(effect, payload) {
+function indexedTransferFields(effect, payload, provider) {
   const standard = effect.effect_type;
   const numericFields = payload.__evm_json_numeric_fields;
   if (standard !== 'erc20' && Array.isArray(numericFields)
       && numericFields.some((field) => ['amount', 'token_id', 'tokenId'].includes(field))) {
     return null;
   }
-  const contract = normalizedAddress(payload.address ?? payload.token_address);
-  const from = normalizedAddress(payload.from_address ?? payload.from);
-  const to = normalizedAddress(payload.to_address ?? payload.to);
+  if (provider === 'moralis') {
+    const contract = normalizedAddress(payload.address ?? payload.token_address);
+    const from = normalizedAddress(payload.from_address ?? payload.from);
+    const to = normalizedAddress(payload.to_address ?? payload.to);
+    const value = decimal(
+      standard === 'erc20' ? payload.value : payload.amount,
+      { allowSafeNumber: standard === 'erc20' }
+    );
+    const tokenId = standard === 'erc20' ? null : decimal(payload.token_id ?? payload.tokenId);
+    if (!contract || !from || !to || value == null || (standard !== 'erc20' && tokenId == null)) {
+      return null;
+    }
+    return { contract, from, to, value, tokenId };
+  }
+  const nested = standard === 'erc20' ? payload.erc20
+    : standard === 'erc721' ? payload.erc721 : payload.erc1155;
+  const contract = normalizedAddress(payload.address ?? payload.token_address
+    ?? payload.tokenAddress);
+  const from = normalizedAddress(payload.from_address ?? payload.from
+    ?? payload.fromAddress ?? nested?.from_address ?? nested?.fromAddress);
+  const to = normalizedAddress(payload.to_address ?? payload.to
+    ?? payload.toAddress ?? nested?.to_address ?? nested?.toAddress);
   const value = decimal(
-    standard === 'erc20' ? payload.value : payload.amount,
+    standard === 'erc20'
+      ? (payload.value ?? payload.amount ?? nested?.value)
+      : (payload.amount ?? payload.value ?? nested?.amount ?? nested?.value ?? '1'),
     { allowSafeNumber: standard === 'erc20' }
   );
-  const tokenId = standard === 'erc20' ? null : decimal(payload.token_id ?? payload.tokenId);
+  const tokenId = standard === 'erc20' ? null : decimal(
+    payload.token_id ?? payload.tokenId ?? nested?.token_id ?? nested?.tokenId
+  );
   if (!contract || !from || !to || value == null || (standard !== 'erc20' && tokenId == null)) {
     return null;
   }
   return { contract, from, to, value, tokenId };
 }
 
-function matchesMoralisTransfer(effect, observation) {
+function matchesIndexedTransfer(effect, observation) {
   if (!effect || !observation || !TRANSFER_TYPES[effect.effect_type]) return false;
-  if (observation.provider !== 'moralis') return false;
+  if (!['moralis', 'coinbase-cdp'].includes(observation.provider)) return false;
   const expectedKind = `${effect.effect_type}_transfer`;
   if (observation.evidence_kind !== expectedKind
       || String(observation.tx_hash || '').toLowerCase() !== String(effect.tx_hash).toLowerCase()
       || Number(observation.log_index) !== Number(effect.log_index)) return false;
-  const fields = moralisTransferFields(effect, observation.payload_json || {});
+  const fields = indexedTransferFields(effect, observation.payload_json || {}, observation.provider);
   return Boolean(fields)
     && fields.contract === String(effect.token_contract || '').toLowerCase()
     && fields.from === String(effect.from_address || '').toLowerCase()
     && fields.to === String(effect.to_address || '').toLowerCase()
     && fields.value === decimal(effect.value_units)
     && fields.tokenId === (effect.effect_type === 'erc20' ? null : decimal(effect.token_id));
+}
+
+function matchesMoralisTransfer(effect, observation) {
+  return observation?.provider === 'moralis' && matchesIndexedTransfer(effect, observation);
 }
 
 function matchesLegacyTransfer(effect, row) {
@@ -80,5 +107,6 @@ function matchesLegacyTransfer(effect, row) {
 module.exports = {
   TRANSFER_TYPES,
   matchesLegacyTransfer,
+  matchesIndexedTransfer,
   matchesMoralisTransfer,
 };

--- a/backend/src/services/evmAudit/effectDecoder.js
+++ b/backend/src/services/evmAudit/effectDecoder.js
@@ -247,9 +247,9 @@ function internalObservationFields(observation, wallet) {
 // pretending it is consensus evidence. When an independent trace provider and
 // the existing ledger contain one unambiguous identical effect, retain both
 // evidence links and mark that effect verified; otherwise it remains provisional
-// and therefore blocks a gap-free audit. Moralis takes precedence when both
-// independent providers are present; Blockscout is the fallback for chains
-// where Moralis does not enumerate history.
+// and therefore blocks a gap-free audit. Coinbase CDP takes precedence for Base
+// and Moralis remains the indexed source for Gnosis; Blockscout is only a finite
+// fallback for chains without either source.
 function effectsFromInternalObservations(context, observations) {
   const wallet = context.address.toLowerCase();
   const byTransaction = new Map();
@@ -264,12 +264,13 @@ function effectsFromInternalObservations(context, observations) {
   for (const [hash, rows] of byTransaction) {
     const internalRows = rows.filter((row) => row.evidence_kind !== 'native_credit'
       && row.payload_json?.native_credit !== true);
-    const moralis = internalRows.filter((row) => row.provider === 'moralis');
+    const indexedProviders = ['coinbase-cdp', 'moralis'];
     const explorer = internalRows.filter((row) => ['blockscout', 'etherscan'].includes(row.provider));
     const explorerProvider = ['blockscout', 'etherscan']
       .find((provider) => explorer.some((row) => row.provider === provider));
-    const selectedProvider = moralis.length ? 'moralis'
-      : explorerProvider || 'existing-ledger';
+    const selectedProvider = indexedProviders.find((provider) =>
+      internalRows.some((row) => row.provider === provider)
+    ) || explorerProvider || 'existing-ledger';
     const selected = internalRows.filter((row) => row.provider === selectedProvider);
     const legacyBySignature = new Map();
     for (const row of rows.filter((candidate) => candidate.provider === 'existing-ledger')) {
@@ -292,7 +293,7 @@ function effectsFromInternalObservations(context, observations) {
       const fields = internalObservationFields(row, wallet);
       if (!fields) continue;
       const signature = `${fields.from}:${fields.to}:${fields.value}`;
-      const legacyMatches = ['moralis', 'blockscout', 'etherscan'].includes(row.provider)
+      const legacyMatches = ['coinbase-cdp', 'moralis', 'blockscout', 'etherscan'].includes(row.provider)
         ? (legacyBySignature.get(signature) || []) : [];
       const independentlyVerified = row.trace_address != null
         && legacyMatches.length === 1

--- a/backend/src/services/evmAudit/normalizer.js
+++ b/backend/src/services/evmAudit/normalizer.js
@@ -25,16 +25,16 @@ function sha256(value) {
   ).digest('hex');
 }
 
-function decimalInteger(value) {
-  const text = String(value ?? '');
-  return /^\d+$/.test(text) ? text : null;
-}
-
 function safeInteger(value) {
-  const text = decimalInteger(value);
-  if (text == null) return null;
-  const parsed = Number(text);
-  return Number.isSafeInteger(parsed) ? parsed : null;
+  if (value == null || value === '') return null;
+  const text = String(value);
+  if (!/^(?:\d+|0x[0-9a-f]+)$/i.test(text)) return null;
+  try {
+    const parsed = BigInt(text);
+    return parsed <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(parsed) : null;
+  } catch {
+    return null;
+  }
 }
 
 function address(value) {
@@ -191,6 +191,133 @@ function historyObservations(context, item) {
   return out;
 }
 
+// Coinbase CDP returns one Ethereum transaction object with its receipt,
+// logs, token transfers and flattened traces nested under `content.ethereum`.
+// Keep every nested coordinate as its own observation so a later RPC check can
+// replace a single receipt field without losing the provider's raw evidence.
+function cdpHistoryObservations(context, item) {
+  const ethereum = item?.content?.ethereum || item?.ethereum || item?.content || {};
+  const hash = txHash(item?.hash || ethereum.hash);
+  if (!hash) throw new Error('Coinbase CDP address history returned an invalid transaction hash');
+  const blockNumber = item.blockHeight ?? ethereum.blockNumber;
+  const block = item.blockHash || ethereum.blockHash;
+  const transactionIndex = ethereum.index ?? ethereum.transactionIndex
+    ?? ethereum.receipt?.transactionIndex ?? ethereum.receipt?.transaction_index;
+  const common = { tx: hash, blockNumber, block, transactionIndex };
+  const out = [baseObservation(context, {
+    ...common,
+    evidenceKind: 'transaction',
+    providerObjectKey: `transaction:${hash}`,
+    payload: item,
+  })];
+  const receipt = ethereum.receipt || {};
+  out.push(baseObservation(context, {
+    ...common,
+    evidenceKind: 'receipt',
+    providerObjectKey: `receipt:${hash}`,
+    payload: { ...receipt, transactionHash: receipt.transactionHash || hash },
+  }));
+  for (const log of (receipt.logs || [])) {
+    const logIndex = safeInteger(log.logIndex ?? log.log_index);
+    out.push(baseObservation(context, {
+      ...common,
+      evidenceKind: 'log',
+      providerObjectKey: logIndex == null
+        ? `log:${hash}:provider:${sha256(log)}` : `log:${hash}:${logIndex}`,
+      payload: log,
+      logIndex,
+      blockNumber: log.blockNumber ?? log.blockHeight ?? blockNumber,
+      block: log.blockHash || block,
+      transactionIndex: log.transactionIndex ?? transactionIndex,
+    }));
+  }
+  for (const trace of (ethereum.flattenedTraces || [])) {
+    const traceAddress = trace.traceAddress ?? trace.trace_address ?? null;
+    out.push(baseObservation(context, {
+      ...common,
+      evidenceKind: 'internal_trace',
+      providerObjectKey: traceAddress == null
+        ? `internal:${hash}:provider:${sha256(trace)}`
+        : `internal:${hash}:${stableJson(traceAddress)}`,
+      payload: trace,
+      traceAddress,
+      blockNumber: trace.blockNumber ?? blockNumber,
+      block: trace.blockHash || block,
+      transactionIndex: trace.transactionIndex ?? transactionIndex,
+    }));
+  }
+  for (const transfer of (ethereum.tokenTransfers || [])) {
+    const nested = transfer.erc1155 ? 'erc1155' : transfer.erc721 || transfer.tokenId != null
+      ? 'erc721' : 'erc20';
+    const evidenceKind = `${nested}_transfer`;
+    const logIndex = safeInteger(transfer.logIndex ?? transfer.log_index);
+    const tokenIdentity = nested === 'erc1155'
+      ? `${transfer.tokenId ?? transfer.erc1155?.tokenId ?? ''}:${transfer.amount ?? transfer.value ?? ''}`
+      : '';
+    out.push(baseObservation(context, {
+      ...common,
+      evidenceKind,
+      providerObjectKey: logIndex == null
+        ? `${evidenceKind}:${hash}:provider:${sha256(transfer)}`
+        : `${evidenceKind}:${hash}:${logIndex}${tokenIdentity ? `:${tokenIdentity}` : ''}`,
+      payload: transfer,
+      logIndex,
+      blockNumber: transfer.blockNumber ?? blockNumber,
+      block: transfer.blockHash || block,
+      transactionIndex: transfer.transactionIndex ?? transactionIndex,
+    }));
+  }
+  return out;
+}
+
+function cdpBalanceObservations(context, balances) {
+  if (!Array.isArray(balances)) {
+    const error = new Error('Coinbase CDP balances response is not an array');
+    error.code = 'CDP_INVALID_RESPONSE';
+    throw error;
+  }
+  return balances.map((balance) => {
+    const asset = balance?.asset;
+    const invalid = (message) => {
+      const error = new Error(`Coinbase CDP returned an invalid balance: ${message}`);
+      error.code = 'CDP_INVALID_RESPONSE';
+      return error;
+    };
+    if (!asset || typeof asset !== 'object' || !String(asset.id || '').trim()
+        || !String(asset.type || '').trim()) {
+      throw invalid('asset identity');
+    }
+    const rawValue = balance.valueStr ?? balance.value;
+    let value;
+    try {
+      if (rawValue == null || rawValue === '') throw new Error('missing value');
+      value = BigInt(rawValue);
+      if (value < 0n) throw new Error('negative value');
+      if (balance.value != null && BigInt(balance.value) !== value) {
+        throw new Error('value and valueStr disagree');
+      }
+    } catch {
+      throw invalid('amount');
+    }
+    const decimals = Number(balance.decimals);
+    if (!Number.isSafeInteger(decimals) || decimals < 0 || decimals > 255) {
+      throw invalid('decimals');
+    }
+    const assetType = String(asset.type).toLowerCase();
+    if (assetType === 'erc20' && !/^0x[0-9a-f]{40}$/i.test(String(asset.groupId || ''))) {
+      throw invalid('ERC-20 contract identity');
+    }
+    const assetId = String(asset.id);
+    const kind = assetType === 'native'
+      ? 'native_balance' : 'token_balance';
+    return baseObservation(context, {
+      evidenceKind: kind,
+      providerObjectKey: `balance:${assetId}`,
+      payload: balance,
+    });
+  });
+}
+
 function rpcTransactionObservations(context, transaction, receipt) {
   const hash = txHash(transaction?.hash || receipt?.transactionHash);
   if (!hash) throw new Error('Consensus RPC returned an invalid transaction hash');
@@ -326,7 +453,8 @@ module.exports = {
   address,
   blockHash,
   canonicalize,
-  decimalInteger,
+  cdpBalanceObservations,
+  cdpHistoryObservations,
   explorerFeedObservations,
   historyObservations,
   legacyTransferObservations,

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -1,0 +1,407 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const CdpClient = require('../src/services/evmAudit/CdpClient');
+const CdpHistoryProvider = require('../src/services/evmAudit/CdpHistoryProvider');
+const normalizer = require('../src/services/evmAudit/normalizer');
+const EthWalletService = require('../src/services/EthWalletService');
+const chains = require('../src/config/chains');
+
+const WALLET = '0x1111111111111111111111111111111111111111';
+const OTHER = '0x2222222222222222222222222222222222222222';
+const CONTRACT = '0x3333333333333333333333333333333333333333';
+const ERC20 = '0x4444444444444444444444444444444444444444';
+const ERC721 = '0x5555555555555555555555555555555555555555';
+const ERC1155 = '0x6666666666666666666666666666666666666666';
+const HASH = `0x${'ab'.repeat(32)}`;
+const BLOCK_HASH = `0x${'cd'.repeat(32)}`;
+
+function transaction(overrides = {}) {
+  return {
+    name: HASH,
+    hash: HASH,
+    blockHash: BLOCK_HASH,
+    blockHeight: 123,
+    status: 'confirmed',
+    content: {
+      ethereum: {
+        from: WALLET,
+        to: OTHER,
+        value: '0x0',
+        gas: '0x5208',
+        gasPrice: '0x64',
+        nonce: '0x0',
+        input: '0x095ea7b3',
+        blockTimestamp: '2024-01-01T00:00:00Z',
+        receipt: {
+          status: '0x1',
+          transactionIndex: '0x3',
+          gasUsed: '0x5208',
+          effectiveGasPrice: '0x64',
+          logs: [{ address: ERC20, logIndex: 4, topics: [] }],
+        },
+        flattenedTraces: [{
+          from: WALLET, to: CONTRACT, value: '0x0', traceAddress: [0],
+          status: '0',
+        }, {
+          from: OTHER, to: CONTRACT, value: '0x999', traceAddress: [1],
+          status: '1',
+        }],
+        tokenTransfers: [
+          {
+            fromAddress: WALLET, toAddress: OTHER, tokenAddress: ERC20,
+            logIndex: 5, erc20: { value: '123456' },
+          },
+          {
+            fromAddress: OTHER, toAddress: WALLET, tokenAddress: ERC721,
+            logIndex: 6, erc721: { tokenId: '7' },
+          },
+          {
+            fromAddress: OTHER, toAddress: WALLET, tokenAddress: ERC1155,
+            logIndex: 7, erc1155: { tokenIds: ['8'], values: ['9'] },
+          },
+          {
+            fromAddress: OTHER, toAddress: OTHER, tokenAddress: ERC20,
+            logIndex: 8, erc20: { value: '999' },
+          },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function jsonRpcResult(result) {
+  return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+test('CDP address history uses bounded cursor pagination and never exposes the key to attempts', async (t) => {
+  const originalFetch = global.fetch;
+  const requests = [];
+  const attempts = [];
+  global.fetch = async (_url, options) => {
+    requests.push(JSON.parse(options.body));
+    const pageToken = requests.at(-1).params[0].pageToken;
+    return jsonRpcResult({
+      addressTransactions: [transaction({ hash: pageToken ? `0x${'ef'.repeat(32)}` : HASH })],
+      nextPageToken: pageToken ? null : 'opaque-next',
+    });
+  };
+  t.after(() => { global.fetch = originalFetch; });
+
+  const pages = [];
+  for await (const page of new CdpClient('do-not-log-this-key', {
+    spacingMs: 0, maxAttempts: 1, onFailedAttempt: async (attempt) => attempts.push(attempt),
+  }).addressTransactionPages(WALLET, { pageSize: 1000 })) pages.push(page);
+
+  assert.equal(pages.length, 2);
+  assert.equal(requests[0].method, 'cdp_listAddressTransactions');
+  assert.deepEqual(requests[0].params[0], {
+    address: WALLET.toLowerCase(), pageSize: 100, pageToken: '',
+  });
+  assert.equal(requests[1].params[0].pageToken, 'opaque-next');
+  assert.equal(pages[0].cursorOut, 'opaque-next');
+  assert.equal(pages[1].cursorOut, null);
+  assert.deepEqual(attempts, []);
+  assert.ok(!JSON.stringify(pages).includes('do-not-log-this-key'));
+});
+
+test('CDP pagination rejects a repeated opaque token', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => jsonRpcResult({
+    addressTransactions: [], nextPageToken: 'same-token',
+  });
+  try {
+    const iterator = new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET);
+    await iterator.next();
+    await assert.rejects(() => iterator.next(), (error) => error.code === 'CDP_PAGINATION_STALLED');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('CDP pagination rejects non-string cursors, non-adjacent cycles, and mixed error/result envelopes', async () => {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async () => jsonRpcResult({
+      addressTransactions: [], nextPageToken: 123,
+    });
+    await assert.rejects(
+      () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+        .addressTransactionPages(WALLET).next(),
+      (error) => error.code === 'CDP_INVALID_RESPONSE'
+    );
+
+    const cursors = [
+      { addressTransactions: [], nextPageToken: 'cursor-a' },
+      { addressTransactions: [], nextPageToken: 'cursor-b' },
+      { addressTransactions: [], nextPageToken: 'cursor-a' },
+    ];
+    global.fetch = async () => jsonRpcResult(cursors.shift());
+    const iterator = new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET);
+    await iterator.next();
+    await iterator.next();
+    await assert.rejects(() => iterator.next(), (error) => error.code === 'CDP_PAGINATION_STALLED');
+
+    global.fetch = async () => new Response(JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      error: { code: -32000, message: 'partial result is invalid' },
+      result: { addressTransactions: [] },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+    await assert.rejects(
+      () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+        .addressTransactionPages(WALLET).next(),
+      (error) => error.code === 'CDP_API_ERROR'
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('CDP errors classify quota and rate limits with retry boundaries', async (t) => {
+  const originalFetch = global.fetch;
+  const responses = [
+    new Response(JSON.stringify({ error: { message: 'monthly billing quota exhausted' } }), { status: 403 }),
+    new Response(JSON.stringify({ error: { message: 'slow down' } }), {
+      status: 429, headers: { 'retry-after': '2' },
+    }),
+  ];
+  global.fetch = async () => responses.shift();
+  t.after(() => { global.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_QUOTA_EXHAUSTED' && error.retryAt instanceof Date
+  );
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_RATE_LIMITED' && error.retryAfterMs === 2000
+  );
+});
+
+test('CDP normalizes failed zero-value calls, internal traces, and all token standards', () => {
+  const item = transaction({
+    status: 'failed',
+    content: {
+      ethereum: {
+        ...transaction().content.ethereum,
+        receipt: { ...transaction().content.ethereum.receipt, status: '0x0' },
+      },
+    },
+  });
+  const normalized = CdpHistoryProvider.normalizePage(WALLET, [item]);
+
+  assert.equal(normalized.transactions.length, 1);
+  assert.equal(normalized.feeds.normal[0].isError, '1');
+  assert.equal(normalized.feeds.normal[0].value, '0');
+  assert.equal(normalized.feeds.internal[0].value, '0');
+  assert.equal(normalized.feeds.internal.length, 1, 'intermediary traces do not enter the wallet ledger');
+  assert.equal(normalized.feeds.internal[0].isError, '1', 'the transaction-level failure propagates to its trace');
+  assert.equal(normalized.feeds.token.length, 1);
+  assert.equal(normalized.feeds.nft.length, 1);
+  assert.equal(normalized.feeds.nft1155.length, 1);
+
+  const ledgerRows = EthWalletService.normalizeFeeds(WALLET, normalized.feeds, {
+    preserveZeroValue: true,
+  });
+  assert.ok(ledgerRows.some((row) => row.transfer_type === 'native' && row.value_wei === '0'));
+  assert.ok(ledgerRows.some((row) => row.transfer_type === 'gas'));
+  assert.ok(ledgerRows.some((row) => row.transfer_type === 'internal' && row.value_wei === '0'));
+  assert.equal(ledgerRows.filter((row) => ['token', 'nft', 'nft1155'].includes(row.transfer_type))
+    .every((row) => row.is_error), true);
+});
+
+test('CDP treats a trace status of string zero as an error', () => {
+  const normalized = CdpHistoryProvider.normalizePage(WALLET, [transaction()]);
+  assert.equal(normalized.feeds.internal[0].isError, '1');
+  assert.equal(normalized.feeds.normal[0].transactionIndex, '3');
+});
+
+test('CDP treats a trace status of string one as successful', () => {
+  const item = transaction();
+  item.content.ethereum.flattenedTraces[0].status = '1';
+  const normalized = CdpHistoryProvider.normalizePage(WALLET, [item]);
+  assert.equal(normalized.feeds.internal[0].isError, '0');
+});
+
+test('CDP requires the provider to return every effect collection', () => {
+  for (const field of ['flattenedTraces', 'tokenTransfers']) {
+    const item = transaction();
+    delete item.content.ethereum[field];
+    assert.throws(
+      () => CdpHistoryProvider.normalizePage(WALLET, [item]),
+      (error) => error.code === 'CDP_INVALID_RESPONSE'
+    );
+  }
+  const item = transaction();
+  delete item.content.ethereum.receipt.logs;
+  assert.throws(
+    () => CdpHistoryProvider.normalizePage(WALLET, [item]),
+    (error) => error.code === 'CDP_INVALID_RESPONSE'
+  );
+});
+
+test('CDP rejects unknown status and malformed canonical economics', () => {
+  assert.throws(
+    () => CdpHistoryProvider.normalizePage(WALLET, [transaction({ status: 'pending' })]),
+    (error) => error.code === 'CDP_INVALID_RESPONSE'
+  );
+
+  const missingGas = transaction();
+  delete missingGas.content.ethereum.gas;
+  assert.throws(
+    () => CdpHistoryProvider.normalizePage(WALLET, [missingGas]),
+    (error) => error.code === 'CDP_INVALID_RESPONSE'
+  );
+
+  const malformed1155 = transaction();
+  malformed1155.content.ethereum.tokenTransfers = [{
+    fromAddress: OTHER, toAddress: WALLET, tokenAddress: ERC1155,
+    erc1155: { tokenIds: ['8', '9'], values: ['1'] },
+  }];
+  assert.throws(
+    () => CdpHistoryProvider.normalizePage(WALLET, [malformed1155]),
+    (error) => error.code === 'CDP_INVALID_RESPONSE'
+  );
+});
+
+test('CDP balance evidence rejects missing or conflicting quantities', () => {
+  const context = { jobId: 1, subjectId: 2, chainId: 8453, provider: 'coinbase-cdp' };
+  const balance = {
+    asset: { id: 'asset-1', type: 'erc20', groupId: ERC20, subGroupId: '' },
+    value: '10', valueStr: '10', decimals: 18,
+  };
+  assert.equal(normalizer.cdpBalanceObservations(context, [balance]).length, 1);
+  assert.throws(
+    () => normalizer.cdpBalanceObservations(context, [{ ...balance, valueStr: '11' }]),
+    (error) => error.code === 'CDP_INVALID_RESPONSE'
+  );
+});
+
+test('CDP receipt logs provide a wallet-scoped Base bridge-credit feed', () => {
+  const bridgeTopic = `0x${'12'.repeat(32)}`;
+  const item = transaction({
+    content: {
+      ethereum: {
+        ...transaction().content.ethereum,
+        from: OTHER,
+        to: CONTRACT,
+        receipt: {
+          ...transaction().content.ethereum.receipt,
+          logs: [{
+            address: CONTRACT,
+            logIndex: 17,
+            topics: [
+              bridgeTopic,
+              `0x${OTHER.slice(2).padStart(64, '0')}`,
+              `0x${WALLET.slice(2).padStart(64, '0')}`,
+            ],
+            data: `0x${'00'.repeat(31)}01`,
+          }],
+        },
+        flattenedTraces: [],
+        tokenTransfers: [],
+      },
+    },
+  });
+  const normalized = CdpHistoryProvider.normalizePage(WALLET, [item], {
+    nativeCredit: { contract: CONTRACT, topic0: bridgeTopic, userTopicIndex: 2 },
+  });
+
+  assert.equal(normalized.feeds.normal.length, 0, 'a bridge-only receipt has no ordinary wallet transaction leg');
+  assert.equal(normalized.feeds.statesync.length, 1);
+  assert.equal(normalized.feeds.statesync[0].from, CONTRACT.toLowerCase());
+  assert.equal(normalized.feeds.statesync[0].to, WALLET.toLowerCase());
+  assert.equal(normalized.feeds.statesync[0].value, '1');
+  const rows = EthWalletService.normalizeFeeds(WALLET, normalized.feeds, {
+    preserveZeroValue: true,
+    stateSyncContract: CONTRACT,
+  });
+  assert.deepEqual(
+    rows.filter((row) => row.transfer_type === 'internal').map((row) => row.value_wei),
+    ['1']
+  );
+  assert.equal(rows.find((row) => row.transfer_type === 'internal').source_log_index, 17);
+});
+
+test('CDP preserves an OP Stack protocol mint as a native bridge credit', () => {
+  const item = transaction({
+    content: {
+      ethereum: {
+        ...transaction().content.ethereum,
+        type: '0x7e',
+        sourceHash: `0x${'ef'.repeat(32)}`,
+        mint: '0x5',
+        value: '0x0',
+      },
+    },
+  });
+  const normalized = CdpHistoryProvider.normalizePage(WALLET, [item]);
+  const rows = EthWalletService.normalizeFeeds(WALLET, normalized.feeds, {
+    preserveZeroValue: true,
+    opStackDeposits: chains.getChain(8453).opStackDeposits,
+  });
+
+  assert.deepEqual(
+    rows.filter((row) => row.transfer_type === 'native').map((row) => ({
+      from: row.from_address, value: row.value_wei, isError: row.is_error,
+    })),
+    [{
+      from: chains.getChain(8453).opStackDeposits.creditSource,
+      value: '5',
+      isError: false,
+    }]
+  );
+  assert.equal(rows.some((row) => row.transfer_type === 'gas'), false,
+    'protocol deposits do not charge the wallet gas');
+});
+
+test('CDP page normalization deduplicates identical transactions and rejects conflicting coordinates', () => {
+  const duplicate = CdpHistoryProvider.normalizePage(WALLET, [transaction(), transaction()]);
+  assert.equal(duplicate.transactions.length, 1);
+  assert.equal(duplicate.feeds.normal.length, 1);
+
+  assert.throws(
+    () => CdpHistoryProvider.normalizePage(WALLET, [
+      transaction(), transaction({ blockHash: `0x${'aa'.repeat(32)}` }),
+    ]),
+    (error) => error.code === 'CDP_CONFLICTING_TRANSACTION'
+  );
+});
+
+test('CDP cross-page dedupe rejects changed economics for one transaction identity', () => {
+  const seen = new Map();
+  assert.equal(CdpHistoryProvider.dedupeItems([transaction()], seen).length, 1);
+  assert.equal(CdpHistoryProvider.dedupeItems([transaction()], seen).length, 0);
+  assert.throws(
+    () => CdpHistoryProvider.dedupeItems([transaction({
+      content: {
+        ethereum: { ...transaction().content.ethereum, value: '0x1' },
+      },
+    })], seen),
+    (error) => error.code === 'CDP_CONFLICTING_TRANSACTION'
+  );
+});
+
+test('CDP raw observations retain receipt, log, trace, and token evidence by identity', () => {
+  const observations = normalizer.cdpHistoryObservations({
+    jobId: 1, subjectId: 2, chainId: 8453, provider: 'coinbase-cdp',
+  }, transaction());
+  const kinds = observations.map((row) => row.evidenceKind);
+  assert.deepEqual(kinds, [
+    'transaction', 'receipt', 'log', 'internal_trace',
+    'internal_trace', 'erc20_transfer', 'erc721_transfer', 'erc1155_transfer',
+    'erc20_transfer',
+  ]);
+  assert.equal(new Set(observations.map((row) => row.providerObjectKey)).size, observations.length);
+  assert.ok(observations.every((row) => row.payloadSha256.length === 64));
+});

--- a/backend/tests/ethDiscovery.test.js
+++ b/backend/tests/ethDiscovery.test.js
@@ -66,7 +66,7 @@ test('discovery frontier respects durable per-depth receipts', async () => {
   assert.match(call.text, /eth_discovery_fetches/);
   assert.match(call.text, /r\.depth = f\.depth/);
   assert.match(call.text, /f\.depth < \$3/);
-  assert.match(call.text, /r\.status IN \('complete', 'contract', 'high_traffic', 'dust'\)/);
+  assert.match(call.text, /r\.status IN \('complete', 'contract', 'high_traffic', 'dust', 'unsupported'\)/);
   assert.match(call.text, /jsonb_array_elements/);
 });
 

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -44,7 +44,9 @@ const EthWallet = require('../src/models/EthWallet');
 const EthWalletChain = require('../src/models/EthWalletChain');
 const EthFeedCoverage = require('../src/models/EthFeedCoverage');
 const EthTransfer = require('../src/models/EthTransfer');
+const EthProviderPage = require('../src/models/EthProviderPage');
 const SecretsService = require('../src/services/SecretsService');
+const RpcClient = require('../src/services/evmAudit/RpcClient');
 const EthDerivedPipeline = require('../src/services/EthDerivedPipeline');
 const MirrorService = require('../src/services/EthTransactionMirrorService');
 const TransactionClassificationService = require('../src/services/TransactionClassificationService');
@@ -69,7 +71,9 @@ function harness(t, {
   cursors = {},
   feedBehavior = {},
   apiKey = 'key',
+  cdpApiKey = apiKey,
   indexedHead = 50000000,
+  cdpResponses = null,
 } = {}) {
   const restore = [];
   const stub = (obj, key, fn) => { restore.push([obj, key, obj[key]]); obj[key] = fn; };
@@ -85,7 +89,7 @@ function harness(t, {
   });
 
   const calls = {
-    fetches: [], heads: [], deletes: [], cursors: [], unsupported: [],
+    fetches: [], cdpPages: [], cdpRequests: [], heads: [], deletes: [], cursors: [], unsupported: [],
     chainErrors: [], cleared: [], inserted: [], coverage: [],
   };
   const chainStates = new Map();
@@ -104,9 +108,69 @@ function harness(t, {
   };
 
   stub(EthWallet, 'findById', async () => ({ id: 7, user_id: 1, address: WALLET }));
-  stub(SecretsService, 'getUserKey', async () => apiKey);
+  stub(SecretsService, 'getUserKey', async (_userId, service) => (
+    service === 'cdp' ? cdpApiKey : apiKey
+  ));
   stub(EthWalletChain, 'ensure', async (walletId, chainId, ingestVersion = 0) =>
     ({ ...stateFor(walletId, chainId, ingestVersion) }));
+  stub(EthWalletChain, 'startProviderScan', async (walletId, chainId, throughBlock) => {
+    const state = stateFor(walletId, chainId, 0);
+    const resumable = ['running', 'deferred', 'failed'].includes(state.provider_scan_status)
+      && Number(state.provider_scan_head) === Number(throughBlock);
+    if (!resumable) {
+      Object.assign(state, {
+        provider_cursor: null, provider_scan_id: 'test-scan-id', provider_scan_head: throughBlock,
+        provider_scan_status: 'running', provider_scan_order: state.provider_scan_order || 'unknown',
+      });
+    }
+    return { ...state };
+  });
+  stub(EthWalletChain, 'checkpointProviderScan', async (walletId, chainId, cursor) => {
+    const state = stateFor(walletId, chainId, 0);
+    state.provider_cursor = cursor;
+    state.provider_scan_status = 'running';
+    return { ...state };
+  });
+  stub(EthWalletChain, 'finishProviderScan', async (walletId, chainId) => {
+    const state = stateFor(walletId, chainId, 0);
+    state.provider_cursor = null;
+    state.provider_scan_status = 'complete';
+    return { ...state };
+  });
+  stub(EthWalletChain, 'failProviderScan', async (walletId, chainId, status) => {
+    const state = stateFor(walletId, chainId, 0);
+    state.provider_scan_status = status;
+    return { ...state };
+  });
+  stub(EthWalletChain, 'setProviderScanOrder', async (walletId, chainId, order) => {
+    const state = stateFor(walletId, chainId, 0);
+    state.provider_scan_order = order;
+    return { ...state };
+  });
+  stub(EthProviderPage, 'record', async (page) => {
+    calls.cdpPages.push(page);
+    return page;
+  });
+  stub(EthProviderPage, 'forWalletChain', async () => []);
+  stub(RpcClient.prototype, 'finalizedBoundary', async () => ({
+    number: indexedHead,
+    numberHex: `0x${Number(indexedHead).toString(16)}`,
+    hash: `0x${'f'.repeat(64)}`,
+  }));
+  const originalFetch = global.fetch;
+  stub(global, 'fetch', async (url, options) => {
+    if (!String(url).includes('/rpc/v1/base/')) return originalFetch(url, options);
+    const body = JSON.parse(options.body);
+    calls.cdpRequests.push(body);
+    if (cdpResponses?.length) {
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0', id: 1, result: cdpResponses.shift(),
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      jsonrpc: '2.0', id: 1, result: { addressTransactions: [], nextPageToken: null },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  });
   stub(EthWalletChain, 'resetForIngestVersion', async (walletId, chainId, ingestVersion) => {
     calls.resets ||= [];
     calls.resets.push({ chainId, ingestVersion });
@@ -180,6 +244,16 @@ function harness(t, {
     calls.deletes.push({ chainId, types: types.join(','), block });
   });
   stub(EthTransfer, 'bulkInsert', async (rows) => { calls.inserted.push(...rows); return rows.length; });
+  stub(EthTransfer, 'replaceFeeds', async (walletId, chainId, replacements, rows) => {
+    for (const replacement of replacements) {
+      calls.deletes.push({
+        chainId, types: replacement.types.join(','), block: replacement.block,
+        ...(replacement.options || {}),
+      });
+    }
+    calls.inserted.push(...rows);
+    return rows.length;
+  });
   stub(EthWalletChain, 'updateCursors', async (walletId, chainId, next) => {
     calls.cursors.push({ chainId, ...next });
     const state = stateFor(walletId, chainId, 0);
@@ -194,9 +268,11 @@ function harness(t, {
     for (const [key, value] of Object.entries(next)) {
       if (value != null) state[columns[key]] = value;
     }
+    return { ...state };
   });
   stub(EthWalletChain, 'setUnsupportedFeeds', async (walletId, chainId, list) => {
     calls.unsupported.push({ chainId, list });
+    return { ...stateFor(walletId, chainId, 0) };
   });
   stub(EthWalletChain, 'setError', async (walletId, chainId, code, message) => {
     calls.chainErrors.push({ chainId, code, message });
@@ -272,9 +348,8 @@ test('a chain-specific Blockscout floor preserves stricter operator pacing', (t)
 test('all live-probed chains default on through their configured providers', () => {
   delete process.env.ETH_CHAINS;
   const byId = new Map(chains.allChains().map((chain) => [chain.id, chain]));
-  // OP/Base use keyless Blockscout because Etherscan gates them by plan. A
-  // partial internal range stays a visible per-feed
-  // gap rather than disabling the other independently complete feeds.
+  // OP and Base remain enabled by default; Base's ordinary history provider is
+  // CDP and its old Blockscout transport is retained only for surgical gaps.
   for (const id of [1, 10, 100, 137, 324, 8453, 32401, 42161, 59144]) {
     assert.equal(byId.get(id).enabled, true, `chain ${id} defaults on through its configured provider`);
   }
@@ -574,37 +649,24 @@ test('an unsupported feed freezes its cursor, keeps its rows, and records the ga
   assert.equal(calls.walletError, undefined);
 });
 
-test('a wholly unreadable chain is isolated to its own row', async (t) => {
-  const unavailable = () => {
-    const err = new Error('Free API access is not supported for this chain.');
-    err.code = 'ETHERSCAN_CHAIN_UNAVAILABLE';
-    throw err;
-  };
+test('a Base wallet without a CDP key is isolated as a deferred chain row', async (t) => {
   const { calls } = harness(t, {
     chainSet: '1,8453',
-    // Only the FIRST feed is wired to fail. The rest must be recognised as
-    // unreadable without being called at all -- they would answer identically,
-    // and the throttle is global across every user.
-    feedBehavior: { '8453:normal': unavailable },
+    cdpApiKey: null,
   });
 
   const result = await EthWalletService.syncWallet(7);
 
-  assert.deepEqual(
-    calls.fetches.filter((c) => c.chainId === 8453).map((c) => c.feed),
-    ['normal'],
-    'an unreadable chain must cost one request, not six'
-  );
-  assert.deepEqual(calls.unsupported.find((u) => u.chainId === 8453).list,
-    ['normal', 'internal', 'token', 'nft', 'nft1155'],
-    'the gap record still names every feed that went unfetched');
+  assert.deepEqual(calls.fetches.filter((c) => c.chainId === 8453), []);
+  assert.deepEqual(calls.cdpRequests, [], 'a missing CDP key makes no provider request');
+  assert.deepEqual(calls.unsupported.find((u) => u.chainId === 8453).list, []);
   const baseError = calls.chainErrors.find((e) => e.chainId === 8453);
-  assert.equal(baseError.code, 'CHAIN_UNAVAILABLE');
-  // Actionable: the two things that actually fix it.
-  assert.match(baseError.message, /Upgrade the plan or remove 8453 from ETH_CHAINS/);
+  assert.equal(baseError.code, 'SYNC_DEFERRED');
+  assert.match(baseError.message, /CDP history deferred/);
   assert.ok(calls.cleared.includes(1), 'mainnet still syncs and reports clean');
-  assert.deepEqual(result.unsupportedFeeds.filter((f) => f.startsWith('Base')).length, 5);
-  assert.equal(calls.walletError, undefined, 'a config condition is not a wallet sync failure');
+  assert.deepEqual(result.deferredFeeds.filter((f) => f.startsWith('Base')).length, 6);
+  assert.equal(calls.walletError.code, 'SYNC_DEFERRED', 'the wallet exposes missing CDP as deferred');
+  assert.match(calls.walletError.message, /deferred because the explorer is rate limited/);
 });
 
 test('a transient failure and an unsupported feed are told apart', async (t) => {
@@ -831,9 +893,9 @@ test('the full-wallet job retries deferred feeds even when another feed failed',
 
 test('a rate-limited coverage boundary returns a deferred chain instead of failing the wallet', async (t) => {
   const { calls, stub } = harness(t, { chainSet: '8453' });
-  stub(EtherscanService, 'coverageBoundary', async () => {
-    const error = new Error('Blockscout rate limit reached; retry after 10s');
-    error.code = 'EXPLORER_RATE_LIMITED';
+  stub(RpcClient.prototype, 'finalizedBoundary', async () => {
+    const error = new Error('Consensus RPC rate limit reached; retry after 10s');
+    error.code = 'RPC_RATE_LIMITED';
     error.retryAfterMs = 10000;
     throw error;
   });
@@ -842,7 +904,7 @@ test('a rate-limited coverage boundary returns a deferred chain instead of faili
 
   assert.deepEqual(calls.fetches, [], 'the boundary failure prevents every feed request');
   assert.deepEqual(result.skippedFeeds, [
-    'Base/normal', 'Base/internal', 'Base/token', 'Base/nft', 'Base/nft1155',
+    'Base/normal', 'Base/internal', 'Base/token', 'Base/nft', 'Base/nft1155', 'Base/statesync',
   ]);
   assert.equal(result.chains[0].rateLimited, true);
   assert.equal(result.status, 'deferred');
@@ -853,7 +915,7 @@ test('a rate-limited coverage boundary returns a deferred chain instead of faili
     entry.status === 'not_applicable'
     || (entry.status === 'deferred' && entry.retryAfterAt instanceof Date)
   )));
-  assert.match(calls.walletError.message, /rate limited/);
+  assert.match(calls.walletError.message, /rate limit/);
 });
 
 // A row on the given chain, so a chain can be told apart by what it inserts.
@@ -1400,8 +1462,8 @@ test('an account feed freezes when the indexed head falls behind its resume bloc
   );
 });
 
-test('a regressed indexed head cannot delete or lower a persisted feed cursor', async (t) => {
-  const { calls } = harness(t, {
+test('a failed Base finalized-boundary check cannot delete or lower a persisted feed cursor', async (t) => {
+  const { calls, stub } = harness(t, {
     chainSet: '8453',
     indexedHead: 199,
     cursors: {
@@ -1416,15 +1478,19 @@ test('a regressed indexed head cannot delete or lower a persisted feed cursor', 
     },
   });
 
-  await assert.rejects(
-    () => EthWalletService.syncWallet(7),
-    (error) => error.code === 'ETHERSCAN_API_ERROR'
-      && /behind persisted cursor/.test(error.message)
-  );
+  stub(RpcClient.prototype, 'finalizedBoundary', async () => {
+    const error = new Error('finalized boundary unavailable');
+    error.code = 'RPC_API_ERROR';
+    throw error;
+  });
+
+  const result = await EthWalletService.syncWallet(7);
   assert.deepEqual(calls.fetches, []);
+  assert.deepEqual(calls.cdpRequests, []);
   assert.deepEqual(calls.deletes, []);
   assert.deepEqual(calls.cursors, []);
-  assert.match(calls.chainErrors[0].message, /behind persisted cursor/);
+  assert.equal(result.status, 'failed');
+  assert.match(calls.chainErrors[0].message, /finalized boundary unavailable/);
   assert.ok(calls.coverage[0].entries.every((entry) => (
     entry.status === 'not_applicable' || entry.status === 'failed'
   )));
@@ -1931,7 +1997,7 @@ test('an OP Stack deposit sent onward is net-zero for the tracked L2 sender', ()
     'mint and execution stay separate so exact balance math nets them to zero');
 });
 
-test('a pre-version OP/Base chain resets every cursor and reingests from genesis once', async (t) => {
+test('a pre-version Base chain resets every cursor and reingests from genesis once', async (t) => {
   const { calls } = harness(t, {
     chainSet: '8453',
     cursors: {
@@ -1949,14 +2015,14 @@ test('a pre-version OP/Base chain resets every cursor and reingests from genesis
 
   await EthWalletService.syncWallet(7);
 
-  assert.deepEqual(calls.resets, [{ chainId: 8453, ingestVersion: 1 }]);
-  assert.ok(calls.fetches.every((call) => call.startBlock === 0),
-    'the provider and normalization change heals every historical feed');
+  assert.deepEqual(calls.resets, [{ chainId: 8453, ingestVersion: 2 }]);
+  assert.ok(calls.cdpRequests.every((request) => request.params[0].pageToken === ''),
+    'the first CDP walk starts at its proven genesis boundary');
   assert.ok(calls.deletes.every((call) => call.block === 0),
     'each successful feed replaces its full old window');
 });
 
-test('empty OP Stack feeds persist indexed coverage and resume incrementally on the next sync', async (t) => {
+test('empty Base CDP pages persist coverage and resume with the CDP cursor contract', async (t) => {
   const { calls } = harness(t, { chainSet: '8453' });
 
   await EthWalletService.syncWallet(7);
@@ -1967,17 +2033,110 @@ test('empty OP Stack feeds persist indexed coverage and resume incrementally on 
   for (const field of ['normal', 'internal', 'token', 'nft', 'nft1155']) {
     assert.equal(cursorWrites[0][field], 50000000, `${field} records empty-feed coverage`);
   }
-  assert.equal(cursorWrites[0].statesync, null,
-    'Base native-credit discovery is audit-only and does not advance routine Sync');
-  const secondFetches = calls.fetches.filter((call) => call.chainId === 8453).slice(5);
-  assert.equal(secondFetches.length, 5);
-  assert.ok(secondFetches.every((call) => call.startBlock === 50000000 - 64),
-    'the second sync uses the stored indexed head with only the reorg overlap');
-  assert.ok(secondFetches.every((call) => call.coverage === 50000000),
-    'all account and native-credit feeds share one indexed coverage boundary');
+  assert.equal(cursorWrites[0].statesync, 50000000,
+    'CDP receipt logs advance the durable Base bridge-credit boundary');
+  assert.equal(calls.cdpRequests.length, 2);
+  assert.ok(calls.cdpRequests.every((request) => request.params[0].pageSize === 100));
+  assert.ok(calls.cdpRequests.every((request) => request.params[0].pageToken === ''),
+    'an exhausted one-page stream restarts at the provider boundary; order is unknown');
+  assert.equal(calls.fetches.filter((call) => call.chainId === 8453).length, 0,
+    'Base ordinary Sync does not call anonymous Blockscout feeds');
 });
 
-test('coverage retires Base state sync without making it a red feed', async (t) => {
+test('Base incremental overlap never stops before the current run proves newest-first order', async (t) => {
+  const item = (hash, blockHeight) => ({
+    hash: `0x${hash.repeat(64)}`,
+    blockHash: `0x${'f'.repeat(64)}`,
+    blockHeight: String(blockHeight),
+    status: 'confirmed',
+    content: { ethereum: {
+      hash: `0x${hash.repeat(64)}`,
+      blockHash: `0x${'f'.repeat(64)}`,
+      blockNumber: String(blockHeight),
+      blockTimestamp: '2026-01-01T00:00:00Z',
+      from: WALLET,
+      to: '0x1111111111111111111111111111111111111111',
+      value: '0', gas: '21000', gasPrice: '1',
+      receipt: { status: '1', gasUsed: '21000', effectiveGasPrice: '1', logs: [] },
+      flattenedTraces: [], tokenTransfers: [],
+    } },
+  });
+  const { calls } = harness(t, {
+    chainSet: '8453',
+    indexedHead: 1000,
+    cursors: {
+      8453: {
+        last_block_normal: 1000, last_block_internal: 1000, last_block_token: 1000,
+        last_block_nft: 1000, last_block_1155: 1000, last_block_statesync: 1000,
+        provider_scan_order: 'newest_first', provider_scan_status: 'complete',
+      },
+    },
+    cdpResponses: [
+      { addressTransactions: [item('a', 900)], nextPageToken: 'page-2' },
+      { addressTransactions: [item('b', 800)], nextPageToken: null },
+    ],
+  });
+
+  await EthWalletService.syncWallet(7);
+
+  assert.equal(calls.cdpRequests.length, 2,
+    'a one-item overlap page cannot terminate an incremental walk');
+});
+
+test('a resumable Base CDP scan rehydrates the journaled prefix before continuing', async (t) => {
+  const item = {
+    hash: `0x${'1'.repeat(64)}`,
+    blockHash: `0x${'2'.repeat(64)}`,
+    blockHeight: '100',
+    content: {
+      ethereum: {
+        hash: `0x${'1'.repeat(64)}`,
+        blockHash: `0x${'2'.repeat(64)}`,
+        blockNumber: '100',
+        blockTimestamp: '2026-01-01T00:00:00Z',
+        from: WALLET,
+        to: '0x1111111111111111111111111111111111111111',
+        value: '7',
+        gas: '21000',
+        gasUsed: '21000',
+        gasPrice: '1',
+        receipt: { status: '1', gasUsed: '21000', effectiveGasPrice: '1', logs: [] },
+        flattenedTraces: [],
+        tokenTransfers: [],
+      },
+    },
+  };
+  const { calls, stub } = harness(t, {
+    chainSet: '8453',
+    cursors: {
+      8453: {
+        last_block_normal: 100,
+        last_block_internal: 100,
+        last_block_token: 100,
+        last_block_nft: 100,
+        last_block_1155: 100,
+        last_block_statesync: 100,
+        provider_cursor: 'page-2',
+        provider_scan_id: 'test-scan-id',
+        provider_scan_head: 50000000,
+        provider_scan_status: 'deferred',
+      },
+    },
+  });
+  stub(EthProviderPage, 'forScan', async () => [{
+    cursor_in: 'page-1',
+    cursor_out: 'page-2',
+    response_json: { addressTransactions: [item] },
+  }]);
+
+  await EthWalletService.syncWallet(7);
+
+  assert.equal(calls.cdpRequests[0].params[0].pageToken, 'page-2');
+  assert.ok(calls.inserted.some((row) => row.tx_hash === item.hash && row.transfer_type === 'native'));
+  assert.ok(calls.inserted.some((row) => row.tx_hash === item.hash && row.transfer_type === 'gas'));
+});
+
+test('coverage reports Base CDP for ordinary feeds and its keyed bridge-credit feed', async (t) => {
   const { calls } = harness(t, { chainSet: '8453' });
 
   await EthWalletService.syncWallet(7);
@@ -1985,13 +2144,13 @@ test('coverage retires Base state sync without making it a red feed', async (t) 
   const entries = calls.coverage.find((attempt) => attempt.chainId === 8453).entries;
   assert.equal(
     entries.find((row) => row.feed === 'normal').provider,
-    'Blockscout (https://base.blockscout.com/api/v2)'
+    'Coinbase CDP address history (Base)'
   );
   assert.equal(
     entries.find((row) => row.feed === 'statesync').provider,
-    'Blockscout (https://base.blockscout.com/api/v2)'
+    'Coinbase CDP address history (Base)'
   );
-  assert.equal(entries.find((row) => row.feed === 'statesync').status, 'not_applicable');
+  assert.equal(entries.find((row) => row.feed === 'statesync').status, 'complete');
 });
 
 test('OP Stack deposit reshaping declines every off-shape enriched row', () => {
@@ -2192,7 +2351,7 @@ test('050 adds an idempotent conservative ingestion version marker', () => {
   assert.match(INGEST_VERSION_MIGRATION,
     /ADD COLUMN IF NOT EXISTS ingest_version INT NOT NULL DEFAULT 0/);
   assert.equal(chains.getChain(10).ingestVersion, 1);
-  assert.equal(chains.getChain(8453).ingestVersion, 1);
+  assert.equal(chains.getChain(8453).ingestVersion, 2);
 });
 
 test('054 converts raw and derived chain times from intended UTC wall clocks exactly once', () => {

--- a/backend/tests/ethStateSyncFeed.test.js
+++ b/backend/tests/ethStateSyncFeed.test.js
@@ -447,11 +447,23 @@ function harness(t, { chainSet, cursors = {}, feedBehavior = {} } = {}) {
     calls.deletes.push({ chainId, types: types.join(','), block, ...opts });
   });
   stub(EthTransfer, 'bulkInsert', async (rows) => { calls.inserted.push(...rows); return rows.length; });
+  stub(EthTransfer, 'replaceFeeds', async (walletId, chainId, replacements, rows) => {
+    for (const replacement of replacements) {
+      calls.deletes.push({
+        chainId, types: replacement.types.join(','), block: replacement.block,
+        ...(replacement.options || {}),
+      });
+    }
+    calls.inserted.push(...rows);
+    return rows.length;
+  });
   stub(EthWalletChain, 'updateCursors', async (walletId, chainId, next) => {
     calls.cursors.push({ chainId, ...next });
+    return { wallet_id: walletId, chain_id: chainId };
   });
   stub(EthWalletChain, 'setUnsupportedFeeds', async (walletId, chainId, list) => {
     calls.unsupported.push({ chainId, list });
+    return { wallet_id: walletId, chain_id: chainId };
   });
   stub(EthWalletChain, 'setError', async (walletId, chainId, code, message) => {
     calls.chainErrors.push({ chainId, code, message });
@@ -474,8 +486,8 @@ function harness(t, { chainSet, cursors = {}, feedBehavior = {} } = {}) {
   return { calls, stub };
 }
 
-test('the native-credit feed runs only on its declaring chains', async (t) => {
-  const { calls } = harness(t, { chainSet: '1,10,100,137,8453,42161' });
+test('the legacy native-credit feed runs only on its declaring chains', async (t) => {
+  const { calls } = harness(t, { chainSet: '1,10,100,137,42161' });
 
   await EthWalletService.syncWallet(7);
 
@@ -485,7 +497,6 @@ test('the native-credit feed runs only on its declaring chains', async (t) => {
   assert.equal(calls.fetches.filter((c) => c.chainId === 137).length, 6);
   assert.equal(calls.fetches.filter((c) => c.chainId === 100).length, 6);
   assert.equal(calls.fetches.filter((c) => c.chainId === 10).length, 6);
-  assert.equal(calls.fetches.filter((c) => c.chainId === 8453).length, 5);
   assert.equal(calls.fetches.filter((c) => c.chainId === 1).length, 5);
   assert.equal(calls.fetches.filter((c) => c.chainId === 42161).length, 5);
   // The feed receives the chain's declared config (the account feeds get none).
@@ -495,7 +506,6 @@ test('the native-credit feed runs only on its declaring chains', async (t) => {
   assert.equal(polygonCall.feedConfig.contract, PRECOMPILE);
   assert.equal(gnosisCall.feedConfig.contract, GNOSIS_REWARD);
   assert.equal(optimismCall.feedConfig.contract, OP_STACK_BRIDGE);
-  assert.ok(!calls.fetches.some((c) => c.feed === 'statesync' && c.chainId === 8453));
 });
 
 test('a state-sync deposit ingests as an internal leg from the precompile', async (t) => {
@@ -545,37 +555,12 @@ test('a Gnosis AddedReceiver credit ingests as a bridge-classifiable internal le
   assert.equal(credit.chain_id, 100);
 });
 
-test('an OP Stack ETHBridgeFinalized credit ingests once from the labeled bridge', async (t) => {
-  const { calls } = harness(t, {
-    chainSet: '8453',
-    feedBehavior: {
-      '8453:statesync': [{
-        hash: DEPOSIT_TX,
-        blockNumber: '49293680',
-        timeStamp: '1785370265',
-        from: OP_STACK_BRIDGE,
-        to: WALLET,
-        value: DEPOSIT_WEI,
-      }],
-      // If Blockscout later serves the same internal trace, the symmetric
-      // bridge-source filter must prevent a duplicate native credit.
-      '8453:internal': [{
-        hash: DEPOSIT_TX,
-        blockNumber: '49293680',
-        timeStamp: '1785370265',
-        from: OP_STACK_BRIDGE,
-        to: WALLET,
-        value: DEPOSIT_WEI,
-      }],
-    },
-  });
-
-  await EthWalletService.syncWallet(7);
-
-  const credits = calls.inserted.filter((row) => row.transfer_type === 'internal');
-  assert.equal(credits.length, 1);
-  assert.equal(credits[0].from_address, OP_STACK_BRIDGE);
-  assert.equal(credits[0].chain_id, 8453);
+test('Base bridge credits do not use the legacy anonymous state-sync feed', () => {
+  const base = chains.getChain(8453);
+  assert.equal(base.stateSyncDeposits, undefined);
+  assert.equal(base.historyProvider, 'coinbase-cdp');
+  assert.equal(base.auditNativeCredits.contract, OP_STACK_BRIDGE);
+  assert.equal(base.auditNativeCredits.topic0, ETH_BRIDGE_FINALIZED_TOPIC0);
 });
 
 test('the two internal-typed feeds do not clear each other: delete windows split by from_address', async (t) => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -52,16 +52,21 @@ test('history audit enumerates every configured chain', () => {
   }
 });
 
-test('Moralis audit scope is limited to Base and Gnosis with explicit explorer fallbacks', () => {
+test('Base audit scope uses CDP while Gnosis retains Moralis with an explorer fallback', () => {
   const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
   assert.match(source, /\[100, \{\s*\n\s*moralis: 'gnosis', fallbackProvider: 'blockscout'/);
-  assert.match(source, /\[8453, \{\s*\n\s*moralis: 'base', fallbackProvider: 'blockscout'/);
+  assert.match(source, /\[8453, \{\s*\n\s*cdp: 'base'/);
+  assert.doesNotMatch(source, /\[8453, \{[\s\S]{0,160}moralis:/);
   assert.match(source, /\[1, \{ auditProvider: 'etherscan' \}\]/);
   assert.match(source, /\[42161, \{ auditProvider: 'etherscan' \}\]/);
   assert.match(source, /const useMoralis = Boolean\(providerConfig\.moralis && moralis\)/);
+  assert.match(source, /const useCdp = Boolean\(providerConfig\.cdp && cdp\)/);
   assert.match(source, /const nativeCredit = chain\?\.auditNativeCredits \|\| chain\?\.stateSyncDeposits/);
   assert.match(source, /fetchStateSyncDeposits\(/);
   assert.match(source, /evidenceKind: 'native_credit'/);
+  assert.match(source, /discoveredChain\.bounded = true/);
+  assert.match(source, /discoveredChain\.status = 'bounded'/);
+  assert.match(source, /discoveredChain\.active_hint_proven = false/);
 });
 
 test('Moralis quota fallback remains visibly deferred and never marks discovery complete', () => {
@@ -69,7 +74,7 @@ test('Moralis quota fallback remains visibly deferred and never marks discovery 
   assert.match(source, /status: 'deferred', source: 'moralis'/);
   assert.match(source, /active_discovery = \{/);
   assert.match(source, /key && moralisRequested\.length/);
-  assert.match(source, /let providerDeferred = Boolean\(moralisUnavailable \|\| unavailable\.length\)/);
+  assert.match(source, /let providerDeferred = Boolean\(moralisUnavailable \|\| cdpUnavailable \|\| unavailable\.length\)/);
 });
 
 test('unsupported audit chains become explicit amber scopes without a provider request', async () => {
@@ -404,7 +409,7 @@ test('Moralis plan quota exhaustion is deferred instead of reported as bad crede
   }
 });
 
-test('Moralis discovery quota exhaustion runs configured explorer fallbacks without certifying discovery', async () => {
+test('Moralis discovery quota exhaustion defers Gnosis while Base still uses CDP', async () => {
   const originalFetch = global.fetch;
   const originals = {
     acquireRunLock: EvmAudit.acquireRunLock,
@@ -412,6 +417,7 @@ test('Moralis discovery quota exhaustion runs configured explorer fallbacks with
     claim: EvmAudit.claim,
     findById: EvmAudit.findById,
     heartbeat: EvmAudit.heartbeat,
+    credentialGenerations: EvmAudit.credentialGenerations,
     credentialGeneration: EvmAudit.credentialGeneration,
     setDiscoveredChains: EvmAudit.setDiscoveredChains,
     recordProviderAttempt: EvmAudit.recordProviderAttempt,
@@ -432,8 +438,11 @@ test('Moralis discovery quota exhaustion runs configured explorer fallbacks with
     id: 44, user_id: 1, subject_id: 9, requested_wallet_id: 3,
     address: WALLET, requested_chains: [100, 8453, 324], mode: 'full',
     credential_generation: null,
+    moralis_credential_generation: null,
+    cdp_credential_generation: null,
   });
   EvmAudit.heartbeat = async () => ({ id: 44 });
+  EvmAudit.credentialGenerations = async () => ({ moralis: null, cdp: null });
   EvmAudit.credentialGeneration = async () => null;
   EvmAudit.setDiscoveredChains = async (_jobId, _owner, chainsFound) => chainsFound;
   EvmAudit.recordProviderAttempt = async () => {};
@@ -441,17 +450,23 @@ test('Moralis discovery quota exhaustion runs configured explorer fallbacks with
     finished = { status, options };
     return finished;
   };
-  SecretsService.getUserKey = async (_userId, service) => service === 'moralis' ? 'test-key' : null;
+  SecretsService.getUserKey = async (_userId, service) => (
+    service === 'moralis' ? 'moralis-key' : service === 'cdp' ? 'cdp-key' : null
+  );
   EvmAuditService.runChain = async (options) => {
-    captured.push({ chainId: options.chainId, moralis: Boolean(options.moralis) });
+    captured.push({
+      chainId: options.chainId,
+      moralis: Boolean(options.moralis),
+      cdp: options.chainId === 8453 && Boolean(options.cdp),
+    });
     return { gaps: 0 };
   };
   try {
     await EvmAuditService.run(44);
     assert.deepEqual(captured, [
-      { chainId: 100, moralis: false },
-      { chainId: 8453, moralis: false },
-      { chainId: 324, moralis: false },
+      { chainId: 100, moralis: false, cdp: false },
+      { chainId: 8453, moralis: false, cdp: true },
+      { chainId: 324, moralis: false, cdp: false },
     ]);
     assert.equal(finished.status, 'deferred');
     assert.equal(finished.options.errorCode, 'MORALIS_QUOTA_EXHAUSTED');
@@ -462,6 +477,7 @@ test('Moralis discovery quota exhaustion runs configured explorer fallbacks with
     EvmAudit.claim = originals.claim;
     EvmAudit.findById = originals.findById;
     EvmAudit.heartbeat = originals.heartbeat;
+    EvmAudit.credentialGenerations = originals.credentialGenerations;
     EvmAudit.credentialGeneration = originals.credentialGeneration;
     EvmAudit.setDiscoveredChains = originals.setDiscoveredChains;
     EvmAudit.recordProviderAttempt = originals.recordProviderAttempt;
@@ -525,7 +541,7 @@ test('Moralis history scope is finalized after transaction lookup pages', () => 
   const lookupPass = source.indexOf('for (const hash of moralisLookupHashes)');
   const canonicalization = source.indexOf("await EvmAudit.heartbeat(job.id, OWNER, { stage: 'canonicalizing' });", lookupPass);
   const finalization = source.indexOf(
-    "await EvmAudit.completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });",
+    "await completeScope(historyScope.id, { status: 'complete', paginationExhausted: true });",
     lookupPass
   );
   assert.ok(lookupPass >= 0);
@@ -542,6 +558,9 @@ test('deferred audits can be reopened after a credential generation change', () 
   assert.match(source, /etherscanCredentialReady/);
   assert.match(source, /SET status = 'queued'/);
   assert.match(source, /credential_generation = \$2/);
+  assert.match(source, /moralis_credential_generation = \$3/);
+  assert.match(source, /cdp_credential_generation = \$4/);
+  assert.match(source, /deferredProviderGenerationChanged/);
   assert.match(source, /credentialChanged/);
   assert.match(source, /retry_after_at = NULL/);
   assert.match(source, /error_code = NULL/);
@@ -627,17 +646,32 @@ test('audit claims cannot bypass a deferred retry deadline', () => {
 
 test('consensus RPC requires matching receipt identity and canonical block membership', async () => {
   const rpc = new RpcClient(8453, { spacingMs: 0 });
-  rpc.request = async (method) => ({
-    eth_getTransactionByHash: { hash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH },
-    eth_getTransactionReceipt: { transactionHash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH },
-    eth_getBlockByNumber: { number: '0xa', hash: BLOCK_HASH },
-  })[method];
+  rpc.requestWithEvidence = async (method, params) => {
+    const result = {
+      eth_getTransactionByHash: { hash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH },
+      eth_getTransactionReceipt: { transactionHash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH },
+      eth_getBlockByNumber: { number: '0xa', hash: BLOCK_HASH },
+    }[method];
+    const rawText = JSON.stringify({ jsonrpc: '2.0', id: 1, result });
+    return {
+      result, rawText, responseJson: JSON.parse(rawText), responseSha256: normalizer.sha256(rawText),
+      requestId: null, method, params,
+    };
+  };
   const result = await rpc.transactionAndReceipt(HASH);
   assert.equal(result.block.hash, BLOCK_HASH);
-  rpc.request = async (method) => ({
-    eth_getTransactionByHash: { hash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH },
-    eth_getTransactionReceipt: { transactionHash: `0x${'ef'.repeat(32)}`, blockNumber: '0xa', blockHash: BLOCK_HASH },
-  })[method];
+  assert.equal(result.evidence.length, 3);
+  rpc.requestWithEvidence = async (method, params) => {
+    const result = {
+      eth_getTransactionByHash: { hash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH },
+      eth_getTransactionReceipt: { transactionHash: `0x${'ef'.repeat(32)}`, blockNumber: '0xa', blockHash: BLOCK_HASH },
+    }[method];
+    const rawText = JSON.stringify({ jsonrpc: '2.0', id: 1, result });
+    return {
+      result, rawText, responseJson: JSON.parse(rawText), responseSha256: normalizer.sha256(rawText),
+      requestId: null, method, params,
+    };
+  };
   await assert.rejects(rpc.transactionAndReceipt(HASH), (error) => error.code === 'RPC_IDENTITY_MISMATCH');
 });
 

--- a/backend/tests/keys.test.js
+++ b/backend/tests/keys.test.js
@@ -46,6 +46,7 @@ beforeEach(() => {
   delete process.env.PLAID_CLIENT_ID;
   delete process.env.PLAID_SECRET;
   delete process.env.MORALIS_API_KEY;
+  delete process.env.CDP_API_KEY;
   process.env.DEV_AUTH_USER_ID = '1';
 });
 
@@ -95,6 +96,7 @@ test('GET reports statuses without ever returning plaintext', async () => {
   assert.deepEqual(response.body.userKeys.etherscan, { source: 'env', masked: null });
   assert.deepEqual(response.body.userKeys.plaid_client_id, { source: 'none', masked: null });
   assert.deepEqual(response.body.userKeys.moralis, { source: 'none', masked: null });
+  assert.deepEqual(response.body.userKeys.cdp, { source: 'none', masked: null });
   assert.deepEqual(response.body.appSettings.cg_api_key, { source: 'none', masked: null });
   assert.ok(!JSON.stringify(response.body).includes('env-super-secret'));
 });
@@ -152,6 +154,25 @@ test('PUT stores Moralis as a user-scoped encrypted service', async () => {
   assert.equal(insert.params[0], 1);
   assert.equal(insert.params[1], 'moralis');
   assert.ok(!insert.params[2].includes('moralis-abcd'));
+});
+
+test('PUT stores CDP separately from the Coinbase exchange credential', async () => {
+  queryHandler = async (text) => (
+    text.startsWith('SELECT encrypted_value, last4')
+      ? { rows: [{ encrypted_value: secretCrypto.encrypt('cdp-abcd'), last4: 'abcd' }] }
+      : { rows: [] }
+  );
+
+  const response = await request(app)
+    .put('/api/keys/cdp')
+    .send({ value: 'cdp-abcd' })
+    .set('Content-Type', 'application/json');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.masked, '••••abcd');
+  const insert = queries.find((q) => q.text.includes('INSERT INTO user_api_keys'));
+  assert.deepEqual(insert.params.slice(0, 2), [1, 'cdp']);
+  assert.ok(!insert.params[2].includes('cdp-abcd'));
 });
 
 test('Moralis status and mutations stay scoped to the authenticated user', async () => {

--- a/backend/tests/secrets.test.js
+++ b/backend/tests/secrets.test.js
@@ -38,6 +38,7 @@ beforeEach(() => {
   process.env.SECRETS_ENCRYPTION_KEY = TEST_KEY;
   delete process.env.ETHERSCAN_API_KEY;
   delete process.env.CG_API_KEY;
+  delete process.env.CDP_API_KEY;
 });
 
 test('encrypt/decrypt roundtrip', () => {
@@ -98,6 +99,19 @@ test('Moralis is a per-user encrypted key with no shared env fallback', async ()
   assert.equal(insert.params[1], 'moralis');
   assert.ok(!insert.params[2].includes('user-two-moralis-key'));
   delete process.env.MORALIS_API_KEY;
+});
+
+test('CDP is a separate per-user encrypted key with no shared env fallback', async () => {
+  process.env.CDP_API_KEY = 'must-not-be-used';
+  assert.ok(SecretsService.USER_SERVICES.includes('cdp'));
+  assert.equal(await SecretsService.getUserKey(1, 'cdp'), null);
+
+  await SecretsService.setUserKey(2, 'cdp', 'user-two-cdp-key');
+  const insert = queries.find((q) => q.text.includes('INSERT INTO user_api_keys'));
+  assert.equal(insert.params[0], 2);
+  assert.equal(insert.params[1], 'cdp');
+  assert.ok(!insert.params[2].includes('user-two-cdp-key'));
+  delete process.env.CDP_API_KEY;
 });
 
 test('reads skip the DB entirely when encryption is unconfigured', async () => {

--- a/frontend/src/components/crypto/WalletsPanel.jsx
+++ b/frontend/src/components/crypto/WalletsPanel.jsx
@@ -16,6 +16,15 @@ const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 // after a provider cooldown or a newly entered credential.
 const auditIsPending = (audit) => ['queued', 'running'].includes(audit?.status);
 
+const auditDeferredMessage = (job) => {
+  const detail = String(job?.error_detail || '').trim();
+  const retryAt = job?.retry_after_at ? new Date(job.retry_after_at) : null;
+  const retryText = retryAt && Number.isFinite(retryAt.getTime())
+    ? ` Retry after ${retryAt.toLocaleString()}.`
+    : '';
+  return `Audit deferred${detail ? `: ${detail}` : '; its provider retry schedule remains in effect.'}${retryText}`;
+};
+
 // Addresses render inside fallback chains and sentences composed here, so a
 // missing value must contribute nothing rather than 'unknown'.
 const shortEthAddress = (address) => shortEthAddressOrUnknown(address, '');
@@ -539,7 +548,7 @@ function WalletsPanel({ wallets, onChanged, onError, showSuccess, showNotice = s
       const { job } = await ethAPI.startHistoryAudit(wallet.id, { mode });
       setAuditByWallet((current) => ({ ...current, [wallet.id]: job }));
       if (job.status === 'deferred') {
-        showNotice('This audit is still deferred; its provider retry schedule remains in effect.');
+        showNotice(auditDeferredMessage(job));
       } else {
         showNotice(mode === 'full'
           ? 'Full history audit queued. You can leave this page; progress and evidence are saved.'

--- a/frontend/src/pages/CryptoWallets.test.jsx
+++ b/frontend/src/pages/CryptoWallets.test.jsx
@@ -431,6 +431,27 @@ describe('Crypto -> Wallets tab', () => {
     expect(await screen.findByText(/History audit: queued/i)).toBeInTheDocument();
   });
 
+  it('surfaces the persisted reason when an audit remains deferred', async () => {
+    apiMocks.eth.startHistoryAudit.mockResolvedValue({
+      created: false,
+      job: {
+        id: '43',
+        requested_wallet_id: 1,
+        status: 'deferred',
+        stage: 'discovering',
+        error_detail: 'Moralis daily plan quota is exhausted; audit deferred',
+        retry_after_at: '2026-08-09T11:00:00.000Z',
+        progress: {},
+      },
+    });
+    await openEthereumTab([wallet(report())]);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /audit mined history for main/i }))[0]);
+
+    expect(await screen.findByText(/Moralis daily plan quota is exhausted/i)).toBeInTheDocument();
+    expect(screen.getByText(/Retry after/)).toBeInTheDocument();
+  });
+
   it('offers an incremental verification run for idempotency checks', async () => {
     apiMocks.eth.startHistoryAudit.mockResolvedValue({
       created: true,

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -67,13 +67,14 @@ const jobRunPresentation = (name, lastRun) => {
   };
 };
 
-// Rows on the API Keys tab. Plaid/Etherscan/Moralis pull the signed-in user's
+// Rows on the API Keys tab. Plaid/Etherscan/Moralis/CDP pull the signed-in user's
 // own financial data; the price keys are shared app-wide (prices are global).
 const USER_KEY_ROWS = [
   { service: 'plaid_client_id', label: 'Plaid Client ID' },
   { service: 'plaid_secret', label: 'Plaid Secret' },
   { service: 'etherscan', label: 'Etherscan API Key' },
   { service: 'moralis', label: 'Moralis API Key' },
+  { service: 'cdp', label: 'Coinbase CDP Client API Key' },
 ];
 const APP_KEY_ROWS = [
   { service: 'cg_api_key', label: 'CoinGecko API Key' },
@@ -1084,7 +1085,7 @@ const Settings = ({ user }) => {
           <AlertTriangle size={16} className="mt-0.5 shrink-0" />
           <span>
             The server is missing SECRETS_ENCRYPTION_KEY, so keys cannot be stored here yet.
-            Integrations with configured server defaults can keep using them, but Moralis audits require an encrypted per-user key.
+            Integrations with configured server defaults can keep using them, but Moralis and Coinbase CDP audits require encrypted per-user keys.
           </span>
         </div>
       )}
@@ -1097,7 +1098,7 @@ const Settings = ({ user }) => {
       <section className="mb-8">
         <div className="mb-3 px-2">
           <h2 className="text-lg font-bold uppercase tracking-tight text-primary">Your Keys</h2>
-          <p className="mt-1 text-xs text-secondary">Credentials for pulling your own financial data. Stored encrypted; only the last four characters are ever shown. Plaid and Etherscan may use configured server defaults; Moralis requires a stored per-user key.</p>
+          <p className="mt-1 text-xs text-secondary">Credentials for pulling your own financial data. Stored encrypted; only the last four characters are ever shown. Plaid and Etherscan may use configured server defaults; Moralis and Coinbase CDP require separate stored per-user keys. The CDP key is not your Coinbase exchange key.</p>
         </div>
         <div className="card divide-y divide-border overflow-hidden">
           {USER_KEY_ROWS.map(({ service, label }) => {

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -113,6 +113,7 @@ describe('Settings display names', () => {
         plaid_secret: { source: 'none', masked: null },
         etherscan: { source: 'none', masked: null },
         moralis: { source: 'none', masked: null },
+        cdp: { source: 'none', masked: null },
       },
       appSettings: {
         cg_api_key: { source: 'none', masked: null },
@@ -173,6 +174,7 @@ describe('Settings display names', () => {
         plaid_secret: { source: 'env', masked: null },
         etherscan: { source: 'db', masked: '••••1234' },
         moralis: { source: 'none', masked: null },
+        cdp: { source: 'none', masked: null },
       },
       appSettings: {
         cg_api_key: { source: 'none', masked: null },
@@ -185,7 +187,8 @@ describe('Settings display names', () => {
 
     await screen.findByText('Your Keys');
     expect(screen.getByText('Moralis API Key')).toBeInTheDocument();
-    expect(screen.getByText(/Moralis requires a stored per-user key/)).toBeInTheDocument();
+    expect(screen.getByText('Coinbase CDP Client API Key')).toBeInTheDocument();
+    expect(screen.getByText(/Moralis and Coinbase CDP require separate stored per-user keys/)).toBeInTheDocument();
     expect(screen.getByText('••••1234')).toBeInTheDocument();
     expect(screen.getByText('Using server default')).toBeInTheDocument();
     // Only the stored (db) key row offers Clear.
@@ -217,6 +220,7 @@ describe('Settings display names', () => {
         plaid_secret: { source: 'env', masked: null },
         etherscan: { source: 'none', masked: null },
         moralis: { source: 'none', masked: null },
+        cdp: { source: 'none', masked: null },
       },
       appSettings: {
         cg_api_key: { source: 'none', masked: null },
@@ -268,6 +272,7 @@ describe('Settings display names', () => {
         plaid_secret: { source: 'none', masked: null },
         etherscan: { source: 'none', masked: null },
         moralis: { source: 'none', masked: null },
+        cdp: { source: 'none', masked: null },
       },
       appSettings: {
         cg_api_key: { source: 'db', masked: '••••7777' },


### PR DESCRIPTION
## What changed

- Add a separately encrypted per-user Coinbase CDP key in Settings; it is never reused for Coinbase exchange sync and is never exposed in logs or API responses.
- Use CDP address history as the sole Base (8453) provider for ordinary wallet Sync and full EVM audits.
- Retain raw paginated CDP pages with opaque cursor checkpoints, restart/idempotency handling, overlap/reorg-safe boundaries, conflict detection, lease fencing, and durable complete/running/deferred/failed status.
- Normalize mined transactions, failed and zero-value calls, gas, internal traces, ERC-20, ERC-721, ERC-1155, receipt/native bridge evidence, nonce checks, and balance evidence.
- Use consensus RPC for authoritative Base finalization, transaction/receipt, nonce, native-balance, and token-balance checks.
- Remove Moralis Base routing and the anonymous chain-wide Base Blockscout bridge walk from critical paths; preserve Blockscout only for future keyed, transaction-scoped repair.
- Add finite coverage/status semantics and update the Settings UI.

## Validation

- Backend: 1,123 tests passed, lint passed, verify:ledger passed all 92 checks.
- Frontend: 211 tests passed, lint passed with the repository's existing 12 warnings and no errors, production build passed.
- CDP provider, EVM audit, multi-chain, pagination, restart, conflict, failed/zero-value, trace/token standards, bridge, nonce, reconciliation, partial-failure, and key-isolation regressions are covered.
- Migration 079 was validated through the ledger/migration gate.

Production canary/full-history and incremental/idempotency audits remain deployment verification steps because they require the user's configured CDP key and live provider data.