### PR TITLE
fix: isolate missing RPC audit chains

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -138,7 +138,7 @@ class EvmAudit {
   static async createOrFindActiveJob(userId, wallet, {
     mode = 'incremental', requestedChains = [], credentialGeneration = null,
     credentialGenerations = null,
-    etherscanConfigured = false, cdpConfigured = false,
+    etherscanConfigured = false, cdpConfigured = false, rpcConfigurationReady = false,
   } = {}) {
     const providerGenerations = credentialGenerations || {
       moralis: credentialGeneration,
@@ -179,6 +179,8 @@ class EvmAudit {
         const etherscanCredentialReady = errorCode === 'ETHERSCAN_NOT_CONFIGURED'
           && etherscanConfigured;
         const cdpCredentialReady = errorCode === 'CDP_NOT_CONFIGURED' && cdpConfigured;
+        const rpcConfigurationReadyNow = errorCode === 'RPC_UNSUPPORTED'
+          && rpcConfigurationReady;
         const deferredProviderGeneration = deferredProvider
           ? providerGenerations[deferredProvider] : null;
         const deferredProviderGenerationColumn = deferredProvider
@@ -199,7 +201,7 @@ class EvmAudit {
               || new Date(priorProviderGeneration).getTime()
                 !== new Date(deferredProviderGeneration).getTime());
         const credentialChanged = etherscanCredentialReady || cdpCredentialReady
-          || deferredProviderGenerationChanged;
+          || deferredProviderGenerationChanged || rpcConfigurationReadyNow;
         if (activeJob.status === 'deferred' && credentialChanged) {
           const refreshed = await client.query(
             `UPDATE evm_audit_jobs

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -351,6 +351,9 @@ class EvmAuditService {
     // reopened without exposing either secret.
     const etherscanConfigured = Boolean(await SecretsService.getUserKey(userId, 'etherscan'));
     const cdpConfigured = Boolean(await SecretsService.getUserKey(userId, 'cdp'));
+    const rpcConfigurationReady = selected
+      .filter((chainId) => !AUDIT_CHAINS.get(chainId).unsupported)
+      .every((chainId) => Boolean(chains.getChain(chainId)?.rpcUrl));
     const result = await EvmAudit.createOrFindActiveJob(userId, wallet, {
       mode,
       requestedChains: [...new Set(selected)],
@@ -358,6 +361,7 @@ class EvmAuditService {
       credentialGenerations,
       etherscanConfigured,
       cdpConfigured,
+      rpcConfigurationReady,
     });
     if (result.job.status !== 'deferred') this.enqueue(result.job.id);
     return result;
@@ -494,9 +498,13 @@ class EvmAuditService {
       if (moralis) {
         await EvmAudit.heartbeat(jobId, OWNER, { stage: 'discovering' });
         try {
-          activeResponse = await moralis.activeChains(
-            job.address, moralisRequested.map((id) => AUDIT_CHAINS.get(id).moralis)
-          );
+          const discoverableMoralisChains = moralisRequested
+            .filter((chainId) => Boolean(chains.getChain(chainId)?.rpcUrl));
+          activeResponse = discoverableMoralisChains.length
+            ? await moralis.activeChains(
+              job.address, discoverableMoralisChains.map((id) => AUDIT_CHAINS.get(id).moralis)
+            )
+            : { body: { active_chains: [] } };
           assertLease(leaseState);
           activeRows = Array.isArray(activeResponse.body.active_chains)
             ? activeResponse.body.active_chains : [];
@@ -515,6 +523,14 @@ class EvmAuditService {
           return {
             chain_id: chainId, active_hint: false, bounded: false,
             status: 'unsupported', error_code: config.errorCode, error_detail: config.errorDetail,
+          };
+        }
+        if (!chains.getChain(chainId)?.rpcUrl) {
+          return {
+            chain_id: chainId, active_hint: null, bounded: false,
+            status: 'deferred', source: 'consensus-rpc',
+            error_code: 'RPC_UNSUPPORTED',
+            error_detail: 'Configure a consensus RPC for this chain to complete its mined-history audit.',
           };
         }
         if (config.moralis && moralisUnavailable) {
@@ -572,6 +588,22 @@ class EvmAuditService {
       const unavailable = [];
       for (const chainId of requested.filter((id) => !unsupportedRequested.includes(id))) {
         const config = AUDIT_CHAINS.get(chainId);
+        if (!chains.getChain(chainId)?.rpcUrl) {
+          // Every runnable history provider still needs consensus RPC for
+          // finalized boundaries, mined receipt/nonce checks, and balance
+          // reconciliation. Defer only this chain when its RPC is absent so
+          // an unrelated configuration gap cannot prevent CDP Base history
+          // from being audited.
+          unavailable.push({
+            chainId,
+            provider: 'consensus-rpc',
+            error: {
+              code: 'RPC_UNSUPPORTED',
+              detail: 'Configure a consensus RPC for this chain to complete its mined-history audit.',
+            },
+          });
+          continue;
+        }
         if (config.moralis && moralis) {
           runnable.push(chainId);
           continue;
@@ -624,19 +656,19 @@ class EvmAuditService {
       }
       const deferred = providerDeferred;
       return EvmAudit.finish(jobId, OWNER,
-        deferred ? 'deferred' : failed ? 'failed' : (gaps ? 'complete_with_gaps' : 'complete'), {
-        errorCode: deferredProviderError?.code || failedProviderError?.code
+        failed ? 'failed' : deferred ? 'deferred' : (gaps ? 'complete_with_gaps' : 'complete'), {
+        errorCode: failedProviderError?.code || deferredProviderError?.code
           || unavailable[0]?.error?.code || null,
-        errorDetail: deferredProviderError?.detail || failedProviderError?.detail
+        errorDetail: failedProviderError?.detail || deferredProviderError?.detail
           || unavailable[0]?.error?.detail || null,
         retryAt: deferred ? (deferredProviderError?.retryAt || new Date(Date.now() + 24 * 60 * 60 * 1000)) : null,
-        progress: { chains_finished: runnable.length + unsupportedRequested.length, gaps },
+        progress: { chains_finished: runnable.length + unavailable.length + unsupportedRequested.length, gaps },
       });
     } catch (error) {
       const deferred = [
         'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
         'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR', 'CDP_NOT_CONFIGURED',
-        'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED',
+        'RPC_UNSUPPORTED', 'RPC_FINALITY_UNAVAILABLE', 'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED',
         'BLOCKSCOUT_TRANSPORT_ERROR', 'ETHERSCAN_RATE_LIMITED',
         'ETHERSCAN_TRANSPORT_ERROR',
       ]

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -77,6 +77,16 @@ test('Moralis quota fallback remains visibly deferred and never marks discovery 
   assert.match(source, /let providerDeferred = Boolean\(moralisUnavailable \|\| cdpUnavailable \|\| unavailable\.length\)/);
 });
 
+test('a chain without consensus RPC is deferred without blocking other audit chains', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8');
+  const guard = source.indexOf("provider: 'consensus-rpc'");
+  const runnable = source.indexOf('runnable.push(chainId)', guard);
+  assert.ok(guard >= 0);
+  assert.ok(runnable > guard);
+  assert.match(source.slice(guard - 500, runnable + 80), /code: 'RPC_UNSUPPORTED'/);
+  assert.match(source.slice(guard - 500, runnable + 80), /continue;/);
+});
+
 test('unsupported audit chains become explicit amber scopes without a provider request', async () => {
   const originalUpsertScope = EvmAudit.upsertScope;
   const scopes = [];


### PR DESCRIPTION
## Summary

- defer chains without a configured consensus RPC as explicit RPC_UNSUPPORTED scopes
- let Base/CDP continue instead of aborting the entire multi-chain audit
- avoid Moralis discovery for chains that cannot pass consensus checks
- preserve discovered-chain status and accurate finished-chain progress
- prevent deferred-chain limitations from masking a real runnable-chain failure
- reopen deferred audits when RPC configuration becomes available

## Validation

- focused EVM audit suite: 44 passed
- backend lint: passed
- independent architecture and bug reviews: addressed