### PR TITLE
fix: preserve EVM audit provider ordering

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -485,6 +485,12 @@ class EvmAudit {
     throughBlock = null, throughHash = null, cursor = null,
     providerOrder = null, coverageBasis = null, errorCode = null, errorDetail = null,
   }, fence = {}) {
+    // Migration 079 made provider_order NOT NULL so every persisted scope has
+    // an explicit ordering state. Initial scopes, unsupported scopes, and
+    // incremental scopes without prior coverage legitimately do not know the
+    // provider order yet; the INSERT turns that null into `unknown`. Keep the
+    // original parameter for the conflict arm so a restart cannot overwrite
+    // an already-proven direction with `unknown`.
     const transactional = Boolean(fence.jobId && fence.owner);
     const client = transactional ? await pool.connect() : pool;
     try {
@@ -502,7 +508,7 @@ class EvmAudit {
          job_id, chain_id, provider, capability, status,
          requested_from_block, requested_through_block, requested_through_hash,
          provider_cursor, provider_order, coverage_basis, error_code, error_detail
-       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,COALESCE($10, 'unknown'),$11,$12,$13)
        ON CONFLICT (job_id, chain_id, provider, capability)
        DO UPDATE SET
          status = EXCLUDED.status,
@@ -510,7 +516,8 @@ class EvmAudit {
          requested_through_block = COALESCE(EXCLUDED.requested_through_block, evm_audit_scopes.requested_through_block),
          requested_through_hash = COALESCE(EXCLUDED.requested_through_hash, evm_audit_scopes.requested_through_hash),
          provider_cursor = COALESCE(EXCLUDED.provider_cursor, evm_audit_scopes.provider_cursor),
-         provider_order = COALESCE(EXCLUDED.provider_order, evm_audit_scopes.provider_order),
+         provider_order = CASE WHEN $10 IS NULL
+           THEN evm_audit_scopes.provider_order ELSE EXCLUDED.provider_order END,
          coverage_basis = COALESCE(EXCLUDED.coverage_basis, evm_audit_scopes.coverage_basis),
          error_code = EXCLUDED.error_code,
          error_detail = EXCLUDED.error_detail,
@@ -813,6 +820,9 @@ class EvmAudit {
     paginationExhausted, status, jobId,
     owner = null,
   }) {
+    // Keep null as "no new ordering observation" for an existing coverage
+    // row, while the INSERT expression below satisfies migration 079's
+    // NOT NULL constraint for a first observation.
     const transactional = Boolean(owner);
     const client = transactional ? await pool.connect() : pool;
     try {
@@ -824,13 +834,14 @@ class EvmAudit {
       `INSERT INTO evm_source_coverage (
          subject_id, chain_id, provider, capability, from_block, through_block,
          through_block_hash, provider_order, coverage_basis, pagination_exhausted, status, source_job_id
-       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8, 'unknown'),$9,$10,$11,$12)
        ON CONFLICT (
          subject_id, chain_id, provider, capability,
          from_block, through_block, source_job_id
        ) DO UPDATE SET
          through_block_hash = EXCLUDED.through_block_hash,
-         provider_order = EXCLUDED.provider_order,
+         provider_order = CASE WHEN $8 IS NULL
+           THEN evm_source_coverage.provider_order ELSE EXCLUDED.provider_order END,
          coverage_basis = EXCLUDED.coverage_basis,
          pagination_exhausted = EXCLUDED.pagination_exhausted,
          status = EXCLUDED.status,

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -121,6 +121,60 @@ test('finishing an audit casts the status parameter consistently for PostgreSQL'
   }
 });
 
+test('new audit scopes persist unknown provider order instead of SQL NULL', async () => {
+  const originalQuery = database.query;
+  let sql;
+  let params;
+  database.query = async (query, queryParams) => {
+    sql = query;
+    params = queryParams;
+    return { rows: [{ id: 1, provider_order: 'unknown' }] };
+  };
+  try {
+    await EvmAudit.upsertScope(1, {
+      chainId: 8453,
+      provider: 'coinbase-cdp',
+      capability: 'active_chain',
+      providerOrder: null,
+    });
+    assert.equal(params[9], null);
+    assert.match(sql, /COALESCE\(\$10, 'unknown'\)/);
+    assert.match(sql, /CASE WHEN \$10 IS NULL/);
+  } finally {
+    database.query = originalQuery;
+  }
+});
+
+test('source coverage persists unknown provider order without erasing known order', async () => {
+  const originalQuery = database.query;
+  let sql;
+  let params;
+  database.query = async (query, queryParams) => {
+    sql = query;
+    params = queryParams;
+    return { rows: [{ id: 1, provider_order: 'unknown' }] };
+  };
+  try {
+    await EvmAudit.acceptCoverage({
+      subjectId: 3,
+      chainId: 8453,
+      provider: 'coinbase-cdp',
+      capability: 'wallet_history',
+      fromBlock: 0,
+      throughBlock: 1,
+      providerOrder: null,
+      paginationExhausted: true,
+      status: 'complete',
+      jobId: 1,
+    });
+    assert.equal(params[7], null);
+    assert.match(sql, /COALESCE\(\$8, 'unknown'\)/);
+    assert.match(sql, /CASE WHEN \$8 IS NULL/);
+  } finally {
+    database.query = originalQuery;
+  }
+});
+
 test('identity repair keeps its canonical-effect query user-scoped', () => {
   const source = fs.readFileSync(path.join(__dirname, '../src/models/EvmAudit.js'), 'utf8');
   const methodStart = source.indexOf('static async repairCorroboratedTransferIdentities');


### PR DESCRIPTION
## Summary

- fix production EVM audit scope creation after migration 079 made provider_order NOT NULL
- persist unknown ordering for new scopes while preserving a known ordering across retries and restarts
- apply the same null-safe behavior to durable source coverage
- add regression tests for both persistence paths

## Root cause

The deployed audit worker passed an explicit SQL NULL for provider_order. PostgreSQL rejected the first scope insert before any provider history was fetched.

## Validation

- focused EVM audit suite: 43 passed
- backend lint: passed
- independent architecture and bug reviews: addressed