### PR TITLE
fix(eth): avoid oversized CDP history pages

### DIFF
--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -22,6 +22,7 @@ const CdpHistoryProvider = require('./evmAudit/CdpHistoryProvider');
 const RpcClient = require('./evmAudit/RpcClient');
 
 const cdpAddressTransactionItems = CdpClient.addressTransactionItems;
+const CDP_HISTORY_PAGE_SIZE = CdpClient.DEFAULT_HISTORY_PAGE_SIZE;
 
 const ADDRESS_RE = /^0x[0-9a-f]{40}$/i;
 
@@ -398,7 +399,7 @@ class EthWalletService {
       }
       for await (const page of cdp.addressTransactionPages(wallet.address, {
         cursor: state.provider_cursor || null,
-        pageSize: 100,
+        pageSize: CDP_HISTORY_PAGE_SIZE,
       })) {
         const blocks = page.items.map(cdpItemBlockNumber)
           .filter((block) => block != null && block <= boundary.number);
@@ -406,7 +407,9 @@ class EthWalletService {
         await EthProviderPage.record({
           walletId: wallet.id, chainId: chain.id, provider: 'coinbase-cdp',
           stream: 'address-history', scanId, cursorIn: page.cursorIn, cursorOut: page.cursorOut,
-          requestParams: { address: wallet.address.toLowerCase(), page_size: 100, page_token: page.cursorIn },
+          requestParams: {
+            address: wallet.address.toLowerCase(), page_size: page.pageSize, page_token: page.cursorIn,
+          },
           responseSha256: page.responseSha256, responseRaw: page.rawText,
           responseJson: page.body, itemCount: page.items.length, owner: PROVIDER_SCAN_OWNER,
         });

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -1027,7 +1027,6 @@ class EvmAuditService {
       try {
         for await (const page of cdp.addressTransactionPages(job.address, {
           cursor,
-          pageSize: 100,
         })) {
           assertLease(leaseState);
           const blocks = page.items
@@ -1047,7 +1046,7 @@ class EvmAuditService {
           else if (orderDirection && order !== orderDirection) order = 'unknown';
           const pageEvidence = pageRecord(
             'coinbase-cdp', 'address-history', {
-              address: job.address.toLowerCase(), page_size: 100, page_token: page.cursorIn,
+              address: job.address.toLowerCase(), page_size: page.pageSize, page_token: page.cursorIn,
             }, page, page.cursorIn, page.cursorOut, page.items.length, order
           );
           await recordRawPage(historyScope.id, pageEvidence);

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -14,6 +14,13 @@ const MAX_INLINE_RETRY_MS = 30_000;
 const MAX_ATTEMPTS = 3;
 const MAX_PAGES = 100_000;
 const MAX_PAGE_SIZE = 100;
+// Address-history responses include receipts, traces, and token effects. A
+// provider page of 100 transactions can exceed CDP's gateway message limit
+// even though 100 is the documented API maximum. Keep the normal request
+// small enough for the largest observed effect-rich transactions; callers may
+// still request a larger page and the iterator will reduce it safely if CDP
+// rejects the response size.
+const DEFAULT_HISTORY_PAGE_SIZE = 10;
 const queues = new Map();
 
 function providerError(message, code, extra = {}) {
@@ -172,6 +179,12 @@ function pageCursor(value, method) {
     );
   }
   return value;
+}
+
+function oversizedResponse(error) {
+  return error?.code === 'CDP_API_ERROR'
+    && (error.httpStatus === 413
+      || /message larger than max|response size|response too large|entity too large/i.test(error.message || ''));
 }
 
 function resultShape(value) {
@@ -337,9 +350,12 @@ class CdpClient {
     });
   }
 
-  async *addressTransactionPages(address, { cursor = null, pageSize = MAX_PAGE_SIZE } = {}) {
+  async *addressTransactionPages(address, { cursor = null, pageSize = DEFAULT_HISTORY_PAGE_SIZE } = {}) {
     const normalizedAddress = String(address || '').toLowerCase();
     let next = pageCursor(cursor, 'address history');
+    let requestedPageSize = Math.min(
+      MAX_PAGE_SIZE, Math.max(1, Number(pageSize) || DEFAULT_HISTORY_PAGE_SIZE)
+    );
     const seenCursors = new Set();
     let pages = 0;
     do {
@@ -349,12 +365,23 @@ class CdpClient {
         }
         seenCursors.add(next);
       }
-      const params = {
-        address: normalizedAddress,
-        pageSize: Math.min(MAX_PAGE_SIZE, Math.max(1, Number(pageSize) || MAX_PAGE_SIZE)),
-        pageToken: next || '',
-      };
-      const response = await this._request('cdp_listAddressTransactions', params, 'address-history');
+      let response;
+      while (!response) {
+        const params = {
+          address: normalizedAddress,
+          pageSize: requestedPageSize,
+          pageToken: next || '',
+        };
+        try {
+          response = await this._request('cdp_listAddressTransactions', params, 'address-history');
+        } catch (error) {
+          // Keep the cursor unchanged while retrying the same page at a
+          // smaller size. No raw page or durable checkpoint is written until
+          // a complete response is received.
+          if (!oversizedResponse(error) || requestedPageSize <= 1) throw error;
+          requestedPageSize = Math.max(1, Math.floor(requestedPageSize / 2));
+        }
+      }
       // `transactions` is accepted as a compatibility alias because Coinbase
       // documents cdp_listTransactions as an alias for this method, while the
       // response examples use addressTransactions. Keep the shape diagnostic
@@ -368,7 +395,9 @@ class CdpClient {
       if (cursorOut && seenCursors.has(cursorOut)) {
         throw providerError('Coinbase CDP address history returned a repeated page token', 'CDP_PAGINATION_STALLED');
       }
-      yield { ...response, items, cursorIn: next, cursorOut };
+      yield {
+        ...response, items, cursorIn: next, cursorOut, pageSize: requestedPageSize,
+      };
       next = cursorOut;
     } while (next);
   }
@@ -411,3 +440,4 @@ module.exports.addressTransactionItems = addressTransactionItems;
 module.exports.parseRetryAfter = parseRetryAfter;
 module.exports.normalizeJsonNumbers = normalizeJsonNumbers;
 module.exports.providerError = providerError;
+module.exports.DEFAULT_HISTORY_PAGE_SIZE = DEFAULT_HISTORY_PAGE_SIZE;

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -111,6 +111,72 @@ test('CDP address history uses bounded cursor pagination and never exposes the k
   assert.ok(!JSON.stringify(pages).includes('do-not-log-this-key'));
 });
 
+test('CDP address history defaults to a response-safe page size', async (t) => {
+  const originalFetch = global.fetch;
+  const requests = [];
+  global.fetch = async (_url, options) => {
+    requests.push(JSON.parse(options.body));
+    return jsonRpcResult({ addressTransactions: [], nextPageToken: null });
+  };
+  t.after(() => { global.fetch = originalFetch; });
+
+  for await (const _page of new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+    .addressTransactionPages(WALLET)) { /* one empty page */ }
+
+  assert.equal(requests[0].params[0].pageSize, 10);
+});
+
+test('CDP address history halves oversized pages without advancing the cursor', async (t) => {
+  const originalFetch = global.fetch;
+  const requests = [];
+  global.fetch = async (_url, options) => {
+    const request = JSON.parse(options.body);
+    requests.push(request);
+    if (request.params[0].pageSize > 10) {
+      return jsonRpcResult({
+        code: 'INTERNAL',
+        details: 'grpc: received message larger than max (18605042 vs. 4194304)',
+        message: 'response too large',
+      });
+    }
+    return jsonRpcResult({ addressTransactions: [transaction()], nextPageToken: null });
+  };
+  t.after(() => { global.fetch = originalFetch; });
+
+  const pages = [];
+  for await (const page of new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+    .addressTransactionPages(WALLET, { pageSize: 100, cursor: 'proven-cursor' })) pages.push(page);
+
+  assert.deepEqual(requests.map((request) => request.params[0].pageSize), [100, 50, 25, 12, 6]);
+  assert.deepEqual(requests.map((request) => request.params[0].pageToken), [
+    'proven-cursor', 'proven-cursor', 'proven-cursor', 'proven-cursor', 'proven-cursor',
+  ]);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].pageSize, 6);
+  assert.equal(pages[0].cursorIn, 'proven-cursor');
+});
+
+test('CDP address history treats HTTP 413 as an oversized page', async (t) => {
+  const originalFetch = global.fetch;
+  const requests = [];
+  global.fetch = async (_url, options) => {
+    const request = JSON.parse(options.body);
+    requests.push(request);
+    if (request.params[0].pageSize > 5) {
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: 413 } }), {
+        status: 413, headers: { 'content-type': 'application/json' },
+      });
+    }
+    return jsonRpcResult({ addressTransactions: [], nextPageToken: null });
+  };
+  t.after(() => { global.fetch = originalFetch; });
+
+  for await (const _page of new CdpClient('test-key', { spacingMs: 0, maxAttempts: 1 })
+    .addressTransactionPages(WALLET, { pageSize: 20 })) { /* one empty page */ }
+
+  assert.deepEqual(requests.map((request) => request.params[0].pageSize), [20, 10, 5]);
+});
+
 test('CDP pagination rejects a repeated opaque token', async () => {
   const originalFetch = global.fetch;
   global.fetch = async () => jsonRpcResult({

--- a/backend/tests/ethMultiChain.test.js
+++ b/backend/tests/ethMultiChain.test.js
@@ -2056,7 +2056,7 @@ test('empty Base CDP pages persist coverage and resume with the CDP cursor contr
   assert.equal(cursorWrites[0].statesync, 50000000,
     'CDP receipt logs advance the durable Base bridge-credit boundary');
   assert.equal(calls.cdpRequests.length, 2);
-  assert.ok(calls.cdpRequests.every((request) => request.params[0].pageSize === 100));
+  assert.ok(calls.cdpRequests.every((request) => request.params[0].pageSize === 10));
   assert.ok(calls.cdpRequests.every((request) => request.params[0].pageToken === ''),
     'an exhausted one-page stream restarts at the provider boundary; order is unknown');
   assert.equal(calls.fetches.filter((call) => call.chainId === 8453).length, 0,


### PR DESCRIPTION
## Summary

- use a response-safe default of 10 transactions for CDP address history in Base Sync and full audits
- halve the requested page size on CDP oversized responses or HTTP 413 while keeping the same cursor
- persist the effective page size in raw provider evidence and add regression coverage

## Root cause

CDP accepted the 100-item request but returned an 18,605,042-byte response, exceeding its 4 MiB gateway message limit. The corrected production key authenticated successfully; the failure was page size, not credentials.

## Validation

- backend tests: 1,134 passing
- CDP focused tests: 24 passing
- backend lint passing
- ledger verification: 92 checks passing
- independent architecture and data-integrity reviews: no remaining P0-P2 findings

The change preserves raw evidence and does not advance a durable cursor until a complete page is accepted.