### PR TITLE
fix(eth): recognize wrapped explorer limitations

### DIFF
--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -321,14 +321,18 @@ function explorerDisplayName(provider) {
 }
 
 function isStandingExplorerLimitation(error) {
-  return ['ETHERSCAN_FEED_UNSUPPORTED', 'ETHERSCAN_CHAIN_UNAVAILABLE'].includes(error?.code);
+  const message = String(error?.message || '').toLowerCase();
+  return ['ETHERSCAN_FEED_UNSUPPORTED', 'ETHERSCAN_CHAIN_UNAVAILABLE'].includes(error?.code)
+    || (message.includes('does not serve') && message.includes('not yet been processed'));
 }
 
 function isStandingProviderLimitation(error) {
+  const message = String(error?.message || '').toLowerCase();
   return [
     'BLOCKSCOUT_FEED_UNSUPPORTED', 'BLOCKSCOUT_CHAIN_UNAVAILABLE',
     'ETHERSCAN_FEED_UNSUPPORTED', 'ETHERSCAN_CHAIN_UNAVAILABLE',
-  ].includes(error?.code);
+  ].includes(error?.code)
+    || (message.includes('does not serve') && message.includes('not yet been processed'));
 }
 
 function assertLease(leaseState) {

--- a/backend/tests/evmAudit.test.js
+++ b/backend/tests/evmAudit.test.js
@@ -258,6 +258,10 @@ test('standing explorer feed limitations defer only that chain', () => {
   assert.equal(EvmAuditService._isStandingExplorerLimitation({
     code: 'ETHERSCAN_FEED_FAILED',
   }), false);
+  assert.equal(EvmAuditService._isStandingExplorerLimitation({
+    code: 'BLOCKSCOUT_FEED_FAILED',
+    message: 'Blockscout does not serve txlistinternal: Some internal transactions within this block range have not yet been processed',
+  }), true);
   const source = fs.readFileSync(
     path.join(__dirname, '../src/services/EvmAuditService.js'), 'utf8'
   );


### PR DESCRIPTION
Follow-up to PR #130. The live OP canary returned the known Blockscout internal indexing limitation with a wrapped/provider-variant error code, so the exact message is now recognized as a standing capability limitation. It remains an amber unsupported scope and does not abort later chains such as Base/CDP. Focused EVM audit tests pass 45/45; backend lint passes.