### PR TITLE
fix(eth): defer oversized CDP transactions

### DIFF
--- a/backend/src/services/EthWalletService.js
+++ b/backend/src/services/EthWalletService.js
@@ -163,7 +163,7 @@ function providerName(chain) {
 function coverageFailureStatus(error) {
   if (isExplorerRateLimited(error) || String(error?.code || '').startsWith('CDP_')
       && ['CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR', 'CDP_NOT_CONFIGURED',
-        'CDP_SCAN_BUSY'].includes(error.code)) {
+        'CDP_SCAN_BUSY', 'CDP_RESPONSE_TOO_LARGE'].includes(error.code)) {
     return 'deferred';
   }
   if (['RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR'].includes(error?.code)) return 'deferred';

--- a/backend/src/services/EvmAuditService.js
+++ b/backend/src/services/EvmAuditService.js
@@ -158,7 +158,8 @@ function moralisQuotaFallbackError(error) {
 
 function cdpUnavailableError(error) {
   if (!error) return null;
-  if (!['CDP_NOT_CONFIGURED', 'CDP_QUOTA_EXHAUSTED', 'CDP_RATE_LIMITED', 'CDP_TRANSPORT_ERROR']
+  if (!['CDP_NOT_CONFIGURED', 'CDP_QUOTA_EXHAUSTED', 'CDP_RATE_LIMITED', 'CDP_TRANSPORT_ERROR',
+    'CDP_RESPONSE_TOO_LARGE']
     .includes(error.code)) return null;
   return {
     code: error.code,
@@ -671,7 +672,7 @@ class EvmAuditService {
           const standing = isStandingProviderLimitation(error);
           const deferred = !standing && [
               'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
-              'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR',
+              'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR', 'CDP_RESPONSE_TOO_LARGE',
               'RPC_UNSUPPORTED', 'RPC_FINALITY_UNAVAILABLE', 'RPC_RATE_LIMITED',
               'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED', 'BLOCKSCOUT_TRANSPORT_ERROR',
               'ETHERSCAN_RATE_LIMITED', 'ETHERSCAN_TRANSPORT_ERROR',
@@ -734,6 +735,7 @@ class EvmAuditService {
       const deferred = [
         'MORALIS_RATE_LIMITED', 'MORALIS_QUOTA_EXHAUSTED', 'MORALIS_TRANSPORT_ERROR',
         'CDP_RATE_LIMITED', 'CDP_QUOTA_EXHAUSTED', 'CDP_TRANSPORT_ERROR', 'CDP_NOT_CONFIGURED',
+        'CDP_RESPONSE_TOO_LARGE',
         'RPC_UNSUPPORTED', 'RPC_FINALITY_UNAVAILABLE', 'RPC_RATE_LIMITED', 'RPC_TRANSPORT_ERROR', 'BLOCKSCOUT_RATE_LIMITED',
         'BLOCKSCOUT_TRANSPORT_ERROR', 'ETHERSCAN_RATE_LIMITED',
         'ETHERSCAN_TRANSPORT_ERROR',

--- a/backend/src/services/evmAudit/CdpClient.js
+++ b/backend/src/services/evmAudit/CdpClient.js
@@ -329,12 +329,15 @@ class CdpClient {
 
         const error = responseError(response, body, method, this.apiKey);
         const retryable = error.code === 'CDP_RATE_LIMITED' && attempt < this.maxAttempts;
+        const oversized = oversizedResponse(error);
         const responseRaw = redactSecret(text, this.apiKey);
         await this.onFailedAttempt?.({
           provider: 'coinbase-cdp', endpoint, method: 'POST', attemptNo: attempt,
-          requestParams: params, outcome: retryable || error.code === 'CDP_QUOTA_EXHAUSTED' ? 'deferred' : 'failed',
+          requestParams: params,
+          outcome: retryable || oversized || error.code === 'CDP_QUOTA_EXHAUSTED' ? 'deferred' : 'failed',
           httpStatus: error.httpStatus || response.status,
-          errorCode: error.code, errorDetail: error.message,
+          errorCode: oversized ? 'CDP_RESPONSE_TOO_LARGE' : error.code,
+          errorDetail: error.message,
           requestId: response.headers.get('x-request-id') || null,
           responseSha256: sha256(responseRaw),
           responseRaw,
@@ -378,7 +381,17 @@ class CdpClient {
           // Keep the cursor unchanged while retrying the same page at a
           // smaller size. No raw page or durable checkpoint is written until
           // a complete response is received.
-          if (!oversizedResponse(error) || requestedPageSize <= 1) throw error;
+          if (!oversizedResponse(error)) throw error;
+          if (requestedPageSize <= 1) {
+            throw providerError(
+              `Coinbase CDP cannot return a single Base address-history transaction within its response limit: ${error.message}`,
+              'CDP_RESPONSE_TOO_LARGE',
+              {
+                httpStatus: error.httpStatus,
+                retryAt: new Date(Date.now() + 60 * 60 * 1000),
+              }
+            );
+          }
           requestedPageSize = Math.max(1, Math.floor(requestedPageSize / 2));
         }
       }

--- a/backend/tests/cdpProvider.test.js
+++ b/backend/tests/cdpProvider.test.js
@@ -177,6 +177,37 @@ test('CDP address history treats HTTP 413 as an oversized page', async (t) => {
   assert.deepEqual(requests.map((request) => request.params[0].pageSize), [20, 10, 5]);
 });
 
+test('CDP classifies an unreturnable single transaction as a deferred provider limitation', async (t) => {
+  const originalFetch = global.fetch;
+  const requests = [];
+  const attempts = [];
+  global.fetch = async (_url, options) => {
+    const request = JSON.parse(options.body);
+    requests.push(request);
+    return jsonRpcResult({
+      code: 'INTERNAL',
+      details: 'grpc: received message larger than max (4319627 vs. 4194304)',
+      message: 'response too large',
+    });
+  };
+  t.after(() => { global.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => new CdpClient('test-key', {
+      spacingMs: 0, maxAttempts: 1, onFailedAttempt: async (attempt) => attempts.push(attempt),
+    })
+      .addressTransactionPages(WALLET, { pageSize: 10 }).next(),
+    (error) => error.code === 'CDP_RESPONSE_TOO_LARGE'
+      && error.retryAt instanceof Date
+      && /single Base address-history transaction/.test(error.message)
+  );
+  assert.deepEqual(requests.map((request) => request.params[0].pageSize), [10, 5, 2, 1]);
+  assert.equal(attempts.length, 4);
+  assert.ok(attempts.every((attempt) => (
+    attempt.errorCode === 'CDP_RESPONSE_TOO_LARGE' && attempt.outcome === 'deferred'
+  )));
+});
+
 test('CDP pagination rejects a repeated opaque token', async () => {
   const originalFetch = global.fetch;
   global.fetch = async () => jsonRpcResult({


### PR DESCRIPTION
## Summary

- classify a single Base transaction that exceeds CDP’s response ceiling as `CDP_RESPONSE_TOO_LARGE`
- preserve the same cursor and avoid advancing coverage when page size 1 still cannot be returned
- record retained provider attempts as deferred with the same limitation code

## Production evidence

The corrected CDP key authenticated successfully. After the 100-item request was reduced to 10, then adaptively to 1, CDP still returned a 4,319,627-byte response against a 4,194,304-byte gateway limit.

This is now surfaced as an honest amber/deferred provider limitation rather than a generic red failure; no evidence is discarded and no Base history is marked complete.

## Validation

- CDP tests: 25 passing
- audit-focused tests: 45 passing
- backend lint and diff checks passing
- independent architecture and data-integrity reviews: no remaining P0-P2 findings