### PR TITLE
fix(eth): isolate audit capability gaps by chain

### DIFF
--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -781,6 +781,42 @@ class EvmAudit {
     }
   }
 
+  static async deferOpenScopes(jobId, chainId, {
+    errorCode = 'AUDIT_PROVIDER_UNAVAILABLE',
+    errorDetail = 'The provider did not complete this chain scope.',
+  }, fence = {}) {
+    const transactional = Boolean(fence.jobId && fence.owner);
+    const client = transactional ? await pool.connect() : pool;
+    try {
+      if (transactional) {
+        await client.query('BEGIN');
+        if (Number(fence.jobId) !== Number(jobId)) {
+          const error = new Error('EVM audit scope fence does not match its job');
+          error.code = 'EVM_AUDIT_LEASE_LOST';
+          throw error;
+        }
+        await assertActiveLease(client, fence.jobId, fence.owner);
+      }
+      const { rowCount } = await client.query(
+        `UPDATE evm_audit_scopes
+            SET status = 'deferred',
+                pagination_exhausted = FALSE,
+                error_code = $3,
+                error_detail = $4,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE job_id = $1 AND chain_id = $2 AND status IN ('queued', 'running')`,
+        [jobId, chainId, errorCode, errorDetail]
+      );
+      if (transactional) await client.query('COMMIT');
+      return rowCount;
+    } catch (error) {
+      if (transactional) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      if (transactional) client.release();
+    }
+  }
+
   static async recordProviderAttempt(row) {
     const transactional = Boolean(row.owner);
     const client = transactional ? await pool.connect() : pool;

--- a/backend/src/models/EvmAudit.js
+++ b/backend/src/models/EvmAudit.js
@@ -784,6 +784,9 @@ class EvmAudit {
   static async deferOpenScopes(jobId, chainId, {
     errorCode = 'AUDIT_PROVIDER_UNAVAILABLE',
     errorDetail = 'The provider did not complete this chain scope.',
+    provider = 'consensus-rpc',
+    scopeStatus = 'deferred',
+    capabilities = [],
   }, fence = {}) {
     const transactional = Boolean(fence.jobId && fence.owner);
     const client = transactional ? await pool.connect() : pool;
@@ -799,14 +802,26 @@ class EvmAudit {
       }
       const { rowCount } = await client.query(
         `UPDATE evm_audit_scopes
-            SET status = 'deferred',
+            SET status = $5,
                 pagination_exhausted = FALSE,
                 error_code = $3,
                 error_detail = $4,
                 updated_at = CURRENT_TIMESTAMP
           WHERE job_id = $1 AND chain_id = $2 AND status IN ('queued', 'running')`,
-        [jobId, chainId, errorCode, errorDetail]
+        [jobId, chainId, errorCode, errorDetail, scopeStatus]
       );
+      if (capabilities.length) {
+        await client.query(
+          `INSERT INTO evm_audit_scopes (
+             job_id, chain_id, provider, capability, status,
+             provider_order, error_code, error_detail
+           )
+           SELECT $1, $2, $3, capability, $4, 'unknown', $5, $6
+             FROM unnest($7::varchar[]) AS requested(capability)
+           ON CONFLICT (job_id, chain_id, provider, capability) DO NOTHING`,
+          [jobId, chainId, provider, scopeStatus, errorCode, errorDetail, capabilities]
+        );
+      }
       if (transactional) await client.query('COMMIT');
       return rowCount;
     } catch (error) {

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -324,6 +324,13 @@ function isStandingExplorerLimitation(error) {
   return ['ETHERSCAN_FEED_UNSUPPORTED', 'ETHERSCAN_CHAIN_UNAVAILABLE'].includes(error?.code);
 }
 
+function isStandingProviderLimitation(error) {
+  return [
+    'BLOCKSCOUT_FEED_UNSUPPORTED', 'BLOCKSCOUT_CHAIN_UNAVAILABLE',
+    'ETHERSCAN_FEED_UNSUPPORTED', 'ETHERSCAN_CHAIN_UNAVAILABLE',
+  ].includes(error?.code);
+}
+
 function assertLease(leaseState) {
   if (!leaseState?.lost) return;
   const error = new Error('EVM audit lease ownership was lost; this worker stopped before further writes.');
@@ -642,6 +649,7 @@ class EvmAuditService {
       }
       let providerDeferred = Boolean(moralisUnavailable || cdpUnavailable || unavailable.length);
       let deferredProviderError = moralisUnavailable || cdpUnavailable;
+      let unsupportedProviderError = null;
       for (const chainId of runnable) {
         assertLease(leaseState);
         let result;
@@ -656,24 +664,26 @@ class EvmAuditService {
           // continue; the final job remains deferred/failed with the exact
           // chain-level reason so it cannot be mistaken for completion.
           assertLease(leaseState);
-          const deferred = isStandingExplorerLimitation(error)
-            || [
+          const standing = isStandingProviderLimitation(error);
+          const deferred = !standing && [
               'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
               'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR',
               'RPC_UNSUPPORTED', 'RPC_FINALITY_UNAVAILABLE', 'RPC_RATE_LIMITED',
               'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED', 'BLOCKSCOUT_TRANSPORT_ERROR',
-              'BLOCKSCOUT_FEED_UNSUPPORTED', 'BLOCKSCOUT_CHAIN_UNAVAILABLE',
               'ETHERSCAN_RATE_LIMITED', 'ETHERSCAN_TRANSPORT_ERROR',
             ].includes(error.code);
           const chainDetail = publicErrorDetail(error);
           await EvmAudit.deferOpenScopes(job.id, chainId, {
             errorCode: error.code || 'EVM_CHAIN_AUDIT_FAILED',
             errorDetail: chainDetail,
+            provider: AUDIT_CHAINS.get(chainId).auditProvider || 'consensus-rpc',
+            scopeStatus: standing ? 'unsupported' : deferred ? 'deferred' : 'failed',
+            capabilities: AUDIT_CAPABILITIES,
           }, { jobId: job.id, owner: OWNER });
           const discoveredChain = discovered.find((row) => row.chain_id === chainId);
           if (discoveredChain) {
             discoveredChain.bounded = false;
-            discoveredChain.status = deferred ? 'deferred' : 'failed';
+            discoveredChain.status = standing ? 'unsupported' : deferred ? 'deferred' : 'failed';
             discoveredChain.error_code = error.code || 'EVM_CHAIN_AUDIT_FAILED';
             discoveredChain.error_detail = chainDetail;
             await EvmAudit.setDiscoveredChains(job.id, OWNER, discovered);
@@ -681,12 +691,16 @@ class EvmAuditService {
           result = {
             gaps: 1,
             deferred,
+            unsupported: standing,
             deferredProviderError: deferred ? {
               code: error.code || 'EVM_CHAIN_AUDIT_DEFERRED', detail: chainDetail,
               retryAt: error.retryAt || null,
             } : null,
-            failed: !deferred,
-            failedProviderError: deferred ? null : {
+            unsupportedProviderError: standing ? {
+              code: error.code || 'EVM_CHAIN_AUDIT_UNSUPPORTED', detail: chainDetail,
+            } : null,
+            failed: !deferred && !standing,
+            failedProviderError: deferred || standing ? null : {
               code: error.code || 'EVM_CHAIN_AUDIT_FAILED', detail: chainDetail,
             },
           };
@@ -696,6 +710,7 @@ class EvmAuditService {
           providerDeferred = true;
           deferredProviderError ||= result.deferredProviderError;
         }
+        if (result.unsupported) unsupportedProviderError ||= result.unsupportedProviderError;
         if (result.failed) {
           failed = true;
           failedProviderError ||= result.failedProviderError;
@@ -705,9 +720,9 @@ class EvmAuditService {
       return EvmAudit.finish(jobId, OWNER,
         failed ? 'failed' : deferred ? 'deferred' : (gaps ? 'complete_with_gaps' : 'complete'), {
         errorCode: failedProviderError?.code || deferredProviderError?.code
-          || unavailable[0]?.error?.code || null,
+          || unsupportedProviderError?.code || unavailable[0]?.error?.code || null,
         errorDetail: failedProviderError?.detail || deferredProviderError?.detail
-          || unavailable[0]?.error?.detail || null,
+          || unsupportedProviderError?.detail || unavailable[0]?.error?.detail || null,
         retryAt: deferred ? (deferredProviderError?.retryAt || new Date(Date.now() + 24 * 60 * 60 * 1000)) : null,
         progress: { chains_finished: runnable.length + unavailable.length + unsupportedRequested.length, gaps },
       });
@@ -880,13 +895,15 @@ class EvmAuditService {
         const name = explorerDisplayName(auditProvider);
         const wrapped = new Error(`${name} indexed boundary failed: ${publicErrorDetail(error)}`);
         wrapped.code = rateLimited ? `${prefix}_RATE_LIMITED`
-          : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_BOUNDARY_FAILED`;
+          : transient ? `${prefix}_TRANSPORT_ERROR`
+            : isStandingExplorerLimitation(error) ? `${prefix}_CHAIN_UNAVAILABLE`
+              : `${prefix}_BOUNDARY_FAILED`;
         wrapped.httpStatus = error.response?.status || error.httpStatus || null;
         wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
         await recordProviderAttempt({
           jobId: job.id, scopeId: activeScope.id, provider: auditProvider,
           endpoint: 'indexed-boundary', requestParams: { chain_id: chainId },
-          outcome: transient ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
+          outcome: transient || isStandingExplorerLimitation(error) ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
           errorCode: wrapped.code, errorDetail: publicErrorDetail(wrapped),
         });
         throw wrapped;
@@ -1161,7 +1178,7 @@ class EvmAuditService {
             jobId: job.id, scopeId: feedScope.id, provider: auditProvider,
             endpoint: `account-${feedSpec.feed}`,
             requestParams: { address: job.address, from_block: feedFromBlock, to_block: sourceThroughBlock },
-            outcome: transient ? 'deferred' : 'failed',
+            outcome: transient || isStandingExplorerLimitation(error) ? 'deferred' : 'failed',
             httpStatus: wrapped.httpStatus, errorCode: wrapped.code,
             errorDetail: publicErrorDetail(wrapped),
           });
@@ -1229,7 +1246,7 @@ class EvmAuditService {
             jobId: job.id, scopeId: nativeCreditScope.id, provider: auditProvider,
             endpoint: 'native-credit', requestParams: {
               address: job.address, from_block: 0, to_block: sourceThroughBlock,
-            }, outcome: transient ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
+            }, outcome: transient || isStandingExplorerLimitation(error) ? 'deferred' : 'failed', httpStatus: wrapped.httpStatus,
             errorCode: wrapped.code, errorDetail: publicErrorDetail(wrapped),
           });
           throw wrapped;

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -320,6 +320,10 @@ function explorerDisplayName(provider) {
   return provider === 'blockscout' ? 'Blockscout' : 'Etherscan';
 }
 
+function isStandingExplorerLimitation(error) {
+  return ['ETHERSCAN_FEED_UNSUPPORTED', 'ETHERSCAN_CHAIN_UNAVAILABLE'].includes(error?.code);
+}
+
 function assertLease(leaseState) {
   if (!leaseState?.lost) return;
   const error = new Error('EVM audit lease ownership was lost; this worker stopped before further writes.');
@@ -640,10 +644,53 @@ class EvmAuditService {
       let deferredProviderError = moralisUnavailable || cdpUnavailable;
       for (const chainId of runnable) {
         assertLease(leaseState);
-        const result = await this.runChain({
-          job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt,
-          explorerApiKey, moralisUnavailable, cdp, cdpUnavailable,
-        });
+        let result;
+        try {
+          result = await this.runChain({
+            job, chainId, moralis, activeResponse, discovered, leaseState, retainAttempt,
+            explorerApiKey, moralisUnavailable, cdp, cdpUnavailable,
+          });
+        } catch (error) {
+          // A capability gap on one chain must not prevent the remaining
+          // configured chains from running. Preserve the open scopes and
+          // continue; the final job remains deferred/failed with the exact
+          // chain-level reason so it cannot be mistaken for completion.
+          assertLease(leaseState);
+          const deferred = isStandingExplorerLimitation(error)
+            || [
+              'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
+              'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR',
+              'RPC_UNSUPPORTED', 'RPC_FINALITY_UNAVAILABLE', 'RPC_RATE_LIMITED',
+              'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED', 'BLOCKSCOUT_TRANSPORT_ERROR',
+              'BLOCKSCOUT_FEED_UNSUPPORTED', 'BLOCKSCOUT_CHAIN_UNAVAILABLE',
+              'ETHERSCAN_RATE_LIMITED', 'ETHERSCAN_TRANSPORT_ERROR',
+            ].includes(error.code);
+          const chainDetail = publicErrorDetail(error);
+          await EvmAudit.deferOpenScopes(job.id, chainId, {
+            errorCode: error.code || 'EVM_CHAIN_AUDIT_FAILED',
+            errorDetail: chainDetail,
+          }, { jobId: job.id, owner: OWNER });
+          const discoveredChain = discovered.find((row) => row.chain_id === chainId);
+          if (discoveredChain) {
+            discoveredChain.bounded = false;
+            discoveredChain.status = deferred ? 'deferred' : 'failed';
+            discoveredChain.error_code = error.code || 'EVM_CHAIN_AUDIT_FAILED';
+            discoveredChain.error_detail = chainDetail;
+            await EvmAudit.setDiscoveredChains(job.id, OWNER, discovered);
+          }
+          result = {
+            gaps: 1,
+            deferred,
+            deferredProviderError: deferred ? {
+              code: error.code || 'EVM_CHAIN_AUDIT_DEFERRED', detail: chainDetail,
+              retryAt: error.retryAt || null,
+            } : null,
+            failed: !deferred,
+            failedProviderError: deferred ? null : {
+              code: error.code || 'EVM_CHAIN_AUDIT_FAILED', detail: chainDetail,
+            },
+          };
+        }
         gaps += result.gaps;
         if (result.deferred) {
           providerDeferred = true;
@@ -1105,7 +1152,9 @@ class EvmAuditService {
           const name = explorerDisplayName(auditProvider);
           const wrapped = new Error(`${name} ${feedSpec.feed} audit feed failed: ${publicErrorDetail(error)}`);
           wrapped.code = rateLimited ? `${prefix}_RATE_LIMITED`
-            : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_FEED_FAILED`;
+            : transient ? `${prefix}_TRANSPORT_ERROR`
+              : isStandingExplorerLimitation(error) ? `${prefix}_FEED_UNSUPPORTED`
+                : `${prefix}_FEED_FAILED`;
           wrapped.httpStatus = error.response?.status || error.httpStatus || null;
           wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
           await recordProviderAttempt({
@@ -1171,7 +1220,9 @@ class EvmAuditService {
           const prefix = explorerFailurePrefix(auditProvider);
           const wrapped = new Error(`Explorer native-credit audit feed failed: ${publicErrorDetail(error)}`);
           wrapped.code = rateLimited ? `${prefix}_RATE_LIMITED`
-            : transient ? `${prefix}_TRANSPORT_ERROR` : `${prefix}_FEED_FAILED`;
+            : transient ? `${prefix}_TRANSPORT_ERROR`
+              : isStandingExplorerLimitation(error) ? `${prefix}_FEED_UNSUPPORTED`
+                : `${prefix}_FEED_FAILED`;
           wrapped.httpStatus = error.response?.status || error.httpStatus || null;
           wrapped.retryAt = transient ? new Date(Date.now() + (rateLimited ? 60 * 60 * 1000 : 60 * 1000)) : null;
           await recordProviderAttempt({
@@ -1686,3 +1737,4 @@ module.exports = EvmAuditService;
 module.exports._missingRanges = missingRanges;
 module.exports._unmatchedEffectCount = unmatchedEffectCount;
 module.exports._isBlockscoutTransient = isBlockscoutTransient;
+module.exports._isStandingExplorerLimitation = isStandingExplorerLimitation;

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -263,6 +263,10 @@ test('standing explorer feed limitations defer only that chain', () => {
   );
   assert.match(source, /deferOpenScopes\(job\.id, chainId/);
   assert.match(source, /for \(const chainId of runnable\)[\s\S]*?try \{[\s\S]*?runChain/);
+  assert.match(source, /scopeStatus: standing \? 'unsupported' : deferred \? 'deferred' : 'failed'/);
+  assert.match(source, /capabilities: AUDIT_CAPABILITIES/);
+  assert.match(source, /isStandingExplorerLimitation\(error\) \? `\$\{prefix\}_CHAIN_UNAVAILABLE`/);
+  assert.match(source, /failed: !deferred && !standing/);
 });
 
 test('consensus canonicalization retains failed mined outgoing transactions and gas', () => {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -248,6 +248,23 @@ test('Blockscout transient provider failures defer instead of becoming permanent
   assert.equal(EvmAuditService._isBlockscoutTransient({ response: { status: 400 } }), false);
 });
 
+test('standing explorer feed limitations defer only that chain', () => {
+  assert.equal(EvmAuditService._isStandingExplorerLimitation({
+    code: 'ETHERSCAN_FEED_UNSUPPORTED',
+  }), true);
+  assert.equal(EvmAuditService._isStandingExplorerLimitation({
+    code: 'ETHERSCAN_CHAIN_UNAVAILABLE',
+  }), true);
+  assert.equal(EvmAuditService._isStandingExplorerLimitation({
+    code: 'ETHERSCAN_FEED_FAILED',
+  }), false);
+  const source = fs.readFileSync(
+    path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8'
+  );
+  assert.match(source, /deferOpenScopes\(job\.id, chainId/);
+  assert.match(source, /for \(const chainId of runnable\)[\s\S]*?try \{[\s\S]*?runChain/);
+});
+
 test('consensus canonicalization retains failed mined outgoing transactions and gas', () => {
   const transaction = {
     hash: HASH, blockNumber: '0xa', blockHash: BLOCK_HASH, transactionIndex: '0x2',


### PR DESCRIPTION
Defer standing explorer capability limitations at the affected chain instead of aborting the entire audit. Preserve open scopes with the provider error and continue remaining configured chains, including Base/CDP. Classify Blockscout/Etherscan standing limitations as deferred. Root cause: OP Mainnet returned a known Blockscout internal-trace coverage limitation, and the audit worker treated that chain-level feed error as a whole-job failure. Validation: focused EVM audit tests 45 passed; backend lint passed.