### PR TITLE
fix(eth): classify CDP result errors

### DIFF
--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -175,9 +175,10 @@ function isExplorerRateLimited(error) {
 }
 
 function retryAfterAt(error) {
-  const explicit = error?.retryAfterAt instanceof Date
-    ? error.retryAfterAt
-    : new Date(error?.retryAfterAt || NaN);
+  const explicitValue = error?.retryAfterAt ?? error?.retryAt;
+  const explicit = explicitValue instanceof Date
+    ? explicitValue
+    : new Date(explicitValue || NaN);
   if (!Number.isNaN(explicit.getTime())) return explicit;
   const delay = Math.min(
     MAX_PROVIDER_RETRY_WAIT_MS,

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -94,10 +94,14 @@ function responseError(response, body, method, apiKey = null) {
     resultFailure?.detail || body?.error?.message || body?.message || '', apiKey
   );
   const resultCode = String(resultFailure?.code || '').toLowerCase();
+  const bodyErrorCode = String(body?.error?.code || '').toLowerCase();
   const authFailure = /unauthorized|unauthenticated|forbidden|invalid.{0,20}(?:key|credential)|permission/i.test(detail)
     || /unauthoriz|unauthenticated|forbidden|permission/.test(resultCode);
   const rateFailure = /rate.?limit|too many requests|slow down/i.test(detail)
     || /rate|throttl|resource[_ -]?exhausted|resource[_ -]?limit/.test(resultCode);
+  const bodyRateFailure = /rate|throttl|resource[_ -]?exhausted|resource[_ -]?limit/.test(bodyErrorCode);
+  const quotaFailure = isQuotaError(detail, resultCode)
+    || (body?.error && isQuotaError(detail, bodyErrorCode));
   if (response.status === 429) {
     const retryAfterMs = parseRetryAfter(response.headers.get('retry-after')) ?? 5_000;
     return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
@@ -106,32 +110,26 @@ function responseError(response, body, method, apiKey = null) {
       retryAt: new Date(Date.now() + retryAfterMs),
     });
   }
-  if ([401, 403].includes(response.status)) {
-    if (isQuotaError(detail, body?.error?.code)) {
-      return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
-        httpStatus: response.status,
-        // CDP Node's free billing-unit allowance is documented as a calendar-
-        // month allowance. A portal/account-specific quota may differ, so the
-        // UI still displays this as a provider retry boundary, not a promise
-        // that all credits reset after 24 hours.
-        retryAt: nextCalendarMonth(),
-      });
-    }
-    return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
-      httpStatus: response.status,
-    });
-  }
-  if (resultFailure && isQuotaError(detail, resultCode)) {
+  if (quotaFailure) {
     return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
       httpStatus: response.status,
+      // CDP Node's free billing-unit allowance is documented as a calendar-
+      // month allowance. A portal/account-specific quota may differ, so the
+      // UI still displays this as a provider retry boundary, not a promise
+      // that all credits reset after 24 hours.
       retryAt: nextCalendarMonth(),
     });
   }
-  if (resultFailure && rateFailure) {
+  if ((resultFailure && rateFailure) || (body?.error && bodyRateFailure)) {
     return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
       httpStatus: response.status,
       retryAfterMs: 5_000,
       retryAt: new Date(Date.now() + 5_000),
+    });
+  }
+  if ([401, 403].includes(response.status)) {
+    return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
+      httpStatus: response.status,
     });
   }
   if (resultFailure && authFailure) {
@@ -147,21 +145,7 @@ function responseError(response, body, method, apiKey = null) {
     );
   }
   if (body?.error) {
-    const code = String(body.error.code || '').toLowerCase();
-    if (isQuotaError(detail, code)) {
-      return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
-        httpStatus: response.status,
-        retryAt: nextCalendarMonth(),
-      });
-    }
-    if (rateFailure || /rate|throttl|resource[_ -]?exhausted|resource[_ -]?limit/.test(code)) {
-      return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
-        httpStatus: response.status,
-        retryAfterMs: 5_000,
-        retryAt: new Date(Date.now() + 5_000),
-      });
-    }
-    if (authFailure || /unauthoriz|unauthenticated|forbidden|permission/.test(code)) {
+    if (authFailure || /unauthoriz|unauthenticated|forbidden|permission/.test(bodyErrorCode)) {
       return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
         httpStatus: response.status,
       });

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -154,6 +154,13 @@ function responseError(response, body, method, apiKey = null) {
         retryAt: nextCalendarMonth(),
       });
     }
+    if (rateFailure || /rate|throttl|resource[_ -]?exhausted|resource[_ -]?limit/.test(code)) {
+      return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
+        httpStatus: response.status,
+        retryAfterMs: 5_000,
+        retryAt: new Date(Date.now() + 5_000),
+      });
+    }
     if (authFailure || /unauthoriz|unauthenticated|forbidden|permission/.test(code)) {
       return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
         httpStatus: response.status,

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -52,8 +52,9 @@ function normalizeJsonNumbers(value) {
   return normalized;
 }
 
-function isQuotaError(detail) {
-  return /(?:quota|credit|billing|usage).*(?:exhaust|limit|exceed)|(?:exhaust|limit|exceed).*(?:quota|credit|billing|usage)/i.test(detail);
+function isQuotaError(detail, code = '') {
+  return /(?:quota|credit|billing|usage).*(?:exhaust|limit|exceed)|(?:exhaust|limit|exceed).*(?:quota|credit|billing|usage)/i.test(detail)
+    || /quota|credit|billing|usage[_ -]?(?:limit|exhausted|exceeded)/i.test(String(code || ''));
 }
 
 function nextCalendarMonth() {
@@ -63,18 +64,27 @@ function nextCalendarMonth() {
 
 function resultError(body) {
   const result = body?.result;
-  if (!result || typeof result !== 'object' || Array.isArray(result)
-      || Array.isArray(result.addressTransactions) || Array.isArray(result.transactions)
-      || Array.isArray(result.balances)) return null;
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return null;
+  const code = typeof result.code === 'string' ? result.code.trim() : '';
   const detail = [result.message, result.details]
     .filter((value) => typeof value === 'string' && value.trim())
     .join(': ');
-  return detail ? { code: result.code, detail } : null;
+  if (!code && !detail) return null;
+  return { code: code || null, detail: detail || code };
+}
+
+function redactSecret(value, apiKey) {
+  if (!apiKey) return value;
+  if (typeof value === 'string') return value.split(String(apiKey)).join('[redacted]');
+  if (Array.isArray(value)) return value.map((child) => redactSecret(child, apiKey));
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(Object.entries(value).map(([key, child]) => [
+    redactSecret(key, apiKey), redactSecret(child, apiKey),
+  ]));
 }
 
 function safeDetail(value, apiKey) {
-  let detail = String(value || '').replace(/\s+/g, ' ').trim();
-  if (apiKey) detail = detail.split(String(apiKey)).join('[redacted]');
+  const detail = String(redactSecret(value, apiKey) || '').replace(/\s+/g, ' ').trim();
   return detail.slice(0, 500);
 }
 
@@ -84,10 +94,10 @@ function responseError(response, body, method, apiKey = null) {
     resultFailure?.detail || body?.error?.message || body?.message || '', apiKey
   );
   const resultCode = String(resultFailure?.code || '').toLowerCase();
-  const authFailure = /unauthorized|forbidden|invalid.{0,20}(?:key|credential)|permission/i.test(detail)
-    || /unauthoriz|forbidden|permission/.test(resultCode);
+  const authFailure = /unauthorized|unauthenticated|forbidden|invalid.{0,20}(?:key|credential)|permission/i.test(detail)
+    || /unauthoriz|unauthenticated|forbidden|permission/.test(resultCode);
   const rateFailure = /rate.?limit|too many requests|slow down/i.test(detail)
-    || /rate|throttl/.test(resultCode);
+    || /rate|throttl|resource[_ -]?exhausted|resource[_ -]?limit/.test(resultCode);
   if (response.status === 429) {
     const retryAfterMs = parseRetryAfter(response.headers.get('retry-after')) ?? 5_000;
     return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
@@ -97,7 +107,7 @@ function responseError(response, body, method, apiKey = null) {
     });
   }
   if ([401, 403].includes(response.status)) {
-    if (isQuotaError(detail)) {
+    if (isQuotaError(detail, body?.error?.code)) {
       return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
         httpStatus: response.status,
         // CDP Node's free billing-unit allowance is documented as a calendar-
@@ -111,7 +121,7 @@ function responseError(response, body, method, apiKey = null) {
       httpStatus: response.status,
     });
   }
-  if (resultFailure && isQuotaError(detail)) {
+  if (resultFailure && isQuotaError(detail, resultCode)) {
     return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
       httpStatus: response.status,
       retryAt: nextCalendarMonth(),
@@ -138,9 +148,20 @@ function responseError(response, body, method, apiKey = null) {
   }
   if (body?.error) {
     const code = String(body.error.code || '').toLowerCase();
+    if (isQuotaError(detail, code)) {
+      return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
+        httpStatus: response.status,
+        retryAt: nextCalendarMonth(),
+      });
+    }
+    if (authFailure || /unauthoriz|unauthenticated|forbidden|permission/.test(code)) {
+      return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
+        httpStatus: response.status,
+      });
+    }
     return providerError(
       `Coinbase CDP ${method} returned an error${detail ? `: ${detail}` : ''}`,
-      isQuotaError(detail) || /quota|credit|billing/.test(code) ? 'CDP_QUOTA_EXHAUSTED' : 'CDP_API_ERROR',
+      'CDP_API_ERROR',
       { httpStatus: response.status }
     );
   }
@@ -304,13 +325,16 @@ class CdpClient {
 
         const error = responseError(response, body, method, this.apiKey);
         const retryable = error.code === 'CDP_RATE_LIMITED' && attempt < this.maxAttempts;
+        const responseRaw = redactSecret(text, this.apiKey);
         await this.onFailedAttempt?.({
           provider: 'coinbase-cdp', endpoint, method: 'POST', attemptNo: attempt,
           requestParams: params, outcome: retryable || error.code === 'CDP_QUOTA_EXHAUSTED' ? 'deferred' : 'failed',
           httpStatus: error.httpStatus || response.status,
           errorCode: error.code, errorDetail: error.message,
           requestId: response.headers.get('x-request-id') || null,
-          responseSha256: sha256(text), responseRaw: text, responseJson: body,
+          responseSha256: sha256(responseRaw),
+          responseRaw,
+          responseJson: redactSecret(body, this.apiKey),
         });
         if (retryable && error.retryAfterMs <= MAX_INLINE_RETRY_MS) {
           await wait(error.retryAfterMs);

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -61,8 +61,33 @@ function nextCalendarMonth() {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
 }
 
-function responseError(response, body, method) {
-  const detail = String(body?.error?.message || body?.message || '').slice(0, 500);
+function resultError(body) {
+  const result = body?.result;
+  if (!result || typeof result !== 'object' || Array.isArray(result)
+      || Array.isArray(result.addressTransactions) || Array.isArray(result.transactions)
+      || Array.isArray(result.balances)) return null;
+  const detail = [result.message, result.details]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join(': ');
+  return detail ? { code: result.code, detail } : null;
+}
+
+function safeDetail(value, apiKey) {
+  let detail = String(value || '').replace(/\s+/g, ' ').trim();
+  if (apiKey) detail = detail.split(String(apiKey)).join('[redacted]');
+  return detail.slice(0, 500);
+}
+
+function responseError(response, body, method, apiKey = null) {
+  const resultFailure = resultError(body);
+  const detail = safeDetail(
+    resultFailure?.detail || body?.error?.message || body?.message || '', apiKey
+  );
+  const resultCode = String(resultFailure?.code || '').toLowerCase();
+  const authFailure = /unauthorized|forbidden|invalid.{0,20}(?:key|credential)|permission/i.test(detail)
+    || /unauthoriz|forbidden|permission/.test(resultCode);
+  const rateFailure = /rate.?limit|too many requests|slow down/i.test(detail)
+    || /rate|throttl/.test(resultCode);
   if (response.status === 429) {
     const retryAfterMs = parseRetryAfter(response.headers.get('retry-after')) ?? 5_000;
     return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
@@ -85,6 +110,31 @@ function responseError(response, body, method) {
     return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
       httpStatus: response.status,
     });
+  }
+  if (resultFailure && isQuotaError(detail)) {
+    return providerError('Coinbase CDP usage limit reached; Base history deferred', 'CDP_QUOTA_EXHAUSTED', {
+      httpStatus: response.status,
+      retryAt: nextCalendarMonth(),
+    });
+  }
+  if (resultFailure && rateFailure) {
+    return providerError('Coinbase CDP rate limit reached; Base history deferred', 'CDP_RATE_LIMITED', {
+      httpStatus: response.status,
+      retryAfterMs: 5_000,
+      retryAt: new Date(Date.now() + 5_000),
+    });
+  }
+  if (resultFailure && authFailure) {
+    return providerError('Coinbase CDP rejected the configured credential', 'CDP_AUTH_FAILED', {
+      httpStatus: response.status,
+    });
+  }
+  if (resultFailure) {
+    return providerError(
+      `Coinbase CDP ${method} returned an error${detail ? `: ${detail}` : ''}`,
+      'CDP_API_ERROR',
+      { httpStatus: response.status }
+    );
   }
   if (body?.error) {
     const code = String(body.error.code || '').toLowerCase();
@@ -239,10 +289,11 @@ class CdpClient {
         }
         const hasResult = body && typeof body === 'object' && !Array.isArray(body)
           && body.result != null;
+        const resultFailure = resultError(body);
         // Do not accept a malformed JSON-RPC envelope that contains both an
         // error and a result. A partial result paired with an error is not a
         // proven page and must not advance a durable cursor.
-        if (response.ok && hasResult && !body.error) {
+        if (response.ok && hasResult && !body.error && !resultFailure) {
           return {
             body: body.result,
             rawText: text,
@@ -251,7 +302,7 @@ class CdpClient {
           };
         }
 
-        const error = responseError(response, body, method);
+        const error = responseError(response, body, method, this.apiKey);
         const retryable = error.code === 'CDP_RATE_LIMITED' && attempt < this.maxAttempts;
         await this.onFailedAttempt?.({
           provider: 'coinbase-cdp', endpoint, method: 'POST', attemptNo: attempt,

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -160,6 +160,17 @@ test('CDP pagination rejects non-string cursors, non-adjacent cycles, and mixed 
         .addressTransactionPages(WALLET).next(),
       (error) => error.code === 'CDP_API_ERROR'
     );
+
+    global.fetch = async () => jsonRpcResult({
+      code: 'METHOD_NOT_AVAILABLE', message: 'provider returned an empty page',
+      addressTransactions: [], nextPageToken: null,
+    });
+    await assert.rejects(
+      () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+        .addressTransactionPages(WALLET).next(),
+      (error) => error.code === 'CDP_API_ERROR'
+        && error.message.includes('provider returned an empty page')
+    );
   } finally {
     global.fetch = originalFetch;
   }
@@ -234,6 +245,55 @@ test('CDP classifies a successful envelope containing a provider result error', 
       && error.message.includes('requested method is unavailable')
       && error.message.includes('address history is not enabled')
   );
+});
+
+test('CDP defers resource-exhausted result errors and keeps quota errors on the calendar boundary', async (t) => {
+  const originalFetch = global.fetch;
+  const responses = [
+    jsonRpcResult({ code: 'RESOURCE_EXHAUSTED', message: 'provider request capacity exhausted' }),
+    jsonRpcResult({ code: 'resource_exhausted', message: 'monthly billing quota exhausted' }),
+  ];
+  global.fetch = async () => responses.shift();
+  t.after(() => { global.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_RATE_LIMITED' && error.retryAfterMs === 5_000
+  );
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_QUOTA_EXHAUSTED' && error.retryAt instanceof Date
+  );
+});
+
+test('CDP recognizes quota and authentication result codes and redacts echoed keys from retained evidence', async (t) => {
+  const originalFetch = global.fetch;
+  const attempts = [];
+  const apiKey = 'key-that-must-not-persist';
+  const responses = [
+    jsonRpcResult({ code: 'QUOTA_EXCEEDED', message: 'monthly allowance exceeded' }),
+    jsonRpcResult({ code: 'UNAUTHENTICATED', message: `credential ${apiKey} is invalid` }),
+  ];
+  global.fetch = async () => responses.shift();
+  t.after(() => { global.fetch = originalFetch; });
+
+  for (const expectedCode of ['CDP_QUOTA_EXHAUSTED', 'CDP_AUTH_FAILED']) {
+    await assert.rejects(
+      () => new CdpClient(apiKey, {
+        spacingMs: 0, maxAttempts: 1, onFailedAttempt: async (attempt) => attempts.push(attempt),
+      }).addressTransactionPages(WALLET).next(),
+      (error) => error.code === expectedCode && !error.message.includes(apiKey)
+    );
+  }
+
+  assert.equal(attempts.length, 2);
+  for (const attempt of attempts) {
+    assert.ok(!JSON.stringify(attempt).includes(apiKey));
+  }
+  assert.ok(attempts[1].responseRaw.includes('[redacted]'));
+  assert.ok(attempts[1].responseJson.result.message.includes('[redacted]'));
 });
 
 test('CDP errors classify quota and rate limits with retry boundaries', async (t) => {

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -307,6 +307,10 @@ test('CDP errors classify quota and rate limits with retry boundaries', async (t
       jsonrpc: '2.0', id: 1,
       error: { code: 'RESOURCE_EXHAUSTED', message: 'provider request capacity exhausted' },
     }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    new Response(JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      error: { code: 'RESOURCE_EXHAUSTED', message: 'provider request capacity exhausted' },
+    }), { status: 403, headers: { 'content-type': 'application/json' } }),
   ];
   global.fetch = async () => responses.shift();
   t.after(() => { global.fetch = originalFetch; });
@@ -320,6 +324,11 @@ test('CDP errors classify quota and rate limits with retry boundaries', async (t
     () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
       .addressTransactionPages(WALLET).next(),
     (error) => error.code === 'CDP_RATE_LIMITED' && error.retryAfterMs === 2000
+  );
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_RATE_LIMITED' && error.retryAfterMs === 5000
   );
   await assert.rejects(
     () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -303,6 +303,10 @@ test('CDP errors classify quota and rate limits with retry boundaries', async (t
     new Response(JSON.stringify({ error: { message: 'slow down' } }), {
       status: 429, headers: { 'retry-after': '2' },
     }),
+    new Response(JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      error: { code: 'RESOURCE_EXHAUSTED', message: 'provider request capacity exhausted' },
+    }), { status: 200, headers: { 'content-type': 'application/json' } }),
   ];
   global.fetch = async () => responses.shift();
   t.after(() => { global.fetch = originalFetch; });
@@ -316,6 +320,11 @@ test('CDP errors classify quota and rate limits with retry boundaries', async (t
     () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
       .addressTransactionPages(WALLET).next(),
     (error) => error.code === 'CDP_RATE_LIMITED' && error.retryAfterMs === 2000
+  );
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_RATE_LIMITED' && error.retryAfterMs === 5000
   );
 });
 

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -219,6 +219,23 @@ test('CDP rejects conflicting address-history result collections before cursor a
   );
 });
 
+test('CDP classifies a successful envelope containing a provider result error', async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => jsonRpcResult({
+    code: 'METHOD_NOT_AVAILABLE', details: 'address history is not enabled',
+    message: 'The requested method is unavailable',
+  });
+  t.after(() => { global.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+      .addressTransactionPages(WALLET).next(),
+    (error) => error.code === 'CDP_API_ERROR'
+      && error.message.includes('requested method is unavailable')
+      && error.message.includes('address history is not enabled')
+  );
+});
+
 test('CDP errors classify quota and rate limits with retry boundaries', async (t) => {
   const originalFetch = global.fetch;
   const responses = [

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -669,6 +669,26 @@ test('a Base wallet without a CDP key is isolated as a deferred chain row', asyn
   assert.match(calls.walletError.message, /deferred because the explorer is rate limited/);
 });
 
+test('a Base CDP quota error preserves its calendar-month retry boundary in wallet sync', async (t) => {
+  const { calls } = harness(t, {
+    chainSet: '8453',
+    cdpResponses: [{ code: 'QUOTA_EXCEEDED', message: 'monthly allowance exceeded' }],
+  });
+
+  const result = await EthWalletService.syncWallet(7);
+  const nextMonth = new Date();
+  nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1, 1);
+  nextMonth.setUTCHours(0, 0, 0, 0);
+
+  assert.equal(result.status, 'deferred');
+  assert.equal(calls.chainErrors[0].code, 'SYNC_DEFERRED');
+  assert.ok(calls.coverage[0].entries.every((entry) => (
+    entry.status === 'deferred'
+      && entry.retryAfterAt instanceof Date
+      && entry.retryAfterAt.getTime() === nextMonth.getTime()
+  )));
+});
+
 test('a transient failure and an unsupported feed are told apart', async (t) => {
   const { calls } = harness(t, {
     chainSet: '1',


### PR DESCRIPTION
## What changed

- recognize Coinbase CDP provider errors returned inside an otherwise successful JSON-RPC `result` object
- classify result-level quota, rate-limit, and credential failures consistently with HTTP failures
- redact the configured key from provider detail before surfacing it and preserve fail-closed cursor behavior
- add regression coverage for the result-level error envelope

## Why

The corrected production key authenticated successfully, but Base history returned a result object with `code`, `details`, and `message`. The client treated that provider error as a malformed page, obscuring the actual cause.

## Validation

- `node --test tests/cdpProvider.test.js --test-name-pattern='CDP (address history|pagination|accepts the documented|journal replay|conflicting|successful envelope|errors classify)'` — 19/19
- backend lint
- production canary reached Base at block 49,724,481 and exposed the result-level envelope
